### PR TITLE
feat: multi-whisper ASR model selection (Swiss-German support)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ scripts/publish-manifest.sh       # Generate manifest.json from r2-upload/ + upl
 **Shared** (`src/shared/`) — Types and Zod validation schemas used by both main and renderer processes.
 
 **ML pipeline — Audio** (strictly sequential, one model at a time):
-1. whisper.cpp subprocess — ASR (Whisper Large V3 Turbo Q5_0, Metal GPU) ✓ implemented
+1. whisper.cpp subprocess — ASR via auswählbares Modell aus Katalog (Default: Whisper Large V3 Turbo Q5_0 multilingual; optional: Swiss-German-Fine-Tune). Active model stored in electron-store (`activeModels.transcription`), verwaltet via Settings → Modelle. ✓ implemented
 2. Python sidecar — pyannote.audio diarization (speaker-diarization-3.1) + alignment ✓ implemented
 3. Python sidecar — flair NER (flair/ner-german-large) + Regex + Blocklist → TipTap document ✓ implemented
 

--- a/docs/plans/2026-04-21-multi-whisper-asr-models.md
+++ b/docs/plans/2026-04-21-multi-whisper-asr-models.md
@@ -1,0 +1,1906 @@
+# Multi-Whisper-ASR-Modelle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Mehrere Whisper-ASR-Modelle als auswählbare Alternativen anbieten (initial: bestehendes multilinguales Turbo + Swiss-German-Fine-Tune von Flurin17), mit On-Demand-Download, Delete und Active-Selection via Settings-Tab "Modelle".
+
+**Architecture:** ASR-Modelle werden als Katalog modelliert (mehrere Definitionen, dieselbe `engineType: 'whisper'`), pyannote + flair bleiben Pflicht-Modelle. `activeModels.transcription` aus electron-store (bereits vorhanden) steuert welches Modell `WhisperService` lädt. First-Launch lädt nur Pflicht-Modelle + das aktive ASR-Modell. Settings-UI listet installierte und verfügbare ASR-Modelle mit Download/Delete/Activate-Aktionen. Update-Check prüft nur installierte Modelle.
+
+**Tech Stack:** Electron 30+, TypeScript strict, React 19, Tailwind v4, better-sqlite3, electron-store, whisper.cpp (subprocess), Zod-IPC-Validierung, Vitest.
+
+---
+
+## File Structure
+
+**Create:**
+- `scripts/convert-hf-whisper.sh` — Shell-Script: HuggingFace-Modell → ggml → Quantisierung
+- `src/main/ipc/model-catalog-handlers.ts` — IPC-Handler für Single-Model-Ops (download/delete/setActive/list)
+- `src/renderer/src/components/settings/ModelsSettings.tsx` — Inhalt des "Modelle"-Tabs
+- `src/renderer/src/components/settings/AsrModelCard.tsx` — Einzelne ASR-Modell-Karte
+- `src/renderer/src/components/settings/RequiredModelRow.tsx` — Read-only Info-Zeile für Pflicht-Modelle
+- `src/shared/validation/model-catalog-schemas.ts` — Zod-Schemas für Catalog-IPC
+- `src/main/services/__tests__/ModelDownloadService.test.ts` — Unit-Tests für reine Funktionen
+
+**Modify:**
+- `src/main/services/ModelDownloadService.ts` — `ModelDefinition` erweitern, neue Funktionen, Swiss-German im Katalog
+- `src/main/ml/WhisperService.ts:38` — `getModelPath()` auf aktives Modell umstellen
+- `src/main/services/UpdateCheckService.ts:107` — Updates nur für installierte Modelle prüfen
+- `src/main/index.ts` — neuen IPC-Handler registrieren
+- `src/preload/index.ts:102` — `modelCatalog`-API ergänzen
+- `src/shared/types/IpcApi.ts` — Typen für neue IPC-Methoden
+- `src/renderer/src/views/Settings.tsx:43-49` — Placeholder durch `<ModelsSettings />` ersetzen
+- `scripts/publish-manifest.sh:72-76` — Multi-ASR-Einträge im Manifest
+- `docs/product/MODELS.md` oder vergleichbar — Release-Flow + Modell-Registrierung dokumentieren
+
+---
+
+## Task 1: `ModelDefinition` um ASR-Katalog-Felder erweitern
+
+**Files:**
+- Modify: `src/main/services/ModelDownloadService.ts:10-23`
+
+- [ ] **Step 1: Typdefinition erweitern**
+
+In `ModelDownloadService.ts` ab Zeile 10 `ModelDefinition` anpassen — neue optionale Felder für die UI und zur Kategorisierung:
+
+```ts
+export type ModelGroup = 'asr' | 'diarization' | 'ner'
+
+export interface ModelDefinition {
+  id: string
+  label: string
+  url: string
+  sizeBytes: number
+  sha256: string
+  // For flat files: relative path to the final file (e.g., 'asr/ggml-large-v3-turbo-q5_0.bin')
+  // For archives: relative path of the extraction directory (e.g., 'diarization')
+  relativePath: string
+  // If true, download is a tar.gz that needs extraction into relativePath
+  archive?: boolean
+  // Path to check for existence (relative to modelsDir). Used by checkModelsExist().
+  checkPath: string
+  // Gruppe — ASR-Modelle sind auswählbar, diarization/ner sind Pflicht.
+  // Optional in Task 1, damit bestehende MODEL_DEFINITIONS noch compilen.
+  // In Task 2 bei allen Einträgen gesetzt — danach könnte man `group` auf required
+  // engziehen, tun wir aber nicht (kein Vorteil, Breaking-Change für externe Consumer).
+  group?: ModelGroup
+  // Wenn true, wird das Modell beim First-Launch automatisch geladen und kann nicht gelöscht werden.
+  // Default (undefined) = false.
+  isRequired?: boolean
+  // Nur für ASR: optionale UI-Metadaten
+  description?: string
+  languages?: string[] // BCP-47 Codes ('de-CH', 'de', 'multi', ...)
+  accuracyScore?: number // 0.0–1.0
+  speedScore?: number // 0.0–1.0
+}
+```
+
+**Warum optional:** Wenn `group` und `isRequired` required wären, würde der Build zwischen Task 1 und Task 2 brechen (bestehende drei `MODEL_DEFINITIONS`-Einträge haben die Felder noch nicht). Optional → Task 1 ist für sich grün, Task 2 füllt alle Einträge vollständig aus. In den Query-Helpers (Task 4) werden fehlende Werte defensiv auf `false`/keine Gruppe gemappt.
+
+- [ ] **Step 2: TypeScript-Check**
+
+Run: `npm run typecheck`
+Expected: PASS. Nächste Schritte füllen die neuen Felder für bestehende Einträge und fügen das Swiss-German-Modell hinzu.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/main/services/ModelDownloadService.ts
+git commit -m "refactor: extend ModelDefinition with group and ASR metadata fields"
+```
+
+---
+
+## Task 2: Bestehende Modelle mit neuen Feldern annotieren
+
+**Files:**
+- Modify: `src/main/services/ModelDownloadService.ts:45-75`
+
+- [ ] **Step 1: `MODEL_DEFINITIONS` ergänzen — alle drei Einträge mit `group` + `isRequired`, ASR-Eintrag mit UI-Metadaten**
+
+```ts
+const MODEL_DEFINITIONS: ModelDefinition[] = [
+  {
+    id: 'whisper-large-v3-turbo',
+    label: 'Whisper Large V3 Turbo (Multilingual)',
+    url: `${R2_CDN}/whisper-ggml-large-v3-turbo-q5_0.bin`,
+    relativePath: 'asr/ggml-large-v3-turbo-q5_0.bin',
+    checkPath: 'asr/ggml-large-v3-turbo-q5_0.bin',
+    sizeBytes: 574_041_195,
+    sha256: '394221709cd5ad1f40c46e6031ca61bce88931e6e088c188294c6d5a55ffa7e2',
+    group: 'asr',
+    isRequired: false,
+    description:
+      'Schnelles multilinguales Modell. Empfohlen wenn Schweizerdeutsch im Dialekt eher moderat ist oder wenn Aufnahmen auch andere Sprachen enthalten.',
+    languages: ['multi'],
+    accuracyScore: 0.8,
+    speedScore: 0.9
+  },
+  {
+    id: 'pyannote-community-1',
+    label: 'Sprechererkennung (pyannote-community-1)',
+    url: `${R2_CDN}/pyannote-models.tar.gz`,
+    relativePath: 'diarization',
+    checkPath: 'diarization/models--pyannote--speaker-diarization-3.1',
+    sizeBytes: 30_461_603,
+    sha256: 'b42e8aee7cf5eb330f4d5519216f9035dc1defad871097977fa9cecc11edb570',
+    archive: true,
+    group: 'diarization',
+    isRequired: true
+  },
+  {
+    id: 'flair-ner-german-large',
+    label: 'Anonymisierung (flair-ner-german-large)',
+    url: `${R2_CDN}/flair-ner-german-large.tar.gz`,
+    relativePath: 'ner',
+    checkPath: 'ner/models/ner-german-large',
+    sizeBytes: 1_741_705_466,
+    sha256: 'a34f6315659a34991930dae5d7a2bc2f3ee24ff6eb70dcd4d41e3aca7a5253e6',
+    archive: true,
+    group: 'ner',
+    isRequired: true
+  }
+]
+```
+
+**Hinweis:** Das bestehende Turbo-Modell hat bewusst `isRequired: false` — bei First-Launch wird aber via `activeModels.transcription` (Default `'whisper-large-v3-turbo'`) garantiert, dass mindestens dieses Modell geladen wird. Siehe Task 5.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/main/services/ModelDownloadService.ts
+git commit -m "refactor: annotate existing model definitions with group and ASR metadata"
+```
+
+---
+
+## Task 3: Swiss-German-Modell im Katalog registrieren (Platzhalter-Hash)
+
+**Files:**
+- Modify: `src/main/services/ModelDownloadService.ts:45-…` (`MODEL_DEFINITIONS`)
+
+**Begründung:** Das konvertierte Modell wird später via Task 16 gebaut und auf R2 hochgeladen. Bis dahin steht der Hash auf einem Platzhalter — der Download würde scheitern, aber der Katalog ist testbar. Nach Upload wird der Hash in einem separaten Commit nachgezogen.
+
+- [ ] **Step 1: Swiss-German-Eintrag zu `MODEL_DEFINITIONS` hinzufügen** (nach dem Turbo-Eintrag, vor pyannote)
+
+```ts
+  {
+    id: 'whisper-large-v3-turbo-swiss',
+    label: 'Whisper Large V3 Turbo (Swiss-German)',
+    url: `${R2_CDN}/whisper-ggml-large-v3-turbo-swiss-q5_0.bin`,
+    relativePath: 'asr/ggml-large-v3-turbo-swiss-q5_0.bin',
+    checkPath: 'asr/ggml-large-v3-turbo-swiss-q5_0.bin',
+    sizeBytes: 0, // TBD: wird nach Konvertierung in Task 16 aus r2-upload/ gesetzt
+    sha256: 'PENDING_UPLOAD', // TBD: wird nach Konvertierung in Task 16 gesetzt
+    group: 'asr',
+    isRequired: false,
+    description:
+      'Feinabgestimmtes Modell (Basis: Flurin17/whisper-large-v3-turbo-swiss-german) — höhere Genauigkeit bei Schweizerdeutsch-Dialekten, Kosten: grösser und spezifisch deutsch/schweizerdeutsch.',
+    languages: ['de-CH', 'de'],
+    accuracyScore: 0.9,
+    speedScore: 0.85
+  },
+```
+
+- [ ] **Step 2: TypeScript-Check**
+
+Run: `npm run typecheck`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/main/services/ModelDownloadService.ts
+git commit -m "feat: register swiss-german whisper model in catalog (placeholder hash)"
+```
+
+---
+
+## Task 4: Query-Helpers + Active-Model-Lookup
+
+**Files:**
+- Modify: `src/main/services/ModelDownloadService.ts` (nach `getModelDefinitions`, ca. Zeile 81)
+- Test: `src/main/services/__tests__/ModelDownloadService.test.ts` (neu)
+
+- [ ] **Step 1: Failing Test schreiben** — Datei `src/main/services/__tests__/ModelDownloadService.test.ts` anlegen:
+
+```ts
+import { describe, it, expect, beforeAll } from 'vitest'
+import {
+  getAsrModels,
+  getRequiredModels,
+  getModelById,
+  getModelsToLoadOnFirstLaunch
+} from '../ModelDownloadService'
+import { initSettings } from '../SettingsService'
+
+// Settings müssen initialisiert sein, weil spätere deleteModel/setActiveAsrModel-Tests
+// via getSettings() drauf zugreifen. Auch vorab OK, kostet wenig.
+beforeAll(() => {
+  initSettings()
+})
+
+describe('ModelDownloadService catalog helpers', () => {
+  it('getAsrModels returns all models with group="asr"', () => {
+    const asrs = getAsrModels()
+    expect(asrs.length).toBeGreaterThanOrEqual(2)
+    expect(asrs.every((m) => m.group === 'asr')).toBe(true)
+  })
+
+  it('getRequiredModels returns pyannote and flair but no asr', () => {
+    const required = getRequiredModels()
+    expect(required.map((m) => m.id).sort()).toEqual([
+      'flair-ner-german-large',
+      'pyannote-community-1'
+    ])
+  })
+
+  it('getModelById returns definition or null', () => {
+    expect(getModelById('whisper-large-v3-turbo')?.group).toBe('asr')
+    expect(getModelById('does-not-exist')).toBeNull()
+  })
+
+  it('getModelsToLoadOnFirstLaunch returns required + activeAsrId', () => {
+    const loaded = getModelsToLoadOnFirstLaunch('whisper-large-v3-turbo')
+    const ids = loaded.map((m) => m.id).sort()
+    expect(ids).toEqual([
+      'flair-ner-german-large',
+      'pyannote-community-1',
+      'whisper-large-v3-turbo'
+    ])
+  })
+
+  it('getModelsToLoadOnFirstLaunch falls back gracefully on unknown activeAsrId', () => {
+    const loaded = getModelsToLoadOnFirstLaunch('nonexistent')
+    // Nur required — ASR darf nicht versucht werden, wenn unbekannt
+    expect(loaded.map((m) => m.id).sort()).toEqual([
+      'flair-ner-german-large',
+      'pyannote-community-1'
+    ])
+  })
+})
+```
+
+- [ ] **Step 2: Test ausführen (soll fehlschlagen)**
+
+Run: `npx vitest run src/main/services/__tests__/ModelDownloadService.test.ts`
+Expected: FAIL — `getAsrModels is not a function` (Symbole noch nicht exportiert).
+
+- [ ] **Step 3: Implementierung in `ModelDownloadService.ts` ergänzen** (nach bestehendem `getModelDefinitions`):
+
+```ts
+export function getAsrModels(): ModelDefinition[] {
+  return MODEL_DEFINITIONS.filter((m) => m.group === 'asr')
+}
+
+export function getRequiredModels(): ModelDefinition[] {
+  return MODEL_DEFINITIONS.filter((m) => m.isRequired === true)
+}
+
+export function getModelById(id: string): ModelDefinition | null {
+  return MODEL_DEFINITIONS.find((m) => m.id === id) ?? null
+}
+
+/**
+ * Modelle, die auf First-Launch heruntergeladen werden müssen:
+ * alle required + das aktive ASR-Modell (falls gültig).
+ */
+export function getModelsToLoadOnFirstLaunch(activeAsrId: string): ModelDefinition[] {
+  const required = getRequiredModels()
+  const active = getModelById(activeAsrId)
+  if (active && active.group === 'asr') {
+    // Duplikate vermeiden (required hat keine ASR, aber defensiv)
+    return [...required, active].filter(
+      (m, i, arr) => arr.findIndex((x) => x.id === m.id) === i
+    )
+  }
+  return required
+}
+
+/**
+ * Prüft, ob die Minimal-Menge (required + aktives ASR) installiert ist.
+ * Ersatz für checkModelsExist(), das alle Modelle erwartete.
+ */
+export function checkRequiredAndActiveAsrExist(activeAsrId: string): boolean {
+  const modelsDir = getModelsDir()
+  const toCheck = getModelsToLoadOnFirstLaunch(activeAsrId)
+  return toCheck.every((m) => existsSync(join(modelsDir, m.checkPath)))
+}
+
+/**
+ * Prüft, ob ein einzelnes Modell installiert ist (für UI-Status).
+ */
+export function isModelInstalled(id: string): boolean {
+  const def = getModelById(id)
+  if (!def) return false
+  return existsSync(join(getModelsDir(), def.checkPath))
+}
+```
+
+- [ ] **Step 4: Test erneut ausführen**
+
+Run: `npx vitest run src/main/services/__tests__/ModelDownloadService.test.ts`
+Expected: PASS (alle 5 Tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/services/ModelDownloadService.ts src/main/services/__tests__/ModelDownloadService.test.ts
+git commit -m "feat: add catalog query helpers (getAsrModels, getModelById, etc)"
+```
+
+---
+
+## Task 5: `checkModelsExist` an Active-ASR-Logik koppeln
+
+**Files:**
+- Modify: `src/main/services/ModelDownloadService.ts:87-93` (`checkModelsExist`)
+- Modify: Aufrufer von `checkModelsExist` in `src/main/ipc/model-download-handlers.ts:16` und `src/main/index.ts` (falls dort aufgerufen)
+
+**Begründung:** `checkModelsExist` prüfte bisher, ob *alle* drei Modelle installiert sind — das stimmt nicht mehr, sobald es optionale ASR-Alternativen gibt. Die Semantik ändert sich zu "Pflicht-Modelle + aktives ASR-Modell vorhanden".
+
+- [ ] **Step 1: `checkModelsExist` in `ModelDownloadService.ts` ersetzen**
+
+Zeilen 87–93 durch diese Version ersetzen:
+
+```ts
+export function checkModelsExist(): boolean {
+  const activeAsrId = getSettings().get('activeModels').transcription
+  return checkRequiredAndActiveAsrExist(activeAsrId)
+}
+```
+
+(Import von `getSettings` steht bereits in Zeile 5.)
+
+- [ ] **Step 2: `getOverallModelSize` + `getAlreadyDownloadedBytes` auf "zu-ladende" Menge umstellen**
+
+Diese beiden Helpers werden vom First-Launch-Progress genutzt. Sie müssen jetzt nur die Modelle zählen, die tatsächlich geladen werden (required + aktives ASR), sonst stimmt die 0%/100%-Skala nicht. Zeilen 95–116 ersetzen:
+
+```ts
+export function getModelsToLoad(): ModelDefinition[] {
+  const activeAsrId = getSettings().get('activeModels').transcription
+  return getModelsToLoadOnFirstLaunch(activeAsrId)
+}
+
+export function getOverallModelSize(): number {
+  return getModelsToLoad().reduce((sum, m) => sum + m.sizeBytes, 0)
+}
+
+export function getAlreadyDownloadedBytes(): number {
+  const modelsDir = getModelsDir()
+  let total = 0
+  for (const model of getModelsToLoad()) {
+    const checkTarget = join(modelsDir, model.checkPath)
+    if (existsSync(checkTarget)) {
+      total += model.sizeBytes
+    } else if (!model.archive) {
+      const partialPath = join(modelsDir, model.relativePath) + '.partial'
+      if (existsSync(partialPath)) {
+        total += statSync(partialPath).size
+      }
+    }
+  }
+  return total
+}
+```
+
+- [ ] **Step 3: TypeScript-Check**
+
+Run: `npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main/services/ModelDownloadService.ts
+git commit -m "refactor: scope model existence checks to required + active asr model"
+```
+
+---
+
+## Task 6: `startModelDownload` auf First-Launch-Menge umstellen
+
+**Files:**
+- Modify: `src/main/services/ModelDownloadService.ts:125-237` (`startModelDownload`)
+
+**Begründung:** Die Schleife geht bislang über alle `MODEL_DEFINITIONS`. Das zieht bei 2+ ASR-Einträgen auch optionale Modelle rein. Ersatz: `getModelsToLoad()`.
+
+- [ ] **Step 1: Schleifenziel austauschen**
+
+In `startModelDownload` Zeile 133 ändern:
+
+```ts
+  for (const model of getModelsToLoad()) {
+```
+
+statt
+
+```ts
+  for (const model of MODEL_DEFINITIONS) {
+```
+
+Alle anderen Zeilen in `startModelDownload` bleiben. `getOverallModelSize()` stimmt durch Task 5 bereits.
+
+- [ ] **Step 2: Manuell gegenlesen**
+
+Die Schleife darf nicht mehr auf `MODEL_DEFINITIONS` zugreifen — sonst wird ein optionales Swiss-German bei First-Launch versehentlich mitgeladen.
+
+Run: `grep -n "MODEL_DEFINITIONS" src/main/services/ModelDownloadService.ts`
+Expected: Nur noch die Declaration-Zeile (45) + die Query-Helper-Funktionen (`getAsrModels`, `getRequiredModels`, `getModelById`). Kein direkter Zugriff aus `startModelDownload`, `getOverallModelSize`, `getAlreadyDownloadedBytes` mehr.
+
+- [ ] **Step 3: Build-Check**
+
+Run: `npm run build`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main/services/ModelDownloadService.ts
+git commit -m "refactor: scope first-launch download to required + active asr model"
+```
+
+---
+
+## Task 7: Single-Model-Download-Funktion
+
+**Files:**
+- Modify: `src/main/services/ModelDownloadService.ts` (neue Funktion am Ende vor den Exports)
+
+- [ ] **Step 1: Failing Test für Happy-Path-Validation (nur Argument-Validierung, kein echter HTTP-Download)**
+
+In `src/main/services/__tests__/ModelDownloadService.test.ts` anhängen:
+
+```ts
+import { downloadSingleModel } from '../ModelDownloadService'
+
+describe('downloadSingleModel', () => {
+  it('throws when model id is unknown', async () => {
+    await expect(downloadSingleModel('does-not-exist')).rejects.toThrow(
+      /unbekanntes Modell/i
+    )
+  })
+
+  it('throws when model is not in group "asr"', async () => {
+    await expect(downloadSingleModel('pyannote-community-1')).rejects.toThrow(
+      /nur ASR-Modelle/i
+    )
+  })
+})
+```
+
+- [ ] **Step 2: Test ausführen**
+
+Run: `npx vitest run src/main/services/__tests__/ModelDownloadService.test.ts`
+Expected: FAIL — `downloadSingleModel is not a function`.
+
+- [ ] **Step 3: `downloadSingleModel` implementieren**
+
+Nach der bestehenden `abortModelDownload`-Funktion (ca. Zeile 239) anhängen:
+
+```ts
+/**
+ * Lädt ein einziges ASR-Modell herunter (nicht für Pflicht-Modelle gedacht —
+ * die laufen via startModelDownload auf First-Launch).
+ *
+ * Sendet denselben `modelDownload:status`-Channel wie startModelDownload,
+ * damit die bestehende UI-Progress-Anzeige wiederverwendbar bleibt.
+ */
+export async function downloadSingleModel(id: string): Promise<void> {
+  const def = getModelById(id)
+  if (!def) {
+    throw new Error(`Download: unbekanntes Modell "${id}"`)
+  }
+  if (def.group !== 'asr') {
+    throw new Error(`Download: nur ASR-Modelle sind einzeln ladbar (id=${id})`)
+  }
+
+  if (abortSignal && !abortSignal.aborted) {
+    throw new Error('Download: bereits aktiv — zuerst abbrechen')
+  }
+
+  abortSignal = { aborted: false }
+  const modelsDir = getModelsDir()
+  const checkTarget = join(modelsDir, def.checkPath)
+
+  if (existsSync(checkTarget)) {
+    sendProgress({ state: 'complete' })
+    abortSignal = null
+    return
+  }
+
+  const targetPath = def.archive
+    ? join(modelsDir, `${def.id}.tar.gz`)
+    : join(modelsDir, def.relativePath)
+
+  const result = await downloadFile(
+    def.url,
+    targetPath,
+    (progress) => {
+      sendProgress({
+        state: 'downloading',
+        progress: {
+          currentModel: def.id,
+          currentModelLabel: def.label,
+          currentModelProgress: progress.percent,
+          currentModelDownloaded: progress.downloadedBytes,
+          currentModelTotal: progress.totalBytes,
+          overallDownloaded: progress.downloadedBytes,
+          overallTotal: def.sizeBytes,
+          overallPercent: progress.percent
+        }
+      })
+    },
+    abortSignal
+  )
+
+  if (!result.success) {
+    sendProgress({
+      state: 'error',
+      error: result.error ?? 'Download fehlgeschlagen',
+      modelId: def.id
+    })
+    abortSignal = null
+    throw new Error(result.error ?? 'Download fehlgeschlagen')
+  }
+
+  sendProgress({ state: 'verifying', modelId: def.id })
+  const valid = await verifyFileSha256(targetPath, def.sha256)
+  if (!valid) {
+    try {
+      unlinkSync(targetPath)
+    } catch {
+      /* non-fatal */
+    }
+    sendProgress({
+      state: 'error',
+      error: `SHA-256-Prüfung fehlgeschlagen für ${def.label}`,
+      modelId: def.id
+    })
+    abortSignal = null
+    throw new Error(`SHA-256-Prüfung fehlgeschlagen für ${def.label}`)
+  }
+
+  if (def.archive) {
+    sendProgress({ state: 'extracting', modelId: def.id })
+    const extractDir = join(modelsDir, def.relativePath)
+    mkdirSync(extractDir, { recursive: true })
+    const extractResult = await extractTarGz(targetPath, extractDir)
+    if (!extractResult.success) {
+      try {
+        unlinkSync(targetPath)
+      } catch {
+        /* non-fatal */
+      }
+      sendProgress({
+        state: 'error',
+        error: extractResult.error ?? 'Entpacken fehlgeschlagen',
+        modelId: def.id
+      })
+      abortSignal = null
+      throw new Error(extractResult.error ?? 'Entpacken fehlgeschlagen')
+    }
+  }
+
+  sendProgress({ state: 'complete' })
+  abortSignal = null
+}
+```
+
+- [ ] **Step 4: Test erneut ausführen**
+
+Run: `npx vitest run src/main/services/__tests__/ModelDownloadService.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/services/ModelDownloadService.ts src/main/services/__tests__/ModelDownloadService.test.ts
+git commit -m "feat: add downloadSingleModel for on-demand ASR downloads"
+```
+
+---
+
+## Task 8: Single-Model-Delete-Funktion
+
+**Files:**
+- Modify: `src/main/services/ModelDownloadService.ts`
+
+- [ ] **Step 1: Failing Test anhängen**
+
+```ts
+import { deleteModel } from '../ModelDownloadService'
+
+describe('deleteModel', () => {
+  it('throws when model id is unknown', async () => {
+    await expect(deleteModel('does-not-exist')).rejects.toThrow(/unbekanntes Modell/i)
+  })
+
+  it('throws when model is required', async () => {
+    await expect(deleteModel('pyannote-community-1')).rejects.toThrow(
+      /Pflicht-Modell/i
+    )
+  })
+
+  it('throws when attempting to delete the active asr model', async () => {
+    // Default ist 'whisper-large-v3-turbo' — das ist aktiv
+    await expect(deleteModel('whisper-large-v3-turbo')).rejects.toThrow(
+      /aktiv/i
+    )
+  })
+})
+```
+
+- [ ] **Step 2: Test ausführen**
+
+Run: `npx vitest run src/main/services/__tests__/ModelDownloadService.test.ts`
+Expected: FAIL — `deleteModel is not a function`.
+
+(Der `beforeAll(() => initSettings())`-Hook aus Task 4 deckt schon ab, dass `getSettings()` hier funktioniert.)
+
+- [ ] **Step 3: `deleteModel` implementieren**
+
+Nach `downloadSingleModel`:
+
+```ts
+import { rmSync } from 'fs'
+// ^ ergänzen zu den bestehenden fs-Imports in Zeile 1
+
+export async function deleteModel(id: string): Promise<void> {
+  const def = getModelById(id)
+  if (!def) {
+    throw new Error(`Löschen: unbekanntes Modell "${id}"`)
+  }
+  if (def.isRequired) {
+    throw new Error(`Löschen: "${def.label}" ist ein Pflicht-Modell und nicht löschbar`)
+  }
+
+  const settings = getSettings()
+  const activeAsr = settings.get('activeModels').transcription
+  if (activeAsr === id) {
+    throw new Error(
+      `Löschen: "${def.label}" ist aktuell aktiv. Zuerst anderes Modell aktivieren.`
+    )
+  }
+
+  const modelsDir = getModelsDir()
+  const target = join(modelsDir, def.checkPath)
+  if (existsSync(target)) {
+    rmSync(target, { recursive: true, force: true })
+  }
+  // Archiv-Rest (tar.gz) ebenfalls wegräumen, falls liegengeblieben
+  const archivePath = join(modelsDir, `${def.id}.tar.gz`)
+  if (existsSync(archivePath)) {
+    try {
+      unlinkSync(archivePath)
+    } catch {
+      /* non-fatal */
+    }
+  }
+
+  // installedModelVersions-Eintrag entfernen (Update-Check soll dieses Modell nicht mehr betrachten)
+  const installed = { ...settings.get('installedModelVersions') }
+  delete installed[id]
+  settings.set('installedModelVersions', installed)
+}
+```
+
+- [ ] **Step 4: Test erneut ausführen**
+
+Run: `npx vitest run src/main/services/__tests__/ModelDownloadService.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/services/ModelDownloadService.ts src/main/services/__tests__/ModelDownloadService.test.ts
+git commit -m "feat: add deleteModel with guards for required + active models"
+```
+
+---
+
+## Task 9: Active-ASR-Setter
+
+**Files:**
+- Modify: `src/main/services/ModelDownloadService.ts`
+
+- [ ] **Step 1: Failing Test anhängen**
+
+```ts
+import { setActiveAsrModel } from '../ModelDownloadService'
+
+describe('setActiveAsrModel', () => {
+  it('throws when model id is unknown', () => {
+    expect(() => setActiveAsrModel('nope')).toThrow(/unbekanntes Modell/i)
+  })
+
+  it('throws when model is not asr group', () => {
+    expect(() => setActiveAsrModel('pyannote-community-1')).toThrow(/keine ASR/i)
+  })
+
+  it('throws when model is not installed', () => {
+    // Swiss-German ist im Katalog, aber nicht auf Disk vorhanden
+    expect(() => setActiveAsrModel('whisper-large-v3-turbo-swiss')).toThrow(
+      /nicht installiert/i
+    )
+  })
+})
+```
+
+- [ ] **Step 2: Test ausführen**
+
+Run: `npx vitest run src/main/services/__tests__/ModelDownloadService.test.ts`
+Expected: FAIL — `setActiveAsrModel is not a function`.
+
+- [ ] **Step 3: Implementieren**
+
+```ts
+export function setActiveAsrModel(id: string): void {
+  const def = getModelById(id)
+  if (!def) {
+    throw new Error(`Aktivieren: unbekanntes Modell "${id}"`)
+  }
+  if (def.group !== 'asr') {
+    throw new Error(`Aktivieren: "${def.label}" ist keine ASR-Engine`)
+  }
+  if (!isModelInstalled(id)) {
+    throw new Error(`Aktivieren: "${def.label}" ist nicht installiert`)
+  }
+  const settings = getSettings()
+  const current = settings.get('activeModels')
+  settings.set('activeModels', { ...current, transcription: id })
+}
+```
+
+- [ ] **Step 4: Test erneut ausführen**
+
+Run: `npx vitest run src/main/services/__tests__/ModelDownloadService.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/services/ModelDownloadService.ts src/main/services/__tests__/ModelDownloadService.test.ts
+git commit -m "feat: add setActiveAsrModel with install/group guards"
+```
+
+---
+
+## Task 10: `WhisperService.getModelPath` auf aktives Modell umstellen
+
+**Files:**
+- Modify: `src/main/ml/WhisperService.ts:38-40`
+
+- [ ] **Step 1: Imports ergänzen** — oben in `WhisperService.ts` nach den bestehenden Imports:
+
+```ts
+import { getSettings } from '../services/SettingsService'
+import { getModelById } from '../services/ModelDownloadService'
+```
+
+- [ ] **Step 2: `getModelPath` ersetzen** (Zeilen 38–40)
+
+```ts
+  private getModelPath(): string {
+    const activeAsrId = getSettings().get('activeModels').transcription
+    const def = getModelById(activeAsrId)
+    if (!def) {
+      throw new Error(
+        `WhisperService: aktives ASR-Modell "${activeAsrId}" nicht im Katalog registriert.`
+      )
+    }
+    return join(getDataDir(), 'models', def.relativePath)
+  }
+```
+
+- [ ] **Step 3: Build + Typecheck**
+
+Run: `npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 4: Manueller Smoke-Test — bestehendes Default-Modell muss weiter funktionieren**
+
+Run: `npm run dev`
+- App starten
+- Session aufnehmen (kurz, ~30 s reicht) → transkribieren
+- Expected: Transkription läuft unverändert mit Turbo-Multilingual durch
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/ml/WhisperService.ts
+git commit -m "refactor: resolve whisper model path via active ASR setting"
+```
+
+---
+
+## Task 11: `UpdateCheckService` auf installierte Modelle beschränken
+
+**Files:**
+- Modify: `src/main/services/UpdateCheckService.ts:107-145`
+
+**Begründung:** Heute lädt `UpdateCheckService` jedes Modell im Manifest zum Update vor, wenn sein Hash von `installedVersions` abweicht. Bei nicht installiertem Swiss-German-Modell ist `installedVersions[id]` leer → Service würde unnötig zum Download auffordern. Fix: nur Modelle updaten, die bereits installiert sind.
+
+- [ ] **Step 1: `isModelInstalled`-Import ergänzen**
+
+In `UpdateCheckService.ts` Zeile 6:
+
+```ts
+import { getModelDefinitions, getModelsDir, isModelInstalled } from './ModelDownloadService'
+```
+
+- [ ] **Step 2: Schleife anpassen** (Zeilen 107–145)
+
+Die Schleife im `checkForUpdates` so ändern, dass sie optionale/nicht installierte Modelle überspringt:
+
+```ts
+    for (const manifestModel of manifest.models) {
+      // Path-traversal guard on id
+      if (manifestModel.id.includes('..') || manifestModel.id.includes('/')) {
+        console.warn(`UpdateCheckService: suspicious model id skipped: ${manifestModel.id}`)
+        continue
+      }
+
+      // Find structural info from local MODEL_DEFINITIONS
+      const definition = definitions.find((d) => d.id === manifestModel.id)
+      if (!definition) {
+        console.warn(`UpdateCheckService: unknown model id in manifest: ${manifestModel.id}`)
+        continue
+      }
+
+      // Nur Modelle updaten, die bereits installiert sind —
+      // optionale ASR-Alternativen ohne Install werden nicht als "Update verfügbar" beworben.
+      if (!isModelInstalled(manifestModel.id)) {
+        continue
+      }
+
+      const installed = installedVersions[manifestModel.id]
+      if (installed && installed.sha256 === manifestModel.sha256) {
+        continue // Already up to date
+      }
+
+      // Path-traversal guard on relativePath
+      if (definition.relativePath.includes('..')) {
+        console.warn(
+          `UpdateCheckService: suspicious relativePath skipped: ${definition.relativePath}`
+        )
+        continue
+      }
+
+      modelUpdates.push({
+        id: manifestModel.id,
+        version: manifestModel.version,
+        label: manifestModel.label,
+        url: manifestModel.url,
+        sha256: manifestModel.sha256,
+        sizeBytes: manifestModel.sizeBytes,
+        relativePath: definition.relativePath,
+        archive: definition.archive,
+        checkPath: definition.checkPath
+      })
+    }
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main/services/UpdateCheckService.ts
+git commit -m "refactor: skip update check for non-installed optional models"
+```
+
+---
+
+## Task 12: Zod-Schemas für neue IPC
+
+**Files:**
+- Create: `src/shared/validation/model-catalog-schemas.ts`
+
+- [ ] **Step 1: Datei neu anlegen**
+
+```ts
+import { z } from 'zod'
+
+export const ModelGroupSchema = z.enum(['asr', 'diarization', 'ner'])
+
+export const ModelCatalogEntrySchema = z.object({
+  id: z.string().min(1).max(64),
+  label: z.string(),
+  description: z.string().optional(),
+  sizeBytes: z.number().int().nonnegative(),
+  group: ModelGroupSchema,
+  isRequired: z.boolean(),
+  languages: z.array(z.string()).optional(),
+  accuracyScore: z.number().min(0).max(1).optional(),
+  speedScore: z.number().min(0).max(1).optional(),
+  isInstalled: z.boolean(),
+  isActive: z.boolean()
+})
+
+export type ModelCatalogEntry = z.infer<typeof ModelCatalogEntrySchema>
+
+export const ModelIdPayloadSchema = z.object({
+  id: z
+    .string()
+    .min(1)
+    .max(64)
+    .regex(/^[a-z0-9-]+$/i, 'nur a-z, 0-9 und Bindestrich erlaubt')
+})
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/shared/validation/model-catalog-schemas.ts
+git commit -m "feat: add zod schemas for model catalog ipc"
+```
+
+---
+
+## Task 13: IPC-Handler `model-catalog-handlers.ts`
+
+**Files:**
+- Create: `src/main/ipc/model-catalog-handlers.ts`
+- Modify: `src/main/index.ts` (Handler registrieren)
+
+- [ ] **Step 1: Handler-Datei anlegen**
+
+`src/main/ipc/model-catalog-handlers.ts`:
+
+```ts
+import { ipcMain } from 'electron'
+import { z } from 'zod'
+import { getSettings } from '../services/SettingsService'
+import {
+  abortModelDownload,
+  deleteModel,
+  downloadSingleModel,
+  getAsrModels,
+  getModelById,
+  isModelInstalled,
+  setActiveAsrModel
+} from '../services/ModelDownloadService'
+import {
+  ModelIdPayloadSchema,
+  type ModelCatalogEntry
+} from '../../shared/validation/model-catalog-schemas'
+
+function buildCatalogEntries(): ModelCatalogEntry[] {
+  const activeAsr = getSettings().get('activeModels').transcription
+  return getAsrModels().map((def) => ({
+    id: def.id,
+    label: def.label,
+    description: def.description,
+    sizeBytes: def.sizeBytes,
+    group: def.group,
+    isRequired: def.isRequired,
+    languages: def.languages,
+    accuracyScore: def.accuracyScore,
+    speedScore: def.speedScore,
+    isInstalled: isModelInstalled(def.id),
+    isActive: def.id === activeAsr
+  }))
+}
+
+function validate<T>(schema: z.ZodType<T>, payload: unknown, channel: string): T {
+  const parsed = schema.safeParse(payload)
+  if (!parsed.success) {
+    throw new Error(`IPC ${channel}: ungültige Argumente: ${parsed.error.message}`)
+  }
+  return parsed.data
+}
+
+export function registerModelCatalogHandlers(): void {
+  ipcMain.handle('modelCatalog:listAsr', () => {
+    return buildCatalogEntries()
+  })
+
+  ipcMain.handle('modelCatalog:download', async (_event, payload: unknown) => {
+    const { id } = validate(ModelIdPayloadSchema, payload, 'modelCatalog:download')
+    await downloadSingleModel(id)
+    return buildCatalogEntries()
+  })
+
+  ipcMain.handle('modelCatalog:delete', async (_event, payload: unknown) => {
+    const { id } = validate(ModelIdPayloadSchema, payload, 'modelCatalog:delete')
+    await deleteModel(id)
+    return buildCatalogEntries()
+  })
+
+  ipcMain.handle('modelCatalog:setActive', (_event, payload: unknown) => {
+    const { id } = validate(ModelIdPayloadSchema, payload, 'modelCatalog:setActive')
+    setActiveAsrModel(id)
+    return buildCatalogEntries()
+  })
+
+  // Cancel läuft gegen dasselbe abortSignal-Singleton, das auch downloadSingleModel nutzt —
+  // funktioniert für laufende Downloads, egal ob via First-Launch oder Catalog-API gestartet.
+  ipcMain.handle('modelCatalog:cancelDownload', () => {
+    abortModelDownload()
+  })
+}
+```
+
+- [ ] **Step 2: Handler in `main/index.ts` registrieren**
+
+`grep -n "registerModelDownloadHandlers" src/main/index.ts` → dort direkt darunter:
+
+```ts
+import { registerModelCatalogHandlers } from './ipc/model-catalog-handlers'
+```
+
+Und in der `app.whenReady()`-Callback-Sequenz, nach der bestehenden `registerModelDownloadHandlers()`-Zeile:
+
+```ts
+registerModelCatalogHandlers()
+```
+
+- [ ] **Step 3: Build**
+
+Run: `npm run build`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main/ipc/model-catalog-handlers.ts src/main/index.ts
+git commit -m "feat: add ipc handlers for asr model catalog (list/download/delete/setActive)"
+```
+
+---
+
+## Task 14: Preload-API erweitern
+
+**Files:**
+- Modify: `src/preload/index.ts:102-114`
+- Modify: `src/shared/types/IpcApi.ts`
+
+- [ ] **Step 1: TypeScript-Typen in `IpcApi.ts` ergänzen**
+
+Am Ende der Datei `src/shared/types/IpcApi.ts`:
+
+```ts
+import type { ModelCatalogEntry } from '../validation/model-catalog-schemas'
+
+export interface ModelCatalogApi {
+  listAsr: () => Promise<ModelCatalogEntry[]>
+  download: (id: string) => Promise<ModelCatalogEntry[]>
+  delete: (id: string) => Promise<ModelCatalogEntry[]>
+  setActive: (id: string) => Promise<ModelCatalogEntry[]>
+  cancelDownload: () => Promise<void>
+}
+```
+
+Danach in der bestehenden `ElectronApi`/`IpcApi`-Interface-Definition einen Eintrag `modelCatalog: ModelCatalogApi` ergänzen. (Exakte Stelle per `grep -n "modelDownload:" src/shared/types/IpcApi.ts` finden — analog anhängen.)
+
+- [ ] **Step 2: Preload-Export ergänzen**
+
+In `src/preload/index.ts`, nach dem `modelDownload`-Block (Zeile 114), einfügen:
+
+```ts
+  modelCatalog: {
+    listAsr: () => ipcRenderer.invoke('modelCatalog:listAsr'),
+    download: (id: string) => ipcRenderer.invoke('modelCatalog:download', { id }),
+    delete: (id: string) => ipcRenderer.invoke('modelCatalog:delete', { id }),
+    setActive: (id: string) => ipcRenderer.invoke('modelCatalog:setActive', { id }),
+    cancelDownload: () => ipcRenderer.invoke('modelCatalog:cancelDownload')
+  },
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/preload/index.ts src/shared/types/IpcApi.ts
+git commit -m "feat: expose modelCatalog api via preload bridge"
+```
+
+---
+
+## Task 15: UI-Komponente `AsrModelCard.tsx`
+
+**Files:**
+- Create: `src/renderer/src/components/settings/AsrModelCard.tsx`
+
+**UX-Hinweise, die im Code umgesetzt sind:**
+- Active-State subtil: nur Border-Akzent + Pill „Aktiv", **kein** Background-Tint (kein visuelles Über-Akzentuieren bei nur 2 Karten — Von Restorff: Pill reicht).
+- **Keine Accuracy/Speed-Balken** — Therapeuten können `0.8 vs 0.9` nicht einordnen. Stattdessen prägnante Chips (Sprache, Geschwindigkeit) + Prosa-Beschreibung im `description`-Feld der Registry, die die „Wann wähle ich was?"-Frage beantwortet.
+- Download-State: Karte leicht gedimmt, Progress + **Cancel-Button** (574 MB dauern auf schlechtem Netz > 5 min — Abbruch ist Pflicht).
+- Karte selbst **nicht** klickbar — alle Aktionen über explizite Buttons (keine versteckten Interaktionen).
+
+- [ ] **Step 1: Komponente anlegen**
+
+`src/renderer/src/components/settings/AsrModelCard.tsx`:
+
+```tsx
+import type { ModelCatalogEntry } from '../../../../shared/validation/model-catalog-schemas'
+
+interface Props {
+  model: ModelCatalogEntry
+  downloading: boolean
+  progress?: number
+  anyBusy: boolean
+  onDownload: () => void
+  onCancelDownload: () => void
+  onDelete: () => void
+  onActivate: () => void
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return '—'
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`
+  if (bytes < 1024 * 1024 * 1024) return `${Math.round(bytes / (1024 * 1024))} MB`
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`
+}
+
+/** Übersetzt BCP-47-Codes in Therapeut-freundliche Labels. */
+function formatLanguage(code: string): string {
+  switch (code) {
+    case 'multi':
+      return 'Multilingual'
+    case 'de':
+      return 'Hochdeutsch'
+    case 'de-CH':
+      return 'Schweizerdeutsch'
+    default:
+      return code
+  }
+}
+
+function Chip({ children }: { children: React.ReactNode }): React.JSX.Element {
+  return (
+    <span className="rounded-full bg-surface-2 px-2 py-0.5 text-xs text-text-tertiary">
+      {children}
+    </span>
+  )
+}
+
+export default function AsrModelCard({
+  model,
+  downloading,
+  progress,
+  anyBusy,
+  onDownload,
+  onCancelDownload,
+  onDelete,
+  onActivate
+}: Props): React.JSX.Element {
+  const dimmed = downloading ? 'opacity-70' : ''
+  const borderClass = model.isActive ? 'border-primary' : 'border-border'
+
+  return (
+    <div
+      className={`rounded-lg border p-4 ${borderClass} ${dimmed}`}
+      role="group"
+      aria-labelledby={`model-${model.id}-name`}
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2">
+            <h3
+              id={`model-${model.id}-name`}
+              className="font-semibold text-text-primary"
+            >
+              {model.label}
+            </h3>
+            {model.isActive && (
+              <span className="rounded-full bg-primary px-2 py-0.5 text-xs font-medium text-white">
+                Aktiv
+              </span>
+            )}
+          </div>
+
+          <div className="mt-1.5 flex flex-wrap gap-1.5">
+            {model.languages?.map((lang) => <Chip key={lang}>{formatLanguage(lang)}</Chip>)}
+            <Chip>{formatBytes(model.sizeBytes)}</Chip>
+          </div>
+
+          {model.description && (
+            <p className="mt-2 text-sm leading-relaxed text-text-secondary">
+              {model.description}
+            </p>
+          )}
+        </div>
+      </div>
+
+      {downloading && progress !== undefined && (
+        <div className="mt-3">
+          <div
+            className="h-1 w-full overflow-hidden rounded-full bg-surface-2"
+            role="progressbar"
+            aria-valuenow={progress}
+            aria-valuemin={0}
+            aria-valuemax={100}
+          >
+            <div
+              className="h-full bg-primary transition-all"
+              style={{ width: `${progress}%` }}
+            />
+          </div>
+          <p className="mt-1 text-xs text-text-tertiary">
+            Lädt herunter … {progress}%
+          </p>
+        </div>
+      )}
+
+      <div className="mt-3 flex justify-end gap-2">
+        {downloading && (
+          <button
+            className="titlebar-no-drag rounded-md border border-border px-3 py-1.5 text-sm text-text-secondary hover:bg-surface-2"
+            onClick={onCancelDownload}
+          >
+            Download abbrechen
+          </button>
+        )}
+        {!downloading && !model.isInstalled && (
+          <button
+            className="titlebar-no-drag rounded-md bg-primary px-3 py-1.5 text-sm text-white hover:bg-primary-hover disabled:opacity-50"
+            onClick={onDownload}
+            disabled={anyBusy}
+          >
+            Herunterladen
+          </button>
+        )}
+        {!downloading && model.isInstalled && !model.isActive && (
+          <>
+            <button
+              className="titlebar-no-drag rounded-md border border-border px-3 py-1.5 text-sm text-text-secondary hover:bg-surface-2 disabled:opacity-50"
+              onClick={onDelete}
+              disabled={anyBusy}
+            >
+              Löschen
+            </button>
+            <button
+              className="titlebar-no-drag rounded-md bg-primary px-3 py-1.5 text-sm text-white hover:bg-primary-hover disabled:opacity-50"
+              onClick={onActivate}
+              disabled={anyBusy}
+            >
+              Aktivieren
+            </button>
+          </>
+        )}
+        {!downloading && model.isInstalled && model.isActive && (
+          <span className="text-xs text-text-tertiary">
+            Wird für Transkription verwendet
+          </span>
+        )}
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/renderer/src/components/settings/AsrModelCard.tsx
+git commit -m "feat: add AsrModelCard component for model settings"
+```
+
+---
+
+## Task 16: UI-Komponente `ModelsSettings.tsx`
+
+**Files:**
+- Create: `src/renderer/src/components/settings/ModelsSettings.tsx`
+
+**UX-Hinweise, die im Code umgesetzt sind:**
+- **Toast-Feedback** via `useToast()` nach Aktivieren — Peak-End Rule: der Wechsel ist ein „peak moment", die Bestätigung prägt das Erlebnis. Inkl. Hinweis "Bereits verarbeitete Sitzungen bleiben unverändert" — schützt vor Panik.
+- **ConfirmDialog** (vorhandene Komponente) statt `window.confirm()` — Details-Array zeigt die freigegebene Grösse, destructive-Flag färbt den Button rot.
+- **Cancel-Button** für Download — leitet zu bestehendem `abortModelDownload()` durch (siehe Task 7.5 unten).
+
+- [ ] **Step 1: Komponente anlegen**
+
+`src/renderer/src/components/settings/ModelsSettings.tsx`:
+
+```tsx
+import { useEffect, useState } from 'react'
+import type { ModelCatalogEntry } from '../../../../shared/validation/model-catalog-schemas'
+import type { ModelDownloadStatus } from '../../../../shared/types/IpcApi'
+import { useToast } from '../../hooks/useToast'
+import { ConfirmDialog } from '../ConfirmDialog'
+import AsrModelCard from './AsrModelCard'
+
+function formatBytesShort(bytes: number): string {
+  if (bytes < 1024 * 1024 * 1024) return `${Math.round(bytes / (1024 * 1024))} MB`
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`
+}
+
+export default function ModelsSettings(): React.JSX.Element {
+  const toast = useToast()
+  const [models, setModels] = useState<ModelCatalogEntry[]>([])
+  const [downloadingId, setDownloadingId] = useState<string | null>(null)
+  const [progress, setProgress] = useState<number | undefined>(undefined)
+  const [deleteCandidate, setDeleteCandidate] = useState<ModelCatalogEntry | null>(null)
+
+  const reload = async (): Promise<void> => {
+    const list = await window.api.modelCatalog.listAsr()
+    setModels(list)
+  }
+
+  useEffect(() => {
+    reload()
+    const unsubscribe = window.api.modelDownload.onStatus((status: ModelDownloadStatus) => {
+      if (status.state === 'downloading') {
+        setProgress(status.progress.currentModelProgress)
+      } else if (status.state === 'complete') {
+        setProgress(undefined)
+        setDownloadingId(null)
+        reload()
+      } else if (status.state === 'error') {
+        toast.error(status.error)
+        setProgress(undefined)
+        setDownloadingId(null)
+      }
+    })
+    return unsubscribe
+  }, [toast])
+
+  const handleDownload = async (id: string): Promise<void> => {
+    setDownloadingId(id)
+    try {
+      const updated = await window.api.modelCatalog.download(id)
+      setModels(updated)
+      toast.success('Modell erfolgreich heruntergeladen.')
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : String(err))
+      setDownloadingId(null)
+    }
+  }
+
+  const handleCancelDownload = async (): Promise<void> => {
+    await window.api.modelCatalog.cancelDownload()
+    setDownloadingId(null)
+    setProgress(undefined)
+  }
+
+  const handleDeleteConfirmed = async (model: ModelCatalogEntry): Promise<void> => {
+    setDeleteCandidate(null)
+    try {
+      const updated = await window.api.modelCatalog.delete(model.id)
+      setModels(updated)
+      toast.success(`"${model.label}" gelöscht — ${formatBytesShort(model.sizeBytes)} freigegeben.`)
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  const handleActivate = async (model: ModelCatalogEntry): Promise<void> => {
+    try {
+      const updated = await window.api.modelCatalog.setActive(model.id)
+      setModels(updated)
+      toast.success(
+        `"${model.label}" aktiviert. Neue Transkriptionen verwenden ab jetzt dieses Modell — bereits verarbeitete Sitzungen bleiben unverändert.`
+      )
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  const installed = models.filter((m) => m.isInstalled)
+  const available = models.filter((m) => !m.isInstalled)
+  const anyBusy = downloadingId !== null
+
+  return (
+    <div className="space-y-6 p-6">
+      <section>
+        <h2 className="mb-1 text-lg font-semibold">Transkriptions-Modelle</h2>
+        <p className="text-sm text-text-secondary">
+          Wähle das Modell, das für die Transkription deiner Sitzungen verwendet werden soll.
+          Ein Modellwechsel wirkt sich nur auf neue Transkriptionen aus.
+        </p>
+      </section>
+
+      {installed.length > 0 && (
+        <section>
+          <h3 className="mb-2 text-sm font-medium text-text-tertiary">Installiert</h3>
+          <div className="space-y-3">
+            {installed.map((m) => (
+              <AsrModelCard
+                key={m.id}
+                model={m}
+                downloading={downloadingId === m.id}
+                progress={downloadingId === m.id ? progress : undefined}
+                anyBusy={anyBusy}
+                onDownload={() => handleDownload(m.id)}
+                onCancelDownload={handleCancelDownload}
+                onDelete={() => setDeleteCandidate(m)}
+                onActivate={() => handleActivate(m)}
+              />
+            ))}
+          </div>
+        </section>
+      )}
+
+      {available.length > 0 && (
+        <section>
+          <h3 className="mb-2 text-sm font-medium text-text-tertiary">Zum Download verfügbar</h3>
+          <div className="space-y-3">
+            {available.map((m) => (
+              <AsrModelCard
+                key={m.id}
+                model={m}
+                downloading={downloadingId === m.id}
+                progress={downloadingId === m.id ? progress : undefined}
+                anyBusy={anyBusy}
+                onDownload={() => handleDownload(m.id)}
+                onCancelDownload={handleCancelDownload}
+                onDelete={() => setDeleteCandidate(m)}
+                onActivate={() => handleActivate(m)}
+              />
+            ))}
+          </div>
+        </section>
+      )}
+
+      <section>
+        <h3 className="mb-2 text-sm font-medium text-text-tertiary">Pflicht-Modelle</h3>
+        <p className="mb-2 text-xs text-text-tertiary">
+          Diese Modelle sind für die Anonymisierung zwingend erforderlich und werden
+          automatisch aktuell gehalten.
+        </p>
+        <ul className="space-y-1 rounded-md border border-border bg-surface-1 p-3 text-xs text-text-tertiary">
+          <li>Sprechererkennung (pyannote-community-1)</li>
+          <li>Anonymisierung (flair-ner-german-large)</li>
+        </ul>
+      </section>
+
+      {deleteCandidate && (
+        <ConfirmDialog
+          title={`${deleteCandidate.label} löschen?`}
+          message={`${formatBytesShort(deleteCandidate.sizeBytes)} werden freigegeben. Du kannst das Modell später jederzeit erneut herunterladen.`}
+          confirmLabel="Löschen"
+          destructive
+          onConfirm={() => handleDeleteConfirmed(deleteCandidate)}
+          onCancel={() => setDeleteCandidate(null)}
+        />
+      )}
+    </div>
+  )
+}
+```
+
+**Hinweis zu `ConfirmDialog`:** Die bestehende Komponente zeigt standardmässig den Zusatzsatz „Diese Aktion kann nicht rückgängig gemacht werden." — das ist für Modell-Löschen **falsch** (kann ja wieder heruntergeladen werden). Akzeptabel als kleine Ungenauigkeit; optional später über Prop-Extension in `ConfirmDialog` fixen.
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/renderer/src/components/settings/ModelsSettings.tsx
+git commit -m "feat: add ModelsSettings tab content"
+```
+
+---
+
+## Task 17: Settings-View verdrahten
+
+**Files:**
+- Modify: `src/renderer/src/views/Settings.tsx:1-54`
+
+- [ ] **Step 1: Import ergänzen und Placeholder ersetzen**
+
+Zeile 1–4 Block um Import erweitern:
+
+```tsx
+import ModelsSettings from '../components/settings/ModelsSettings'
+```
+
+Zeilen 43–49 ersetzen:
+
+```tsx
+        {currentTab === 'modelle' && <ModelsSettings />}
+```
+
+- [ ] **Step 2: Manueller Smoke-Test**
+
+Run: `npm run dev`
+- Settings öffnen → Tab "Modelle"
+- Expected: Karten für beide Whisper-Modelle; Turbo-Multilingual als "Aktiv", Swiss-German als "Zum Download verfügbar" (wird aber bei Klick scheitern, weil Task 18 noch aussteht — das ist ok)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/renderer/src/views/Settings.tsx
+git commit -m "feat: wire ModelsSettings into settings view"
+```
+
+---
+
+## Task 18: HF-Konvertierungs-Script
+
+**Files:**
+- Create: `scripts/convert-hf-whisper.sh`
+
+**Begründung:** Reproduzierbarer Weg, Flurin17's Modell (und weitere HF-Whisper-Fine-Tunes in Zukunft) auf ggml/q5_0 zu bringen. Das Script wird **einmalig** lokal gelaufen, Output landet in `r2-upload/`.
+
+- [ ] **Step 1: Script anlegen**
+
+`scripts/convert-hf-whisper.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Konvertiert ein HuggingFace-Whisper-Modell in ggml-q5_0 für whisper.cpp.
+#
+# Voraussetzungen:
+#   - git, python3 (3.10+), pip, cmake
+#   - huggingface-cli eingeloggt (falls Modell gated)
+#
+# Usage:
+#   scripts/convert-hf-whisper.sh <hf-repo> <output-basename>
+# Beispiel:
+#   scripts/convert-hf-whisper.sh Flurin17/whisper-large-v3-turbo-swiss-german \
+#     whisper-ggml-large-v3-turbo-swiss-q5_0
+#
+# Output: r2-upload/<output-basename>.bin (quantisiert, hochladebereit)
+
+set -euo pipefail
+
+if [ $# -ne 2 ]; then
+  echo "Usage: $0 <hf-repo> <output-basename>" >&2
+  exit 1
+fi
+
+HF_REPO="$1"
+OUT_NAME="$2"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+WORK_DIR="$PROJECT_ROOT/build/convert-hf-whisper"
+OUT_DIR="$PROJECT_ROOT/r2-upload"
+WHISPER_CPP_DIR="$WORK_DIR/whisper.cpp"
+OPENAI_WHISPER_DIR="$WORK_DIR/openai-whisper"
+MODEL_DIR="$WORK_DIR/hf-model"
+
+mkdir -p "$WORK_DIR" "$OUT_DIR"
+
+# 1a. whisper.cpp clonen (Konvertierungs-Script + quantize-Tool)
+if [ ! -d "$WHISPER_CPP_DIR" ]; then
+  echo "→ Klone whisper.cpp nach $WHISPER_CPP_DIR"
+  git clone --depth 1 https://github.com/ggml-org/whisper.cpp "$WHISPER_CPP_DIR"
+fi
+
+# 1b. openai/whisper-Repo clonen — convert-h5-to-ggml.py erwartet das
+#     als zweites Argument (Quelle: Mel-Filter-Assets + Tokenizer-Artefakte).
+#     Die Script-Signatur aus whisper.cpp/models/convert-h5-to-ggml.py:
+#       python3 convert-h5-to-ggml.py <hf-model-dir> <whisper-repo-dir> <out-dir>
+if [ ! -d "$OPENAI_WHISPER_DIR" ]; then
+  echo "→ Klone openai/whisper nach $OPENAI_WHISPER_DIR"
+  git clone --depth 1 https://github.com/openai/whisper "$OPENAI_WHISPER_DIR"
+fi
+
+# 2. Python-Deps in ein venv, um System-Python nicht zu verschmutzen
+VENV="$WORK_DIR/venv"
+if [ ! -d "$VENV" ]; then
+  python3 -m venv "$VENV"
+fi
+source "$VENV/bin/activate"
+pip install --quiet --upgrade pip
+pip install --quiet torch transformers huggingface_hub
+
+# 3. HF-Modell herunterladen
+if [ ! -d "$MODEL_DIR/$(basename "$HF_REPO")" ]; then
+  echo "→ Lade $HF_REPO herunter"
+  mkdir -p "$MODEL_DIR"
+  huggingface-cli download "$HF_REPO" \
+    --local-dir "$MODEL_DIR/$(basename "$HF_REPO")" \
+    --local-dir-use-symlinks False
+fi
+
+# 4. ggml-Conversion
+#    Das Script legt `ggml-model.bin` in $WORK_DIR ab.
+GGML_RAW="$WORK_DIR/$OUT_NAME-raw.bin"
+echo "→ Konvertiere nach ggml"
+python "$WHISPER_CPP_DIR/models/convert-h5-to-ggml.py" \
+  "$MODEL_DIR/$(basename "$HF_REPO")" \
+  "$OPENAI_WHISPER_DIR" \
+  "$WORK_DIR"
+mv "$WORK_DIR/ggml-model.bin" "$GGML_RAW"
+
+# 5. whisper.cpp bauen (ohne expliziten --target: neuere Versionen benennen
+#    den Binary `quantize` in `whisper-quantize` um, je nach Release).
+if [ ! -d "$WHISPER_CPP_DIR/build" ]; then
+  echo "→ Baue whisper.cpp"
+  (cd "$WHISPER_CPP_DIR" && cmake -B build && cmake --build build -j)
+fi
+
+# 6. Quantize-Binary finden (Name variiert nach whisper.cpp-Version)
+QUANTIZE_BIN=""
+for candidate in "$WHISPER_CPP_DIR/build/bin/quantize" \
+                 "$WHISPER_CPP_DIR/build/bin/whisper-quantize"; do
+  if [ -x "$candidate" ]; then
+    QUANTIZE_BIN="$candidate"
+    break
+  fi
+done
+if [ -z "$QUANTIZE_BIN" ]; then
+  echo "Error: quantize-Binary nicht gefunden in $WHISPER_CPP_DIR/build/bin/" >&2
+  ls "$WHISPER_CPP_DIR/build/bin/" >&2
+  exit 1
+fi
+
+# 7. Quantisierung → q5_0
+echo "→ Quantisiere q5_0 via $QUANTIZE_BIN"
+"$QUANTIZE_BIN" "$GGML_RAW" "$OUT_DIR/$OUT_NAME.bin" q5_0
+
+# 8. SHA-256 + Grösse ausgeben
+HASH=$(shasum -a 256 "$OUT_DIR/$OUT_NAME.bin" | cut -d' ' -f1)
+SIZE=$(stat -f%z "$OUT_DIR/$OUT_NAME.bin")
+echo ""
+echo "=== Fertig ==="
+echo "Datei:     $OUT_DIR/$OUT_NAME.bin"
+echo "SHA-256:   $HASH"
+echo "Grösse:    $SIZE bytes"
+echo ""
+echo "Nächste Schritte:"
+echo "  1. sha256 + sizeBytes in MODEL_DEFINITIONS (ModelDownloadService.ts) eintragen"
+echo "  2. scripts/publish-manifest.sh laufen lassen (lädt nach R2)"
+```
+
+- [ ] **Step 2: Ausführbar machen**
+
+Run: `chmod +x scripts/convert-hf-whisper.sh`
+
+- [ ] **Step 3: Sanity-Check gegen Base-Turbo — bevor wir dem Fine-Tune-Modell vertrauen**
+
+Das konvertierte Base-Modell muss sich laden lassen. Wenn das schon scheitert, ist die Conversion-Toolchain für Turbo blockiert und der Plan stoppt hier.
+
+Run:
+```bash
+scripts/convert-hf-whisper.sh openai/whisper-large-v3-turbo whisper-turbo-smoke-test
+```
+
+Smoke-Load-Test:
+```bash
+resources/bin/whisper-cli -m r2-upload/whisper-turbo-smoke-test.bin \
+  -f <pfad-zu-testaudio.wav> -l de --no-prints
+```
+
+Expected: whisper-cli gibt Transkript aus ohne "invalid model"-Fehler. Wenn das klappt → Base-Turbo-Conversion funktioniert, Flurin17-Fine-Tune hat hohe Erfolgsaussicht. Wenn nicht → Issue aufmachen, Plan pausieren.
+
+Nach erfolgreichem Smoke-Test: `rm r2-upload/whisper-turbo-smoke-test.bin`
+
+- [ ] **Step 4: Flurin17-Modell konvertieren — erzeugt die Release-Datei + druckt SHA-256 und Grösse**
+
+Run:
+```bash
+scripts/convert-hf-whisper.sh Flurin17/whisper-large-v3-turbo-swiss-german \
+  whisper-ggml-large-v3-turbo-swiss-q5_0
+```
+
+Expected (nach einigen Minuten): Datei unter `r2-upload/whisper-ggml-large-v3-turbo-swiss-q5_0.bin`, Hash auf stdout. Notiere Hash und Grösse für Task 19.
+
+- [ ] **Step 5: Commit Script (ohne die Modelldatei, die ist gitignored via `r2-upload/`)**
+
+```bash
+git add scripts/convert-hf-whisper.sh
+git commit -m "feat: add script to convert huggingface whisper models to ggml q5_0"
+```
+
+---
+
+## Task 19: SHA-256 + sizeBytes des Swiss-German-Modells nachziehen
+
+**Files:**
+- Modify: `src/main/services/ModelDownloadService.ts` (Swiss-German-Eintrag aus Task 3)
+
+- [ ] **Step 1: Platzhalter ersetzen**
+
+Im `MODEL_DEFINITIONS`-Eintrag `whisper-large-v3-turbo-swiss`:
+- `sizeBytes: 0` → tatsächliche Grösse aus Task 18 Step 3
+- `sha256: 'PENDING_UPLOAD'` → tatsächlichen Hash aus Task 18 Step 3
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/main/services/ModelDownloadService.ts
+git commit -m "chore: set sha256 + size for swiss-german whisper model"
+```
+
+---
+
+## Task 20: `publish-manifest.sh` auf Multi-ASR erweitern
+
+**Files:**
+- Modify: `scripts/publish-manifest.sh:72-76` (MODELS-Array)
+
+- [ ] **Step 1: Swiss-German-Eintrag im `MODELS`-Array ergänzen**
+
+Array-Block so ergänzen:
+
+```bash
+declare -a MODELS=(
+  "whisper-large-v3-turbo|whisper-ggml-large-v3-turbo-q5_0.bin|Whisper Large V3 Turbo (Multilingual)|asr/ggml-large-v3-turbo-q5_0.bin|false|asr/ggml-large-v3-turbo-q5_0.bin"
+  "whisper-large-v3-turbo-swiss|whisper-ggml-large-v3-turbo-swiss-q5_0.bin|Whisper Large V3 Turbo (Swiss-German)|asr/ggml-large-v3-turbo-swiss-q5_0.bin|false|asr/ggml-large-v3-turbo-swiss-q5_0.bin"
+  "pyannote-community-1|pyannote-models.tar.gz|Sprechererkennung (pyannote-community-1)|diarization|true|diarization/models--pyannote--speaker-diarization-3.1"
+  "flair-ner-german-large|flair-ner-german-large.tar.gz|Anonymisierung (flair-ner-german-large)|ner|true|ner/models/ner-german-large"
+)
+```
+
+- [ ] **Step 2: Dry-Run prüfen**
+
+Run: `scripts/publish-manifest.sh --dry-run`
+Expected: Das JSON enthält vier `models`-Einträge (nicht drei) mit korrekten SHA-256-Werten (Dry-Run liest aus `r2-upload/`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/publish-manifest.sh
+git commit -m "chore: include swiss-german whisper in manifest publisher"
+```
+
+---
+
+## Task 21: Swiss-German-Modell auf R2 hochladen + Manifest publizieren
+
+**Files (extern):**
+- R2 Bucket `therascript`
+
+- [ ] **Step 1: Modelldatei auf R2 hochladen**
+
+Run:
+```bash
+source .env
+export AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY"
+export AWS_DEFAULT_REGION=auto
+aws s3 cp r2-upload/whisper-ggml-large-v3-turbo-swiss-q5_0.bin \
+  s3://therascript/whisper-ggml-large-v3-turbo-swiss-q5_0.bin \
+  --endpoint-url "https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com"
+```
+
+Expected: Upload-Bestätigung, keine Fehler.
+
+- [ ] **Step 2: Manifest publizieren**
+
+Run: `scripts/publish-manifest.sh`
+Expected: `manifest.json` auf R2 aktualisiert. Enthält Swiss-German-Eintrag mit korrektem Hash/URL.
+
+- [ ] **Step 3: Verify — Manifest über CDN abrufen**
+
+Run:
+```bash
+curl -s https://pub-f6971d643e3a464ba6977c0816c43e50.r2.dev/manifest.json | jq '.models[] | {id, sha256, sizeBytes}'
+```
+
+Expected: Vier Einträge, Swiss-German-Hash stimmt mit `MODEL_DEFINITIONS` überein.
+
+- [ ] **Step 4: Commit `manifest.json`** (falls lokal aktualisiert durch Dry-Run)
+
+```bash
+git add manifest.json
+git commit -m "chore: update manifest with swiss-german whisper entry"
+```
+
+---
+
+## Task 22: End-to-End-Test im Dev-Modus
+
+**Files:** keine Änderungen, nur Verifikation.
+
+- [ ] **Step 1: Frischer Settings-State simulieren** (optional, nur wenn man den First-Launch testen will)
+
+Run: `mv ~/.therascript/models ~/.therascript/models.bak`
+
+- [ ] **Step 2: Dev-Server starten**
+
+Run: `npm run dev`
+Expected:
+- First-Launch zeigt Download-Screen
+- Lädt nur drei Modelle (Turbo-Multilingual + pyannote + flair), NICHT Swiss-German
+- Gesamtgrösse ~2.3 GB (nicht ~4 GB)
+
+Falls Step 1 übersprungen: App startet direkt.
+
+- [ ] **Step 3: Modelle-Tab**
+
+- Settings → Tab "Modelle"
+- Expected: Turbo-Multilingual als "Installiert, Aktiv", Swiss-German als "Zum Download verfügbar"
+
+- [ ] **Step 4: Swiss-German laden**
+
+- Klick "Herunterladen" bei Swiss-German-Karte
+- Expected: Karte wird gedimmt, Progress-Bar + "Download abbrechen"-Button erscheinen
+- Am Ende: Karte zeigt "Installiert", Button "Aktivieren" erscheint, Success-Toast "Modell erfolgreich heruntergeladen"
+
+- [ ] **Step 4b: Download-Abbruch verifizieren** (kurz — nur Start, dann cancel)
+
+- Vor Step 4, oder nach Delete in Step 6: erneut "Herunterladen" klicken
+- Warte bis Progress ~5–10%, dann "Download abbrechen"
+- Expected: Karte kehrt in "Zum Download verfügbar"-State zurück, keine halbe Datei in `~/.therascript/models/asr/`
+
+- [ ] **Step 5: Aktivieren + Transkribieren**
+
+- Klick "Aktivieren" bei Swiss-German-Karte
+- Expected: Badge springt auf Swiss-German, Success-Toast mit Erklärungssatz ("Neue Transkriptionen verwenden ab jetzt dieses Modell — bereits verarbeitete Sitzungen bleiben unverändert.")
+- Neue Session aufnehmen (Schweizerdeutsch sprechen, 30–60 s)
+- Expected: Transkription läuft durch, Output erkennt Schweizerdeutsch-Dialekt erkennbar besser als mit Multilingual
+
+- [ ] **Step 6: Löschen**
+
+- Zurück auf Modelle-Tab, Swiss-German ist aktiv → Delete-Button fehlt (Guard greift)
+- Turbo-Multilingual aktivieren → Swiss-German bekommt jetzt "Löschen"-Button
+- Klick "Löschen" → ConfirmDialog erscheint mit Grössenangabe ("574 MB werden freigegeben.")
+- Abbrechen-Button schliesst Dialog ohne Effekt
+- Erneut klicken, dann bestätigen → Modell verschwindet aus "Installiert"-Sektion, taucht in "Zum Download verfügbar" auf, Success-Toast mit freigegebener Grösse
+
+- [ ] **Step 7: Cleanup (falls Step 1 gemacht)**
+
+Run: `mv ~/.therascript/models.bak ~/.therascript/models`
+
+- [ ] **Step 8: Keine Code-Änderungen — kein Commit nötig.**
+
+---
+
+## Task 23: Doku aktualisieren
+
+**Files:**
+- Modify: `CLAUDE.md` (ML-Pipeline-Abschnitt)
+- Modify: `docs/product/` (eine passende Datei, z. B. `architecture.md` oder eine neue `models.md`)
+
+- [ ] **Step 1: `CLAUDE.md` ML-Pipeline-Audio-Abschnitt anpassen**
+
+Den Bullet "1. whisper.cpp subprocess — ASR (Whisper Large V3 Turbo Q5_0, Metal GPU) ✓ implemented" erweitern:
+
+```markdown
+1. whisper.cpp subprocess — ASR via auswählbares Modell aus Katalog (Default: Whisper Large V3 Turbo Q5_0 multilingual; optional: Swiss-German-Fine-Tune). Active model stored in electron-store (`activeModels.transcription`), verwaltet via Settings → Modelle.
+```
+
+- [ ] **Step 2: Neue Doku `docs/product/models.md`** (oder bestehenden Architektur-Eintrag erweitern) mit:
+  - Tabelle der verfügbaren ASR-Modelle (ID, Sprache, Grösse, Quelle)
+  - Release-Flow für neue Modelle (Script → R2-Upload → publish-manifest → Hash nachziehen)
+  - Entscheidungs-Hinweis wann welches Modell (Multilingual vs. Swiss-German)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CLAUDE.md docs/product/
+git commit -m "docs: describe multi-asr-model selection and release flow"
+```
+
+---
+
+## Self-Review gegen die Anforderungen
+
+**Spec coverage:**
+- Mehrere ASR-Modelle im Katalog? → Task 1–3
+- Active-Model über Settings steuerbar? → Task 4, 9, 10, 16
+- First-Launch lädt nur Pflicht + aktives ASR? → Task 5–6
+- On-Demand-Download einzelner Modelle? → Task 7, 13, 16
+- Delete-Funktion mit Guards? → Task 8, 13, 16
+- UI à la Handy (Active-Badge, Bars, Download, Delete)? → Task 15, 16, 17
+- Update-Check für nicht installierte Modelle unterdrückt? → Task 11
+- HF → ggml Konvertierungs-Pipeline? → Task 18
+- Manifest + R2-Deploy? → Task 20, 21
+- Bestehende User verlieren nichts? → `activeModels.transcription` hat bereits seit heute Default `'whisper-large-v3-turbo'` (siehe `SettingsService.ts:28`) → keine Migration nötig
+- End-to-End-Verifikation? → Task 22
+
+**Platzhalter-Scan:** Task 3 hat explizit `sha256: 'PENDING_UPLOAD'` + `sizeBytes: 0` — das ist bewusst (Placeholder wird in Task 19 nachgezogen, nachdem Task 18 gelaufen ist). Keine weiteren Platzhalter.
+
+**Type consistency:** `ModelDefinition` erweitert (Task 1), alle späteren Tasks referenzieren dieselben Felder (`group`, `isRequired`, `description`, `languages`, `accuracyScore`, `speedScore`). IPC-Schema `ModelCatalogEntry` (Task 12) spiegelt die UI-relevanten Felder plus `isInstalled` + `isActive` wider. Funktionsnamen durchgängig konsistent (`getAsrModels`, `getModelById`, `downloadSingleModel`, `deleteModel`, `setActiveAsrModel`, `isModelInstalled`).

--- a/docs/product/features/model-management.md
+++ b/docs/product/features/model-management.md
@@ -2,7 +2,7 @@
 
 Therascript relies on three ML models that are downloaded on first launch and kept up to date via an R2-hosted manifest. App updates are surfaced separately through a non-blocking hint.
 
-Since v0.5 the ASR-Modell (Transkription) is **auswählbar** aus einem Katalog — Default ist das multilinguale Turbo-Modell, optional kann ein Schweizerdeutsch-Fine-Tune installiert werden. Siehe [ASR Model Catalog](#asr-model-catalog) unten.
+Since v0.5 the ASR model (transcription) is **user-selectable** from a catalog — the default is the multilingual Turbo model; a Swiss-German fine-tune can optionally be installed. See [ASR Model Catalog](#asr-model-catalog) below.
 
 ## First Launch Flow
 
@@ -253,47 +253,47 @@ The `cachedAppUpdateStatus` electron-store key follows this lifecycle:
 
 ## ASR Model Catalog
 
-Seit v0.5 ist das ASR-Modell auswählbar. `ModelDefinition` hat zwei neue Kategorisierungs-Felder:
+Since v0.5, the ASR model is user-selectable. `ModelDefinition` has two categorization fields:
 
-- **`group`**: `'asr' | 'diarization' | 'ner'` — legt fest, welche Helper greifen (`getAsrModels()`, `getRequiredModels()`)
-- **`isRequired`**: Pflicht-Modelle werden auf First-Launch automatisch geladen und können nicht gelöscht werden. Nur `pyannote-community-1` + `flair-ner-german-large` sind Pflicht.
+- **`group`**: `'asr' | 'diarization' | 'ner'` — drives which helpers apply (`getAsrModels()`, `getRequiredModels()`).
+- **`isRequired`**: required models are downloaded automatically on first launch and cannot be deleted. Only `pyannote-community-1` and `flair-ner-german-large` are required.
 
-### First-Launch-Scope
+### First-Launch Scope
 
-`checkModelsExist()` ruft intern `checkRequiredAndActiveAsrExist(activeAsrId)` → lädt **nur** die Pflicht-Modelle **plus** das aktive ASR-Modell (`activeModels.transcription` aus electron-store). Optionale ASR-Alternativen werden erst auf User-Wunsch via Settings → Modelle heruntergeladen.
+`checkModelsExist()` delegates to `checkRequiredAndActiveAsrExist(activeAsrId)`, which requires **only** the required models **plus** the active ASR model (`activeModels.transcription` in electron-store) to be present. Optional ASR alternatives are downloaded on demand via Settings → Models.
 
-### Verfügbare ASR-Modelle (Stand v0.5)
+### Available ASR Models (as of v0.5)
 
-| ID | Sprachen | Grösse | Szenario |
+| ID | Languages | Size | Use case |
 |---|---|---|---|
-| `whisper-large-v3-turbo` (Default) | Multilingual | 574 MB | Standard — funktioniert mit Hochdeutsch, Englisch, etc. |
-| `whisper-large-v3-turbo-swiss` | Schweizerdeutsch, Hochdeutsch | ~574 MB | Spezialist-Modell (Basis: Flurin17/whisper-large-v3-turbo-swiss-german). Merklich bessere Erkennung bei starken Dialekten, nicht für andere Sprachen geeignet. |
+| `whisper-large-v3-turbo` (default) | Multilingual | 574 MB | General-purpose — handles High German, English, and more. |
+| `whisper-large-v3-turbo-swiss` | Swiss German, High German | ~574 MB | Specialist model (base: Flurin17/whisper-large-v3-turbo-swiss-german). Noticeably better on strong Swiss-German dialects; not suitable for other languages. |
 
-### Settings → Modelle
+### Settings → Models
 
-Der Tab in `src/renderer/src/views/Settings.tsx` rendert `ModelsSettings.tsx`. Die Komponente:
+The tab in `src/renderer/src/views/Settings.tsx` renders `ModelsSettings.tsx`. The component:
 
-- listet ASR-Modelle in zwei Sektionen (Installiert / Zum Download verfügbar)
-- zeigt Active-Badge, Sprach-Chips, Grössenangabe, Beschreibungs-Prosa
-- bietet Herunterladen / Löschen / Aktivieren / Download-Abbrechen
-- nutzt `ConfirmDialog` + `useToast()` für Destructive-/Success-Feedback
-- zeigt die Pflicht-Modelle read-only als Info-Block
+- Lists ASR models in two sections (Installed / Available for Download).
+- Shows an active badge, language chips, size label, and a descriptive paragraph per model.
+- Offers Download / Delete / Activate / Cancel-download actions.
+- Uses `ConfirmDialog` + `useToast()` for destructive confirmation and success/error feedback.
+- Displays required models read-only as an info block.
 
-### IPC-Channels
+### IPC Channels
 
 | Channel | Direction | Purpose |
 |---------|-----------|---------|
-| `modelCatalog:listAsr` | handle | Gibt alle ASR-Modelle mit `isInstalled`/`isActive` zurück |
-| `modelCatalog:download` | handle | Lädt ein einzelnes ASR-Modell (mit `abortSignal`-Singleton) |
-| `modelCatalog:delete` | handle | Löscht Modell (Guards: nicht Pflicht, nicht aktiv) |
-| `modelCatalog:setActive` | handle | Wechselt `activeModels.transcription` (Guard: installiert) |
-| `modelCatalog:cancelDownload` | handle | Bricht laufenden Download ab |
+| `modelCatalog:listAsr` | handle | Returns all ASR models with `isInstalled`/`isActive` flags |
+| `modelCatalog:download` | handle | Downloads a single ASR model (uses the shared `abortSignal` singleton) |
+| `modelCatalog:delete` | handle | Deletes a model (guards: not required, not active) |
+| `modelCatalog:setActive` | handle | Switches `activeModels.transcription` (guard: installed) |
+| `modelCatalog:cancelDownload` | handle | Aborts an in-flight download |
 
-### Release-Flow für neue ASR-Modelle
+### Release Flow for New ASR Models
 
-1. `scripts/convert-hf-whisper.sh <hf-repo> <output-basename>` — konvertiert ein HuggingFace-Whisper-Modell via `convert-h5-to-ggml.py` + quantisiert auf `q5_0`. Output: `r2-upload/<basename>.bin`. Druckt SHA-256 + Grösse.
-2. Datei auf R2 hochladen (via `aws s3 cp`)
-3. Eintrag in `MODEL_DEFINITIONS` (`ModelDownloadService.ts`) ergänzen: `group: 'asr'`, `isRequired: false`, `description`, `languages`, `accuracyScore`, `speedScore`, korrekter SHA-256 und `sizeBytes`
-4. Manifest-Array in `scripts/publish-manifest.sh` um den neuen Eintrag erweitern
-5. `scripts/publish-manifest.sh` laufen lassen
-6. App-Release (Hash-Sync — siehe CLAUDE.md "Model hash sync")
+1. `scripts/convert-hf-whisper.sh <hf-repo> <output-basename>` — converts a HuggingFace Whisper model via `convert-h5-to-ggml.py` and quantizes to `q5_0`. Output: `r2-upload/<basename>.bin`. Prints SHA-256 and size.
+2. Upload the file to R2 (via `aws s3 cp`).
+3. Add an entry to `MODEL_DEFINITIONS` (`ModelDownloadService.ts`): `group: 'asr'`, `isRequired: false`, `description`, `languages`, `accuracyScore`, `speedScore`, plus the correct `sha256` and `sizeBytes`.
+4. Add the new entry to the manifest array in `scripts/publish-manifest.sh`.
+5. Run `scripts/publish-manifest.sh`.
+6. Ship an app release (hash sync — see CLAUDE.md "Model hash sync").

--- a/docs/product/features/model-management.md
+++ b/docs/product/features/model-management.md
@@ -2,6 +2,8 @@
 
 Therascript relies on three ML models that are downloaded on first launch and kept up to date via an R2-hosted manifest. App updates are surfaced separately through a non-blocking hint.
 
+Since v0.5 the ASR-Modell (Transkription) is **auswählbar** aus einem Katalog — Default ist das multilinguale Turbo-Modell, optional kann ein Schweizerdeutsch-Fine-Tune installiert werden. Siehe [ASR Model Catalog](#asr-model-catalog) unten.
+
 ## First Launch Flow
 
 On startup, `App.tsx` calls `modelDownload:status` (which runs `checkModelsExist()`) to determine whether all models are present. If any model is missing, `modelsReady` is `false` and the app renders `FirstLaunchScreen` instead of the main UI.
@@ -248,3 +250,50 @@ The `cachedAppUpdateStatus` electron-store key follows this lifecycle:
 | `appUpdate:check` | handle | Triggers full manifest check (model + app) |
 | `appUpdate:openReleasePage` | handle | Opens GitHub Releases in default browser |
 | `appUpdate:status` | send | Pushes app update status to renderer |
+
+## ASR Model Catalog
+
+Seit v0.5 ist das ASR-Modell auswählbar. `ModelDefinition` hat zwei neue Kategorisierungs-Felder:
+
+- **`group`**: `'asr' | 'diarization' | 'ner'` — legt fest, welche Helper greifen (`getAsrModels()`, `getRequiredModels()`)
+- **`isRequired`**: Pflicht-Modelle werden auf First-Launch automatisch geladen und können nicht gelöscht werden. Nur `pyannote-community-1` + `flair-ner-german-large` sind Pflicht.
+
+### First-Launch-Scope
+
+`checkModelsExist()` ruft intern `checkRequiredAndActiveAsrExist(activeAsrId)` → lädt **nur** die Pflicht-Modelle **plus** das aktive ASR-Modell (`activeModels.transcription` aus electron-store). Optionale ASR-Alternativen werden erst auf User-Wunsch via Settings → Modelle heruntergeladen.
+
+### Verfügbare ASR-Modelle (Stand v0.5)
+
+| ID | Sprachen | Grösse | Szenario |
+|---|---|---|---|
+| `whisper-large-v3-turbo` (Default) | Multilingual | 574 MB | Standard — funktioniert mit Hochdeutsch, Englisch, etc. |
+| `whisper-large-v3-turbo-swiss` | Schweizerdeutsch, Hochdeutsch | ~574 MB | Spezialist-Modell (Basis: Flurin17/whisper-large-v3-turbo-swiss-german). Merklich bessere Erkennung bei starken Dialekten, nicht für andere Sprachen geeignet. |
+
+### Settings → Modelle
+
+Der Tab in `src/renderer/src/views/Settings.tsx` rendert `ModelsSettings.tsx`. Die Komponente:
+
+- listet ASR-Modelle in zwei Sektionen (Installiert / Zum Download verfügbar)
+- zeigt Active-Badge, Sprach-Chips, Grössenangabe, Beschreibungs-Prosa
+- bietet Herunterladen / Löschen / Aktivieren / Download-Abbrechen
+- nutzt `ConfirmDialog` + `useToast()` für Destructive-/Success-Feedback
+- zeigt die Pflicht-Modelle read-only als Info-Block
+
+### IPC-Channels
+
+| Channel | Direction | Purpose |
+|---------|-----------|---------|
+| `modelCatalog:listAsr` | handle | Gibt alle ASR-Modelle mit `isInstalled`/`isActive` zurück |
+| `modelCatalog:download` | handle | Lädt ein einzelnes ASR-Modell (mit `abortSignal`-Singleton) |
+| `modelCatalog:delete` | handle | Löscht Modell (Guards: nicht Pflicht, nicht aktiv) |
+| `modelCatalog:setActive` | handle | Wechselt `activeModels.transcription` (Guard: installiert) |
+| `modelCatalog:cancelDownload` | handle | Bricht laufenden Download ab |
+
+### Release-Flow für neue ASR-Modelle
+
+1. `scripts/convert-hf-whisper.sh <hf-repo> <output-basename>` — konvertiert ein HuggingFace-Whisper-Modell via `convert-h5-to-ggml.py` + quantisiert auf `q5_0`. Output: `r2-upload/<basename>.bin`. Druckt SHA-256 + Grösse.
+2. Datei auf R2 hochladen (via `aws s3 cp`)
+3. Eintrag in `MODEL_DEFINITIONS` (`ModelDownloadService.ts`) ergänzen: `group: 'asr'`, `isRequired: false`, `description`, `languages`, `accuracyScore`, `speedScore`, korrekter SHA-256 und `sizeBytes`
+4. Manifest-Array in `scripts/publish-manifest.sh` um den neuen Eintrag erweitern
+5. `scripts/publish-manifest.sh` laufen lassen
+6. App-Release (Hash-Sync — siehe CLAUDE.md "Model hash sync")

--- a/scripts/convert-hf-whisper.sh
+++ b/scripts/convert-hf-whisper.sh
@@ -46,6 +46,17 @@ if [ ! -d "$WHISPER_CPP_DIR" ]; then
   git clone --depth 1 https://github.com/ggml-org/whisper.cpp "$WHISPER_CPP_DIR"
 fi
 
+# 1a-patch: convert-h5-to-ggml.py unterstützt BFloat16 nicht out-of-the-box.
+# Flurin17 und viele andere HF-Whisper-Fine-Tunes werden in bf16 gespeichert.
+# Fix: .float()-Cast vor .numpy() einfügen. Idempotent via grep-Check.
+CONVERT_SCRIPT="$WHISPER_CPP_DIR/models/convert-h5-to-ggml.py"
+if ! grep -q 'squeeze()\.float()\.numpy()' "$CONVERT_SCRIPT"; then
+  echo "-> Patche $CONVERT_SCRIPT (BFloat16-Support)"
+  # macOS sed braucht '' nach -i
+  sed -i '' 's|list_vars\[src\]\.squeeze()\.numpy()|list_vars[src].squeeze().float().numpy()|g' \
+    "$CONVERT_SCRIPT"
+fi
+
 # 1b. openai/whisper-Repo clonen - convert-h5-to-ggml.py erwartet das
 #     als zweites Argument (Quelle: Mel-Filter-Assets + Tokenizer-Artefakte).
 if [ ! -d "$OPENAI_WHISPER_DIR" ]; then

--- a/scripts/convert-hf-whisper.sh
+++ b/scripts/convert-hf-whisper.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Konvertiert ein HuggingFace-Whisper-Modell in ggml-q5_0 für whisper.cpp.
+#
+# Voraussetzungen:
+#   - git, python3 (3.10+), pip, cmake
+#   - huggingface-cli eingeloggt (falls Modell gated)
+#
+# Usage:
+#   scripts/convert-hf-whisper.sh <hf-repo> <output-basename>
+# Beispiel:
+#   scripts/convert-hf-whisper.sh Flurin17/whisper-large-v3-turbo-swiss-german \
+#     whisper-ggml-large-v3-turbo-swiss-q5_0
+#
+# Output: r2-upload/<output-basename>.bin (quantisiert, hochladebereit)
+
+set -euo pipefail
+
+if [ $# -ne 2 ]; then
+  echo "Usage: $0 <hf-repo> <output-basename>" >&2
+  exit 1
+fi
+
+HF_REPO="$1"
+OUT_NAME="$2"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+WORK_DIR="$PROJECT_ROOT/build/convert-hf-whisper"
+OUT_DIR="$PROJECT_ROOT/r2-upload"
+WHISPER_CPP_DIR="$WORK_DIR/whisper.cpp"
+OPENAI_WHISPER_DIR="$WORK_DIR/openai-whisper"
+MODEL_DIR="$WORK_DIR/hf-model"
+
+mkdir -p "$WORK_DIR" "$OUT_DIR"
+
+# 1a. whisper.cpp clonen (Konvertierungs-Script + quantize-Tool)
+if [ ! -d "$WHISPER_CPP_DIR" ]; then
+  echo "-> Klone whisper.cpp nach $WHISPER_CPP_DIR"
+  git clone --depth 1 https://github.com/ggml-org/whisper.cpp "$WHISPER_CPP_DIR"
+fi
+
+# 1b. openai/whisper-Repo clonen - convert-h5-to-ggml.py erwartet das
+#     als zweites Argument (Quelle: Mel-Filter-Assets + Tokenizer-Artefakte).
+if [ ! -d "$OPENAI_WHISPER_DIR" ]; then
+  echo "-> Klone openai/whisper nach $OPENAI_WHISPER_DIR"
+  git clone --depth 1 https://github.com/openai/whisper "$OPENAI_WHISPER_DIR"
+fi
+
+# 2. Python-Deps in ein venv, um System-Python nicht zu verschmutzen
+VENV="$WORK_DIR/venv"
+if [ ! -d "$VENV" ]; then
+  python3 -m venv "$VENV"
+fi
+# shellcheck disable=SC1091
+source "$VENV/bin/activate"
+pip install --quiet --upgrade pip
+pip install --quiet torch transformers huggingface_hub
+
+# 3. HF-Modell herunterladen
+if [ ! -d "$MODEL_DIR/$(basename "$HF_REPO")" ]; then
+  echo "-> Lade $HF_REPO herunter"
+  mkdir -p "$MODEL_DIR"
+  huggingface-cli download "$HF_REPO" \
+    --local-dir "$MODEL_DIR/$(basename "$HF_REPO")" \
+    --local-dir-use-symlinks False
+fi
+
+# 4. ggml-Conversion. Script legt ggml-model.bin in $WORK_DIR ab.
+GGML_RAW="$WORK_DIR/$OUT_NAME-raw.bin"
+echo "-> Konvertiere nach ggml"
+python "$WHISPER_CPP_DIR/models/convert-h5-to-ggml.py" \
+  "$MODEL_DIR/$(basename "$HF_REPO")" \
+  "$OPENAI_WHISPER_DIR" \
+  "$WORK_DIR"
+mv "$WORK_DIR/ggml-model.bin" "$GGML_RAW"
+
+# 5. whisper.cpp bauen (ohne --target, weil der Binary-Name je Version
+#    zwischen `quantize` und `whisper-quantize` wechselt).
+if [ ! -d "$WHISPER_CPP_DIR/build" ]; then
+  echo "-> Baue whisper.cpp"
+  (cd "$WHISPER_CPP_DIR" && cmake -B build && cmake --build build -j)
+fi
+
+# 6. Quantize-Binary finden (Name variiert nach whisper.cpp-Version)
+QUANTIZE_BIN=""
+for candidate in "$WHISPER_CPP_DIR/build/bin/quantize" \
+                 "$WHISPER_CPP_DIR/build/bin/whisper-quantize"; do
+  if [ -x "$candidate" ]; then
+    QUANTIZE_BIN="$candidate"
+    break
+  fi
+done
+if [ -z "$QUANTIZE_BIN" ]; then
+  echo "Error: quantize-Binary nicht gefunden in $WHISPER_CPP_DIR/build/bin/" >&2
+  ls "$WHISPER_CPP_DIR/build/bin/" >&2
+  exit 1
+fi
+
+# 7. Quantisierung -> q5_0
+echo "-> Quantisiere q5_0 via $QUANTIZE_BIN"
+"$QUANTIZE_BIN" "$GGML_RAW" "$OUT_DIR/$OUT_NAME.bin" q5_0
+
+# 8. SHA-256 + Groesse ausgeben
+HASH=$(shasum -a 256 "$OUT_DIR/$OUT_NAME.bin" | cut -d' ' -f1)
+SIZE=$(stat -f%z "$OUT_DIR/$OUT_NAME.bin")
+echo ""
+echo "=== Fertig ==="
+echo "Datei:     $OUT_DIR/$OUT_NAME.bin"
+echo "SHA-256:   $HASH"
+echo "Groesse:   $SIZE bytes"
+echo ""
+echo "Naechste Schritte:"
+echo "  1. sha256 + sizeBytes in MODEL_DEFINITIONS (ModelDownloadService.ts) eintragen"
+echo "  2. scripts/publish-manifest.sh laufen lassen (laedt nach R2)"

--- a/scripts/convert-hf-whisper.sh
+++ b/scripts/convert-hf-whisper.sh
@@ -23,6 +23,13 @@ fi
 HF_REPO="$1"
 OUT_NAME="$2"
 
+# Python 3.14 is too new for current torch wheels → default to 3.12, allow override.
+PYTHON_BIN="${PYTHON_BIN:-python3.12}"
+if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
+  echo "Error: $PYTHON_BIN nicht gefunden. Setze PYTHON_BIN=python3.x explizit." >&2
+  exit 1
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 WORK_DIR="$PROJECT_ROOT/build/convert-hf-whisper"
@@ -49,7 +56,7 @@ fi
 # 2. Python-Deps in ein venv, um System-Python nicht zu verschmutzen
 VENV="$WORK_DIR/venv"
 if [ ! -d "$VENV" ]; then
-  python3 -m venv "$VENV"
+  "$PYTHON_BIN" -m venv "$VENV"
 fi
 # shellcheck disable=SC1091
 source "$VENV/bin/activate"

--- a/scripts/convert-hf-whisper.sh
+++ b/scripts/convert-hf-whisper.sh
@@ -63,13 +63,11 @@ source "$VENV/bin/activate"
 pip install --quiet --upgrade pip
 pip install --quiet torch transformers huggingface_hub
 
-# 3. HF-Modell herunterladen
+# 3. HF-Modell herunterladen (hf ist der neue CLI; huggingface-cli ist deprecated seit 2025)
 if [ ! -d "$MODEL_DIR/$(basename "$HF_REPO")" ]; then
   echo "-> Lade $HF_REPO herunter"
   mkdir -p "$MODEL_DIR"
-  huggingface-cli download "$HF_REPO" \
-    --local-dir "$MODEL_DIR/$(basename "$HF_REPO")" \
-    --local-dir-use-symlinks False
+  hf download "$HF_REPO" --local-dir "$MODEL_DIR/$(basename "$HF_REPO")"
 fi
 
 # 4. ggml-Conversion. Script legt ggml-model.bin in $WORK_DIR ab.
@@ -81,25 +79,38 @@ python "$WHISPER_CPP_DIR/models/convert-h5-to-ggml.py" \
   "$WORK_DIR"
 mv "$WORK_DIR/ggml-model.bin" "$GGML_RAW"
 
-# 5. whisper.cpp bauen (ohne --target, weil der Binary-Name je Version
-#    zwischen `quantize` und `whisper-quantize` wechselt).
-if [ ! -d "$WHISPER_CPP_DIR/build" ]; then
-  echo "-> Baue whisper.cpp"
-  (cd "$WHISPER_CPP_DIR" && cmake -B build && cmake --build build -j)
-fi
-
-# 6. Quantize-Binary finden (Name variiert nach whisper.cpp-Version)
+# 5/6. Quantize-Binary finden. Reihenfolge:
+#   1. Homebrew (whisper-cpp formula installiert whisper-quantize) — bevorzugt,
+#      weil cmake-Build aus Source oft an Xcode-SDK-Problemen scheitert.
+#   2. Lokal gebautes whisper.cpp (Fallback, falls Homebrew-Version fehlt).
 QUANTIZE_BIN=""
-for candidate in "$WHISPER_CPP_DIR/build/bin/quantize" \
-                 "$WHISPER_CPP_DIR/build/bin/whisper-quantize"; do
+for candidate in "/opt/homebrew/bin/whisper-quantize" \
+                 "/usr/local/bin/whisper-quantize" \
+                 "$WHISPER_CPP_DIR/build/bin/whisper-quantize" \
+                 "$WHISPER_CPP_DIR/build/bin/quantize"; do
   if [ -x "$candidate" ]; then
     QUANTIZE_BIN="$candidate"
     break
   fi
 done
+
 if [ -z "$QUANTIZE_BIN" ]; then
-  echo "Error: quantize-Binary nicht gefunden in $WHISPER_CPP_DIR/build/bin/" >&2
-  ls "$WHISPER_CPP_DIR/build/bin/" >&2
+  echo "-> Kein quantize-Binary gefunden — baue whisper.cpp aus Source"
+  if [ ! -d "$WHISPER_CPP_DIR/build" ]; then
+    (cd "$WHISPER_CPP_DIR" && cmake -B build && cmake --build build -j)
+  fi
+  for candidate in "$WHISPER_CPP_DIR/build/bin/whisper-quantize" \
+                   "$WHISPER_CPP_DIR/build/bin/quantize"; do
+    if [ -x "$candidate" ]; then
+      QUANTIZE_BIN="$candidate"
+      break
+    fi
+  done
+fi
+
+if [ -z "$QUANTIZE_BIN" ]; then
+  echo "Error: quantize-Binary nicht gefunden. Installiere Homebrew whisper-cpp:" >&2
+  echo "  brew install whisper-cpp" >&2
   exit 1
 fi
 

--- a/scripts/publish-manifest.sh
+++ b/scripts/publish-manifest.sh
@@ -70,7 +70,8 @@ fi
 # Model metadata: id|filename|label|relativePath|archive|checkPath
 # Must match MODEL_DEFINITIONS in ModelDownloadService.ts
 declare -a MODELS=(
-  "whisper-large-v3-turbo|whisper-ggml-large-v3-turbo-q5_0.bin|Spracherkennung (whisper-large-v3-turbo)|asr/ggml-large-v3-turbo-q5_0.bin|false|asr/ggml-large-v3-turbo-q5_0.bin"
+  "whisper-large-v3-turbo|whisper-ggml-large-v3-turbo-q5_0.bin|Whisper Large V3 Turbo (Multilingual)|asr/ggml-large-v3-turbo-q5_0.bin|false|asr/ggml-large-v3-turbo-q5_0.bin"
+  "whisper-large-v3-turbo-swiss|whisper-ggml-large-v3-turbo-swiss-q5_0.bin|Whisper Large V3 Turbo (Swiss-German)|asr/ggml-large-v3-turbo-swiss-q5_0.bin|false|asr/ggml-large-v3-turbo-swiss-q5_0.bin"
   "pyannote-community-1|pyannote-models.tar.gz|Sprechererkennung (pyannote-community-1)|diarization|true|diarization/models--pyannote--speaker-diarization-3.1"
   "flair-ner-german-large|flair-ner-german-large.tar.gz|Anonymisierung (flair-ner-german-large)|ner|true|ner/models/ner-german-large"
 )

--- a/scripts/publish-manifest.sh
+++ b/scripts/publish-manifest.sh
@@ -71,6 +71,7 @@ fi
 # Must match MODEL_DEFINITIONS in ModelDownloadService.ts
 declare -a MODELS=(
   "whisper-large-v3-turbo|whisper-ggml-large-v3-turbo-q5_0.bin|Whisper Large V3 Turbo (Multilingual)|asr/ggml-large-v3-turbo-q5_0.bin|false|asr/ggml-large-v3-turbo-q5_0.bin"
+  "whisper-large-v3-turbo-german|whisper-ggml-large-v3-turbo-german-q5_0.bin|Whisper Large V3 Turbo (German)|asr/ggml-large-v3-turbo-german-q5_0.bin|false|asr/ggml-large-v3-turbo-german-q5_0.bin"
   "whisper-large-v3-turbo-swiss|whisper-ggml-large-v3-turbo-swiss-q5_0.bin|Whisper Large V3 Turbo (Swiss-German)|asr/ggml-large-v3-turbo-swiss-q5_0.bin|false|asr/ggml-large-v3-turbo-swiss-q5_0.bin"
   "pyannote-community-1|pyannote-models.tar.gz|Sprechererkennung (pyannote-community-1)|diarization|true|diarization/models--pyannote--speaker-diarization-3.1"
   "flair-ner-german-large|flair-ner-german-large.tar.gz|Anonymisierung (flair-ner-german-large)|ner|true|ner/models/ner-german-large"

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -16,6 +16,7 @@ import { registerPDFHandlers } from './ipc/pdf-handlers'
 import { registerReviewHandlers } from './ipc/review-handlers'
 import { registerSystemHandlers } from './ipc/system-handlers'
 import { registerModelDownloadHandlers } from './ipc/model-download-handlers'
+import { registerModelCatalogHandlers } from './ipc/model-catalog-handlers'
 import { registerModelUpdateHandlers } from './ipc/model-update-handlers'
 import { initTray, getTray } from './services/TrayService'
 import {
@@ -157,6 +158,7 @@ app.whenReady().then(() => {
   registerReviewHandlers()
   registerSystemHandlers()
   registerModelDownloadHandlers()
+  registerModelCatalogHandlers()
   registerModelUpdateHandlers()
   registerAppUpdateHandlers()
 

--- a/src/main/ipc/model-catalog-handlers.ts
+++ b/src/main/ipc/model-catalog-handlers.ts
@@ -1,0 +1,70 @@
+import { ipcMain } from 'electron'
+import { z } from 'zod'
+import { getSettings } from '../services/SettingsService'
+import {
+  abortModelDownload,
+  deleteModel,
+  downloadSingleModel,
+  getAsrModels,
+  isModelInstalled,
+  setActiveAsrModel
+} from '../services/ModelDownloadService'
+import {
+  ModelIdPayloadSchema,
+  type ModelCatalogEntry
+} from '../../shared/validation/model-catalog-schemas'
+
+function buildCatalogEntries(): ModelCatalogEntry[] {
+  const activeAsr = getSettings().get('activeModels').transcription
+  return getAsrModels().map((def) => ({
+    id: def.id,
+    label: def.label,
+    description: def.description,
+    sizeBytes: def.sizeBytes,
+    group: 'asr' as const,
+    isRequired: def.isRequired === true,
+    languages: def.languages,
+    accuracyScore: def.accuracyScore,
+    speedScore: def.speedScore,
+    isInstalled: isModelInstalled(def.id),
+    isActive: def.id === activeAsr
+  }))
+}
+
+function validate<T>(schema: z.ZodType<T>, payload: unknown, channel: string): T {
+  const parsed = schema.safeParse(payload)
+  if (!parsed.success) {
+    throw new Error(`IPC ${channel}: ungültige Argumente: ${parsed.error.message}`)
+  }
+  return parsed.data
+}
+
+export function registerModelCatalogHandlers(): void {
+  ipcMain.handle('modelCatalog:listAsr', () => {
+    return buildCatalogEntries()
+  })
+
+  ipcMain.handle('modelCatalog:download', async (_event, payload: unknown) => {
+    const { id } = validate(ModelIdPayloadSchema, payload, 'modelCatalog:download')
+    await downloadSingleModel(id)
+    return buildCatalogEntries()
+  })
+
+  ipcMain.handle('modelCatalog:delete', async (_event, payload: unknown) => {
+    const { id } = validate(ModelIdPayloadSchema, payload, 'modelCatalog:delete')
+    await deleteModel(id)
+    return buildCatalogEntries()
+  })
+
+  ipcMain.handle('modelCatalog:setActive', (_event, payload: unknown) => {
+    const { id } = validate(ModelIdPayloadSchema, payload, 'modelCatalog:setActive')
+    setActiveAsrModel(id)
+    return buildCatalogEntries()
+  })
+
+  // Cancel läuft gegen dasselbe abortSignal-Singleton, das auch downloadSingleModel nutzt —
+  // funktioniert für laufende Downloads, egal ob via First-Launch oder Catalog-API gestartet.
+  ipcMain.handle('modelCatalog:cancelDownload', () => {
+    abortModelDownload()
+  })
+}

--- a/src/main/ml/WhisperService.ts
+++ b/src/main/ml/WhisperService.ts
@@ -246,11 +246,13 @@ export class WhisperService implements TaskExecutor {
 
     const duration = cleanedWords.length > 0 ? cleanedWords[cleanedWords.length - 1].end : 0
 
+    const activeAsrId = getSettings().get('activeModels').transcription
+
     return {
       words: cleanedWords,
       segments,
       metadata: {
-        model: 'whisper-large-v3-turbo-q5_0',
+        model: activeAsrId,
         language: 'de',
         duration
       }

--- a/src/main/ml/WhisperService.ts
+++ b/src/main/ml/WhisperService.ts
@@ -8,6 +8,8 @@ import type { TranscriptData } from '../../shared/types'
 import type { TaskExecutor } from '../services/task-executors'
 import { SessionService } from '../services/SessionService'
 import { getDatabase, getDataDir } from '../db/connection'
+import { getSettings } from '../services/SettingsService'
+import { getModelById } from '../services/ModelDownloadService'
 import { writeFileAtomic } from '../utils/file-ops'
 import { removeFillerWords, rebuildSegments } from './filler-removal'
 import { filterSpecialTokens, mergeSubTokens } from './token-processing'
@@ -36,7 +38,14 @@ export class WhisperService implements TaskExecutor {
   }
 
   private getModelPath(): string {
-    return join(getDataDir(), 'models', 'asr', 'ggml-large-v3-turbo-q5_0.bin')
+    const activeAsrId = getSettings().get('activeModels').transcription
+    const def = getModelById(activeAsrId)
+    if (!def) {
+      throw new Error(
+        `WhisperService: aktives ASR-Modell "${activeAsrId}" nicht im Katalog registriert.`
+      )
+    }
+    return join(getDataDir(), 'models', def.relativePath)
   }
 
   async execute(task: Task, onProgress: (progress: number) => void, signal?: AbortSignal): Promise<void> {

--- a/src/main/services/ModelDownloadService.ts
+++ b/src/main/services/ModelDownloadService.ts
@@ -71,6 +71,22 @@ const MODEL_DEFINITIONS: ModelDefinition[] = [
     speedScore: 0.9
   },
   {
+    id: 'whisper-large-v3-turbo-swiss',
+    label: 'Whisper Large V3 Turbo (Swiss-German)',
+    url: `${R2_CDN}/whisper-ggml-large-v3-turbo-swiss-q5_0.bin`,
+    relativePath: 'asr/ggml-large-v3-turbo-swiss-q5_0.bin',
+    checkPath: 'asr/ggml-large-v3-turbo-swiss-q5_0.bin',
+    sizeBytes: 0, // TBD: set after model conversion in scripts/convert-hf-whisper.sh
+    sha256: 'PENDING_UPLOAD', // TBD: set after model conversion
+    group: 'asr',
+    isRequired: false,
+    description:
+      'Spezialisiert auf starke Schweizerdeutsch-Dialekte (Basis: Flurin17/whisper-large-v3-turbo-swiss-german). Merklich präzisere Transkription bei ausgeprägter Mundart. Nicht geeignet für andere Sprachen.',
+    languages: ['de-CH', 'de'],
+    accuracyScore: 0.9,
+    speedScore: 0.85
+  },
+  {
     id: 'pyannote-community-1',
     label: 'Sprechererkennung (pyannote-community-1)',
     url: `${R2_CDN}/pyannote-models.tar.gz`,

--- a/src/main/services/ModelDownloadService.ts
+++ b/src/main/services/ModelDownloadService.ts
@@ -22,9 +22,7 @@ export interface ModelDefinition {
   archive?: boolean
   // Path to check for existence (relative to modelsDir). Used by checkModelsExist().
   checkPath: string
-  // Optional in Task 1 to keep existing MODEL_DEFINITIONS valid; populated in Task 2.
   group?: ModelGroup
-  // Default (undefined) = false. Required models download on first-launch, can't be deleted.
   isRequired?: boolean
   // ASR-only UI metadata
   description?: string

--- a/src/main/services/ModelDownloadService.ts
+++ b/src/main/services/ModelDownloadService.ts
@@ -7,6 +7,8 @@ import { downloadFile, verifyFileSha256, extractTarGz } from './DownloadService'
 
 const R2_CDN = 'https://pub-f6971d643e3a464ba6977c0816c43e50.r2.dev'
 
+export type ModelGroup = 'asr' | 'diarization' | 'ner'
+
 export interface ModelDefinition {
   id: string
   label: string
@@ -20,6 +22,15 @@ export interface ModelDefinition {
   archive?: boolean
   // Path to check for existence (relative to modelsDir). Used by checkModelsExist().
   checkPath: string
+  // Optional in Task 1 to keep existing MODEL_DEFINITIONS valid; populated in Task 2.
+  group?: ModelGroup
+  // Default (undefined) = false. Required models download on first-launch, can't be deleted.
+  isRequired?: boolean
+  // ASR-only UI metadata
+  description?: string
+  languages?: string[]
+  accuracyScore?: number
+  speedScore?: number
 }
 
 export interface ModelDownloadProgress {

--- a/src/main/services/ModelDownloadService.ts
+++ b/src/main/services/ModelDownloadService.ts
@@ -118,6 +118,52 @@ export function getModelDefinitions(): ModelDefinition[] {
   return MODEL_DEFINITIONS
 }
 
+export function getAsrModels(): ModelDefinition[] {
+  return MODEL_DEFINITIONS.filter((m) => m.group === 'asr')
+}
+
+export function getRequiredModels(): ModelDefinition[] {
+  return MODEL_DEFINITIONS.filter((m) => m.isRequired === true)
+}
+
+export function getModelById(id: string): ModelDefinition | null {
+  return MODEL_DEFINITIONS.find((m) => m.id === id) ?? null
+}
+
+/**
+ * Modelle, die auf First-Launch heruntergeladen werden müssen:
+ * alle required + das aktive ASR-Modell (falls gültig).
+ */
+export function getModelsToLoadOnFirstLaunch(activeAsrId: string): ModelDefinition[] {
+  const required = getRequiredModels()
+  const active = getModelById(activeAsrId)
+  if (active && active.group === 'asr') {
+    return [...required, active].filter(
+      (m, i, arr) => arr.findIndex((x) => x.id === m.id) === i
+    )
+  }
+  return required
+}
+
+/**
+ * Prüft, ob die Minimal-Menge (required + aktives ASR) installiert ist.
+ * Ersatz für checkModelsExist(), das alle Modelle erwartete.
+ */
+export function checkRequiredAndActiveAsrExist(activeAsrId: string): boolean {
+  const modelsDir = getModelsDir()
+  const toCheck = getModelsToLoadOnFirstLaunch(activeAsrId)
+  return toCheck.every((m) => existsSync(join(modelsDir, m.checkPath)))
+}
+
+/**
+ * Prüft, ob ein einzelnes Modell installiert ist (für UI-Status).
+ */
+export function isModelInstalled(id: string): boolean {
+  const def = getModelById(id)
+  if (!def) return false
+  return existsSync(join(getModelsDir(), def.checkPath))
+}
+
 export function getModelsDir(): string {
   return join(getDataDir(), 'models')
 }

--- a/src/main/services/ModelDownloadService.ts
+++ b/src/main/services/ModelDownloadService.ts
@@ -56,12 +56,19 @@ export type ModelDownloadStatus =
 const MODEL_DEFINITIONS: ModelDefinition[] = [
   {
     id: 'whisper-large-v3-turbo',
-    label: 'Spracherkennung (whisper-large-v3-turbo)',
+    label: 'Whisper Large V3 Turbo (Multilingual)',
     url: `${R2_CDN}/whisper-ggml-large-v3-turbo-q5_0.bin`,
     relativePath: 'asr/ggml-large-v3-turbo-q5_0.bin',
     checkPath: 'asr/ggml-large-v3-turbo-q5_0.bin',
     sizeBytes: 574_041_195,
-    sha256: '394221709cd5ad1f40c46e6031ca61bce88931e6e088c188294c6d5a55ffa7e2'
+    sha256: '394221709cd5ad1f40c46e6031ca61bce88931e6e088c188294c6d5a55ffa7e2',
+    group: 'asr',
+    isRequired: false,
+    description:
+      'Schnelles multilinguales Modell. Empfohlen wenn Sitzungen auch auf Hochdeutsch oder anderen Sprachen geführt werden, oder wenn Schweizerdeutsch im Dialekt eher moderat ausgeprägt ist.',
+    languages: ['multi'],
+    accuracyScore: 0.8,
+    speedScore: 0.9
   },
   {
     id: 'pyannote-community-1',
@@ -71,7 +78,9 @@ const MODEL_DEFINITIONS: ModelDefinition[] = [
     checkPath: 'diarization/models--pyannote--speaker-diarization-3.1',
     sizeBytes: 30_461_603,
     sha256: 'b42e8aee7cf5eb330f4d5519216f9035dc1defad871097977fa9cecc11edb570',
-    archive: true
+    archive: true,
+    group: 'diarization',
+    isRequired: true
   },
   {
     id: 'flair-ner-german-large',
@@ -81,7 +90,9 @@ const MODEL_DEFINITIONS: ModelDefinition[] = [
     checkPath: 'ner/models/ner-german-large',
     sizeBytes: 1_741_705_466,
     sha256: 'a34f6315659a34991930dae5d7a2bc2f3ee24ff6eb70dcd4d41e3aca7a5253e6',
-    archive: true
+    archive: true,
+    group: 'ner',
+    isRequired: true
   }
 ]
 

--- a/src/main/services/ModelDownloadService.ts
+++ b/src/main/services/ModelDownloadService.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, statSync, unlinkSync } from 'fs'
+import { existsSync, mkdirSync, rmSync, statSync, unlinkSync } from 'fs'
 import { join } from 'path'
 import { BrowserWindow } from 'electron'
 import { getDataDir } from '../db/connection'
@@ -430,4 +430,46 @@ export async function downloadSingleModel(id: string): Promise<void> {
 
   sendProgress({ state: 'complete' })
   abortSignal = null
+}
+
+/**
+ * Löscht ein einzelnes Modell von Disk. Verboten für:
+ *   - unbekannte IDs
+ *   - Pflicht-Modelle (isRequired)
+ *   - das aktuell aktive ASR-Modell
+ */
+export async function deleteModel(id: string): Promise<void> {
+  const def = getModelById(id)
+  if (!def) {
+    throw new Error(`Löschen: unbekanntes Modell "${id}"`)
+  }
+  if (def.isRequired) {
+    throw new Error(`Löschen: "${def.label}" ist ein Pflicht-Modell und nicht löschbar`)
+  }
+
+  const settings = getSettings()
+  const activeAsr = settings.get('activeModels').transcription
+  if (activeAsr === id) {
+    throw new Error(
+      `Löschen: "${def.label}" ist aktuell aktiv. Zuerst anderes Modell aktivieren.`
+    )
+  }
+
+  const modelsDir = getModelsDir()
+  const target = join(modelsDir, def.checkPath)
+  if (existsSync(target)) {
+    rmSync(target, { recursive: true, force: true })
+  }
+  const archivePath = join(modelsDir, `${def.id}.tar.gz`)
+  if (existsSync(archivePath)) {
+    try {
+      unlinkSync(archivePath)
+    } catch {
+      /* non-fatal */
+    }
+  }
+
+  const installed = { ...settings.get('installedModelVersions') }
+  delete installed[id]
+  settings.set('installedModelVersions', installed)
 }

--- a/src/main/services/ModelDownloadService.ts
+++ b/src/main/services/ModelDownloadService.ts
@@ -214,7 +214,7 @@ export async function startModelDownload(): Promise<void> {
   const overallTotal = getOverallModelSize()
   let overallDownloaded = 0
 
-  for (const model of MODEL_DEFINITIONS) {
+  for (const model of getModelsToLoad()) {
     const checkTarget = join(modelsDir, model.checkPath)
 
     // Skip already downloaded/extracted models

--- a/src/main/services/ModelDownloadService.ts
+++ b/src/main/services/ModelDownloadService.ts
@@ -169,27 +169,27 @@ export function getModelsDir(): string {
 }
 
 export function checkModelsExist(): boolean {
-  const modelsDir = getModelsDir()
-  return MODEL_DEFINITIONS.every((model) => {
-    const checkTarget = join(modelsDir, model.checkPath)
-    return existsSync(checkTarget)
-  })
+  const activeAsrId = getSettings().get('activeModels').transcription
+  return checkRequiredAndActiveAsrExist(activeAsrId)
+}
+
+export function getModelsToLoad(): ModelDefinition[] {
+  const activeAsrId = getSettings().get('activeModels').transcription
+  return getModelsToLoadOnFirstLaunch(activeAsrId)
 }
 
 export function getOverallModelSize(): number {
-  return MODEL_DEFINITIONS.reduce((sum, m) => sum + m.sizeBytes, 0)
+  return getModelsToLoad().reduce((sum, m) => sum + m.sizeBytes, 0)
 }
 
 export function getAlreadyDownloadedBytes(): number {
   const modelsDir = getModelsDir()
   let total = 0
-  for (const model of MODEL_DEFINITIONS) {
+  for (const model of getModelsToLoad()) {
     const checkTarget = join(modelsDir, model.checkPath)
     if (existsSync(checkTarget)) {
-      // Model already extracted/downloaded — count full size
       total += model.sizeBytes
     } else if (!model.archive) {
-      // Check for partial download of flat file
       const partialPath = join(modelsDir, model.relativePath) + '.partial'
       if (existsSync(partialPath)) {
         total += statSync(partialPath).size

--- a/src/main/services/ModelDownloadService.ts
+++ b/src/main/services/ModelDownloadService.ts
@@ -473,3 +473,25 @@ export async function deleteModel(id: string): Promise<void> {
   delete installed[id]
   settings.set('installedModelVersions', installed)
 }
+
+/**
+ * Wechselt das aktive ASR-Modell. Das Modell muss:
+ *   - existieren (bekannte ID)
+ *   - in der ASR-Gruppe liegen
+ *   - auf Disk installiert sein
+ */
+export function setActiveAsrModel(id: string): void {
+  const def = getModelById(id)
+  if (!def) {
+    throw new Error(`Aktivieren: unbekanntes Modell "${id}"`)
+  }
+  if (def.group !== 'asr') {
+    throw new Error(`Aktivieren: "${def.label}" ist keine ASR-Engine`)
+  }
+  if (!isModelInstalled(id)) {
+    throw new Error(`Aktivieren: "${def.label}" ist nicht installiert`)
+  }
+  const settings = getSettings()
+  const current = settings.get('activeModels')
+  settings.set('activeModels', { ...current, transcription: id })
+}

--- a/src/main/services/ModelDownloadService.ts
+++ b/src/main/services/ModelDownloadService.ts
@@ -63,9 +63,25 @@ const MODEL_DEFINITIONS: ModelDefinition[] = [
     group: 'asr',
     isRequired: false,
     description:
-      'Schnelles multilinguales Modell. Empfohlen wenn Sitzungen auch auf Hochdeutsch oder anderen Sprachen geführt werden, oder wenn Schweizerdeutsch im Dialekt eher moderat ausgeprägt ist.',
+      'Unterstützt alle Sprachen (Deutsch, Englisch, Französisch, Italienisch, …). Empfohlen als Standardmodell oder wenn Sitzungen mehrsprachig geführt werden.',
     languages: ['multi'],
     accuracyScore: 0.8,
+    speedScore: 0.9
+  },
+  {
+    id: 'whisper-large-v3-turbo-german',
+    label: 'Whisper Large V3 Turbo (German)',
+    url: `${R2_CDN}/whisper-ggml-large-v3-turbo-german-q5_0.bin`,
+    relativePath: 'asr/ggml-large-v3-turbo-german-q5_0.bin',
+    checkPath: 'asr/ggml-large-v3-turbo-german-q5_0.bin',
+    sizeBytes: 574_041_195,
+    sha256: '15e92e3db0993c52fffa781513eec9253475331c1be808f8fb409285c9d9d030',
+    group: 'asr',
+    isRequired: false,
+    description:
+      'Auf Hochdeutsch optimiert (Basis: primeline/whisper-large-v3-turbo-german). Präziser bei Standarddeutsch als das multilinguale Modell. Nicht geeignet für starke Schweizerdeutsch-Mundart oder andere Sprachen.',
+    languages: ['de'],
+    accuracyScore: 0.87,
     speedScore: 0.9
   },
   {

--- a/src/main/services/ModelDownloadService.ts
+++ b/src/main/services/ModelDownloadService.ts
@@ -325,3 +325,109 @@ export function abortModelDownload(): void {
     abortSignal.aborted = true
   }
 }
+
+/**
+ * Lädt ein einziges ASR-Modell herunter (nicht für Pflicht-Modelle gedacht —
+ * die laufen via startModelDownload auf First-Launch).
+ *
+ * Sendet denselben `modelDownload:status`-Channel wie startModelDownload,
+ * damit die bestehende UI-Progress-Anzeige wiederverwendbar bleibt.
+ */
+export async function downloadSingleModel(id: string): Promise<void> {
+  const def = getModelById(id)
+  if (!def) {
+    throw new Error(`Download: unbekanntes Modell "${id}"`)
+  }
+  if (def.group !== 'asr') {
+    throw new Error(`Download: nur ASR-Modelle sind einzeln ladbar (id=${id})`)
+  }
+  if (abortSignal && !abortSignal.aborted) {
+    throw new Error('Download: bereits aktiv — zuerst abbrechen')
+  }
+
+  abortSignal = { aborted: false }
+  const modelsDir = getModelsDir()
+  const checkTarget = join(modelsDir, def.checkPath)
+
+  if (existsSync(checkTarget)) {
+    sendProgress({ state: 'complete' })
+    abortSignal = null
+    return
+  }
+
+  const targetPath = def.archive
+    ? join(modelsDir, `${def.id}.tar.gz`)
+    : join(modelsDir, def.relativePath)
+
+  const result = await downloadFile(
+    def.url,
+    targetPath,
+    (progress) => {
+      sendProgress({
+        state: 'downloading',
+        progress: {
+          currentModel: def.id,
+          currentModelLabel: def.label,
+          currentModelProgress: progress.percent,
+          currentModelDownloaded: progress.downloadedBytes,
+          currentModelTotal: progress.totalBytes,
+          overallDownloaded: progress.downloadedBytes,
+          overallTotal: def.sizeBytes,
+          overallPercent: progress.percent
+        }
+      })
+    },
+    abortSignal
+  )
+
+  if (!result.success) {
+    sendProgress({
+      state: 'error',
+      error: result.error ?? 'Download fehlgeschlagen',
+      modelId: def.id
+    })
+    abortSignal = null
+    throw new Error(result.error ?? 'Download fehlgeschlagen')
+  }
+
+  sendProgress({ state: 'verifying', modelId: def.id })
+  const valid = await verifyFileSha256(targetPath, def.sha256)
+  if (!valid) {
+    try {
+      unlinkSync(targetPath)
+    } catch {
+      /* non-fatal */
+    }
+    sendProgress({
+      state: 'error',
+      error: `SHA-256-Prüfung fehlgeschlagen für ${def.label}`,
+      modelId: def.id
+    })
+    abortSignal = null
+    throw new Error(`SHA-256-Prüfung fehlgeschlagen für ${def.label}`)
+  }
+
+  if (def.archive) {
+    sendProgress({ state: 'extracting', modelId: def.id })
+    const extractDir = join(modelsDir, def.relativePath)
+    mkdirSync(extractDir, { recursive: true })
+    const extractResult = await extractTarGz(targetPath, extractDir)
+    if (!extractResult.success) {
+      try {
+        unlinkSync(targetPath)
+      } catch {
+        /* non-fatal */
+      }
+      sendProgress({
+        state: 'error',
+        error: extractResult.error ?? 'Entpacken fehlgeschlagen',
+        modelId: def.id
+      })
+      abortSignal = null
+      throw new Error(extractResult.error ?? 'Entpacken fehlgeschlagen')
+    }
+  }
+
+  sendProgress({ state: 'complete' })
+  abortSignal = null
+}

--- a/src/main/services/ModelDownloadService.ts
+++ b/src/main/services/ModelDownloadService.ts
@@ -380,12 +380,10 @@ export async function downloadSingleModel(id: string): Promise<void> {
     abortSignal
   )
 
+  // Error-Reporting läuft ausschliesslich via thrown Error → IPC-Rejection → Renderer-Toast.
+  // Kein sendProgress({state:'error'}) hier, sonst würde der Renderer den Toast doppelt zeigen
+  // (einmal via modelDownload:status-Subscription, einmal via IPC-Catch in ModelsSettings).
   if (!result.success) {
-    sendProgress({
-      state: 'error',
-      error: result.error ?? 'Download fehlgeschlagen',
-      modelId: def.id
-    })
     abortSignal = null
     throw new Error(result.error ?? 'Download fehlgeschlagen')
   }
@@ -398,11 +396,6 @@ export async function downloadSingleModel(id: string): Promise<void> {
     } catch {
       /* non-fatal */
     }
-    sendProgress({
-      state: 'error',
-      error: `SHA-256-Prüfung fehlgeschlagen für ${def.label}`,
-      modelId: def.id
-    })
     abortSignal = null
     throw new Error(`SHA-256-Prüfung fehlgeschlagen für ${def.label}`)
   }
@@ -418,11 +411,6 @@ export async function downloadSingleModel(id: string): Promise<void> {
       } catch {
         /* non-fatal */
       }
-      sendProgress({
-        state: 'error',
-        error: extractResult.error ?? 'Entpacken fehlgeschlagen',
-        modelId: def.id
-      })
       abortSignal = null
       throw new Error(extractResult.error ?? 'Entpacken fehlgeschlagen')
     }

--- a/src/main/services/ModelDownloadService.ts
+++ b/src/main/services/ModelDownloadService.ts
@@ -76,8 +76,8 @@ const MODEL_DEFINITIONS: ModelDefinition[] = [
     url: `${R2_CDN}/whisper-ggml-large-v3-turbo-swiss-q5_0.bin`,
     relativePath: 'asr/ggml-large-v3-turbo-swiss-q5_0.bin',
     checkPath: 'asr/ggml-large-v3-turbo-swiss-q5_0.bin',
-    sizeBytes: 0, // TBD: set after model conversion in scripts/convert-hf-whisper.sh
-    sha256: 'PENDING_UPLOAD', // TBD: set after model conversion
+    sizeBytes: 574_041_195,
+    sha256: '2d56e773724a247360067b527417842b81d25ff891fed014341a6844f15ea612',
     group: 'asr',
     isRequired: false,
     description:

--- a/src/main/services/UpdateCheckService.ts
+++ b/src/main/services/UpdateCheckService.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdirSync, readdirSync, renameSync, rmSync } from 'fs'
 import { join } from 'path'
 import { get as httpsGet } from 'https'
 import { getSettings } from './SettingsService'
-import { getModelDefinitions, getModelsDir } from './ModelDownloadService'
+import { getModelDefinitions, getModelsDir, isModelInstalled } from './ModelDownloadService'
 import { downloadFile, verifyFileSha256, extractTarGz } from './DownloadService'
 import {
   ManifestSchema,
@@ -111,16 +111,22 @@ export async function checkForUpdates(): Promise<CheckResult> {
         continue
       }
 
-      const installed = installedVersions[manifestModel.id]
-      if (installed && installed.sha256 === manifestModel.sha256) {
-        continue // Already up to date
-      }
-
       // Find structural info from local MODEL_DEFINITIONS
       const definition = definitions.find((d) => d.id === manifestModel.id)
       if (!definition) {
         console.warn(`UpdateCheckService: unknown model id in manifest: ${manifestModel.id}`)
         continue
+      }
+
+      // Nur Modelle updaten, die bereits installiert sind — optionale ASR-Alternativen
+      // ohne Install werden nicht als "Update verfügbar" beworben.
+      if (!isModelInstalled(manifestModel.id)) {
+        continue
+      }
+
+      const installed = installedVersions[manifestModel.id]
+      if (installed && installed.sha256 === manifestModel.sha256) {
+        continue // Already up to date
       }
 
       // Path-traversal guard on relativePath

--- a/src/main/services/__tests__/ModelDownloadService.test.ts
+++ b/src/main/services/__tests__/ModelDownloadService.test.ts
@@ -42,7 +42,8 @@ import {
   getRequiredModels,
   getModelById,
   getModelsToLoadOnFirstLaunch,
-  downloadSingleModel
+  downloadSingleModel,
+  deleteModel
 } from '../ModelDownloadService'
 
 describe('ModelDownloadService catalog helpers', () => {
@@ -95,5 +96,20 @@ describe('downloadSingleModel', () => {
     await expect(downloadSingleModel('pyannote-community-1')).rejects.toThrow(
       /nur ASR-Modelle/i
     )
+  })
+})
+
+describe('deleteModel', () => {
+  it('throws when model id is unknown', async () => {
+    await expect(deleteModel('does-not-exist')).rejects.toThrow(/unbekanntes Modell/i)
+  })
+
+  it('throws when model is required', async () => {
+    await expect(deleteModel('pyannote-community-1')).rejects.toThrow(/Pflicht-Modell/i)
+  })
+
+  it('throws when attempting to delete the active asr model', async () => {
+    // Mock returns activeModels.transcription = 'whisper-large-v3-turbo'
+    await expect(deleteModel('whisper-large-v3-turbo')).rejects.toThrow(/aktiv/i)
   })
 })

--- a/src/main/services/__tests__/ModelDownloadService.test.ts
+++ b/src/main/services/__tests__/ModelDownloadService.test.ts
@@ -43,7 +43,8 @@ import {
   getModelById,
   getModelsToLoadOnFirstLaunch,
   downloadSingleModel,
-  deleteModel
+  deleteModel,
+  setActiveAsrModel
 } from '../ModelDownloadService'
 
 describe('ModelDownloadService catalog helpers', () => {
@@ -111,5 +112,22 @@ describe('deleteModel', () => {
   it('throws when attempting to delete the active asr model', async () => {
     // Mock returns activeModels.transcription = 'whisper-large-v3-turbo'
     await expect(deleteModel('whisper-large-v3-turbo')).rejects.toThrow(/aktiv/i)
+  })
+})
+
+describe('setActiveAsrModel', () => {
+  it('throws when model id is unknown', () => {
+    expect(() => setActiveAsrModel('nope')).toThrow(/unbekanntes Modell/i)
+  })
+
+  it('throws when model is not asr group', () => {
+    expect(() => setActiveAsrModel('pyannote-community-1')).toThrow(/keine ASR/i)
+  })
+
+  it('throws when model is not installed', () => {
+    // Swiss-German is in the catalog but not on disk (existsSync mocked to false)
+    expect(() => setActiveAsrModel('whisper-large-v3-turbo-swiss')).toThrow(
+      /nicht installiert/i
+    )
   })
 })

--- a/src/main/services/__tests__/ModelDownloadService.test.ts
+++ b/src/main/services/__tests__/ModelDownloadService.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi } from 'vitest'
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock('electron', () => ({
+  app: { getPath: vi.fn().mockReturnValue('/tmp/therascript-test') },
+  BrowserWindow: { getAllWindows: vi.fn().mockReturnValue([]) }
+}))
+
+vi.mock('../../db/connection', () => ({
+  getDataDir: () => '/tmp/therascript-test'
+}))
+
+const mockSettingsStore = {
+  get: vi.fn((key: string) => {
+    if (key === 'activeModels') {
+      return { transcription: 'whisper-large-v3-turbo' }
+    }
+    return undefined
+  }),
+  set: vi.fn()
+}
+vi.mock('../SettingsService', () => ({
+  getSettings: () => mockSettingsStore,
+  initSettings: () => mockSettingsStore
+}))
+
+vi.mock('fs', () => {
+  const fsMock = {
+    existsSync: vi.fn().mockReturnValue(false),
+    mkdirSync: vi.fn(),
+    statSync: vi.fn(),
+    unlinkSync: vi.fn(),
+    rmSync: vi.fn()
+  }
+  return { ...fsMock, default: fsMock }
+})
+
+// Import after mocks
+import {
+  getAsrModels,
+  getRequiredModels,
+  getModelById,
+  getModelsToLoadOnFirstLaunch
+} from '../ModelDownloadService'
+
+describe('ModelDownloadService catalog helpers', () => {
+  it('getAsrModels returns all models with group="asr"', () => {
+    const asrs = getAsrModels()
+    expect(asrs.length).toBeGreaterThanOrEqual(2)
+    expect(asrs.every((m) => m.group === 'asr')).toBe(true)
+  })
+
+  it('getRequiredModels returns pyannote and flair but no asr', () => {
+    const required = getRequiredModels()
+    expect(required.map((m) => m.id).sort()).toEqual([
+      'flair-ner-german-large',
+      'pyannote-community-1'
+    ])
+  })
+
+  it('getModelById returns definition or null', () => {
+    expect(getModelById('whisper-large-v3-turbo')?.group).toBe('asr')
+    expect(getModelById('does-not-exist')).toBeNull()
+  })
+
+  it('getModelsToLoadOnFirstLaunch returns required + activeAsrId', () => {
+    const loaded = getModelsToLoadOnFirstLaunch('whisper-large-v3-turbo')
+    const ids = loaded.map((m) => m.id).sort()
+    expect(ids).toEqual([
+      'flair-ner-german-large',
+      'pyannote-community-1',
+      'whisper-large-v3-turbo'
+    ])
+  })
+
+  it('getModelsToLoadOnFirstLaunch falls back gracefully on unknown activeAsrId', () => {
+    const loaded = getModelsToLoadOnFirstLaunch('nonexistent')
+    expect(loaded.map((m) => m.id).sort()).toEqual([
+      'flair-ner-german-large',
+      'pyannote-community-1'
+    ])
+  })
+})

--- a/src/main/services/__tests__/ModelDownloadService.test.ts
+++ b/src/main/services/__tests__/ModelDownloadService.test.ts
@@ -41,7 +41,8 @@ import {
   getAsrModels,
   getRequiredModels,
   getModelById,
-  getModelsToLoadOnFirstLaunch
+  getModelsToLoadOnFirstLaunch,
+  downloadSingleModel
 } from '../ModelDownloadService'
 
 describe('ModelDownloadService catalog helpers', () => {
@@ -80,5 +81,19 @@ describe('ModelDownloadService catalog helpers', () => {
       'flair-ner-german-large',
       'pyannote-community-1'
     ])
+  })
+})
+
+describe('downloadSingleModel', () => {
+  it('throws when model id is unknown', async () => {
+    await expect(downloadSingleModel('does-not-exist')).rejects.toThrow(
+      /unbekanntes Modell/i
+    )
+  })
+
+  it('throws when model is not in group "asr"', async () => {
+    await expect(downloadSingleModel('pyannote-community-1')).rejects.toThrow(
+      /nur ASR-Modelle/i
+    )
   })
 })

--- a/src/main/services/__tests__/UpdateCheckService.test.ts
+++ b/src/main/services/__tests__/UpdateCheckService.test.ts
@@ -61,7 +61,11 @@ vi.mock('../ModelDownloadService', () => ({
       sizeBytes: 200,
       archive: true
     }
-  ]
+  ],
+  // Für den "update only installed"-Filter in checkForUpdates: Die bestehenden Tests
+  // simulieren eine Vollinstallation (alle im Manifest gelisteten Modelle sind auf Disk).
+  // Per Default true → bestehende Test-Assertions bleiben unverändert.
+  isModelInstalled: () => true
 }))
 
 const mockDownloadFile = vi.fn()

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -112,6 +112,13 @@ const api: IpcApi = {
       }
     }
   },
+  modelCatalog: {
+    listAsr: () => ipcRenderer.invoke('modelCatalog:listAsr'),
+    download: (id: string) => ipcRenderer.invoke('modelCatalog:download', { id }),
+    delete: (id: string) => ipcRenderer.invoke('modelCatalog:delete', { id }),
+    setActive: (id: string) => ipcRenderer.invoke('modelCatalog:setActive', { id }),
+    cancelDownload: () => ipcRenderer.invoke('modelCatalog:cancelDownload')
+  },
   modelUpdate: {
     check: () => ipcRenderer.invoke('modelUpdate:check'),
     restart: (updates: PendingModelUpdate[]) =>

--- a/src/renderer/src/__tests__/App.test.tsx
+++ b/src/renderer/src/__tests__/App.test.tsx
@@ -70,6 +70,13 @@ beforeEach(() => {
       start: vi.fn(),
       onStatus: vi.fn().mockReturnValue(() => {})
     },
+    modelCatalog: {
+      listAsr: vi.fn().mockResolvedValue([]),
+      download: vi.fn().mockResolvedValue([]),
+      delete: vi.fn().mockResolvedValue([]),
+      setActive: vi.fn().mockResolvedValue([]),
+      cancelDownload: vi.fn().mockResolvedValue(undefined)
+    },
     modelUpdate: mockModelUpdate,
     appUpdate: {
       getStatus: vi.fn().mockResolvedValue(null),

--- a/src/renderer/src/components/__tests__/SessionDashboard.test.tsx
+++ b/src/renderer/src/components/__tests__/SessionDashboard.test.tsx
@@ -144,6 +144,13 @@ beforeEach(() => {
       start: vi.fn(),
       onStatus: vi.fn().mockReturnValue(() => {})
     },
+    modelCatalog: {
+      listAsr: vi.fn().mockResolvedValue([]),
+      download: vi.fn().mockResolvedValue([]),
+      delete: vi.fn().mockResolvedValue([]),
+      setActive: vi.fn().mockResolvedValue([]),
+      cancelDownload: vi.fn().mockResolvedValue(undefined)
+    },
     modelUpdate: mockModelUpdate,
     appUpdate: {
       getStatus: vi.fn().mockResolvedValue(null),

--- a/src/renderer/src/components/settings/AsrModelCard.tsx
+++ b/src/renderer/src/components/settings/AsrModelCard.tsx
@@ -1,4 +1,5 @@
 import type { ModelCatalogEntry } from '../../../../shared/validation/model-catalog-schemas'
+import { formatBytes } from '../../utils/formatBytes'
 
 interface Props {
   model: ModelCatalogEntry
@@ -11,11 +12,10 @@ interface Props {
   onActivate: () => void
 }
 
-function formatBytes(bytes: number): string {
+/** Zeigt '—' für unbekannte Grössen (Platzhalter-Modelle vor R2-Upload). */
+function formatModelSize(bytes: number): string {
   if (bytes === 0) return '—'
-  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`
-  if (bytes < 1024 * 1024 * 1024) return `${Math.round(bytes / (1024 * 1024))} MB`
-  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`
+  return formatBytes(bytes)
 }
 
 function formatLanguage(code: string): string {
@@ -73,7 +73,7 @@ export default function AsrModelCard({
 
           <div className="mt-1.5 flex flex-wrap gap-1.5">
             {model.languages?.map((lang) => <Chip key={lang}>{formatLanguage(lang)}</Chip>)}
-            <Chip>{formatBytes(model.sizeBytes)}</Chip>
+            <Chip>{formatModelSize(model.sizeBytes)}</Chip>
           </div>
 
           {model.description && (

--- a/src/renderer/src/components/settings/AsrModelCard.tsx
+++ b/src/renderer/src/components/settings/AsrModelCard.tsx
@@ -1,0 +1,147 @@
+import type { ModelCatalogEntry } from '../../../../shared/validation/model-catalog-schemas'
+
+interface Props {
+  model: ModelCatalogEntry
+  downloading: boolean
+  progress?: number
+  anyBusy: boolean
+  onDownload: () => void
+  onCancelDownload: () => void
+  onDelete: () => void
+  onActivate: () => void
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return '—'
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`
+  if (bytes < 1024 * 1024 * 1024) return `${Math.round(bytes / (1024 * 1024))} MB`
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`
+}
+
+function formatLanguage(code: string): string {
+  switch (code) {
+    case 'multi':
+      return 'Multilingual'
+    case 'de':
+      return 'Hochdeutsch'
+    case 'de-CH':
+      return 'Schweizerdeutsch'
+    default:
+      return code
+  }
+}
+
+function Chip({ children }: { children: React.ReactNode }): React.JSX.Element {
+  return (
+    <span className="rounded-full bg-surface-2 px-2 py-0.5 text-xs text-text-tertiary">
+      {children}
+    </span>
+  )
+}
+
+export default function AsrModelCard({
+  model,
+  downloading,
+  progress,
+  anyBusy,
+  onDownload,
+  onCancelDownload,
+  onDelete,
+  onActivate
+}: Props): React.JSX.Element {
+  const dimmed = downloading ? 'opacity-70' : ''
+  const borderClass = model.isActive ? 'border-primary' : 'border-border'
+
+  return (
+    <div
+      className={`rounded-lg border p-4 ${borderClass} ${dimmed}`}
+      role="group"
+      aria-labelledby={`model-${model.id}-name`}
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <h3 id={`model-${model.id}-name`} className="font-semibold text-text-primary">
+              {model.label}
+            </h3>
+            {model.isActive && (
+              <span className="rounded-full bg-primary px-2 py-0.5 text-xs font-medium text-white">
+                Aktiv
+              </span>
+            )}
+          </div>
+
+          <div className="mt-1.5 flex flex-wrap gap-1.5">
+            {model.languages?.map((lang) => <Chip key={lang}>{formatLanguage(lang)}</Chip>)}
+            <Chip>{formatBytes(model.sizeBytes)}</Chip>
+          </div>
+
+          {model.description && (
+            <p className="mt-2 text-sm leading-relaxed text-text-secondary">
+              {model.description}
+            </p>
+          )}
+        </div>
+      </div>
+
+      {downloading && progress !== undefined && (
+        <div className="mt-3">
+          <div
+            className="h-1 w-full overflow-hidden rounded-full bg-surface-2"
+            role="progressbar"
+            aria-valuenow={progress}
+            aria-valuemin={0}
+            aria-valuemax={100}
+          >
+            <div
+              className="h-full bg-primary transition-all"
+              style={{ width: `${progress}%` }}
+            />
+          </div>
+          <p className="mt-1 text-xs text-text-tertiary">Lädt herunter … {progress}%</p>
+        </div>
+      )}
+
+      <div className="mt-3 flex justify-end gap-2">
+        {downloading && (
+          <button
+            className="titlebar-no-drag rounded-md border border-border px-3 py-1.5 text-sm text-text-secondary hover:bg-surface-2"
+            onClick={onCancelDownload}
+          >
+            Download abbrechen
+          </button>
+        )}
+        {!downloading && !model.isInstalled && (
+          <button
+            className="titlebar-no-drag rounded-md bg-primary px-3 py-1.5 text-sm text-white hover:bg-primary-hover disabled:opacity-50"
+            onClick={onDownload}
+            disabled={anyBusy}
+          >
+            Herunterladen
+          </button>
+        )}
+        {!downloading && model.isInstalled && !model.isActive && (
+          <>
+            <button
+              className="titlebar-no-drag rounded-md border border-border px-3 py-1.5 text-sm text-text-secondary hover:bg-surface-2 disabled:opacity-50"
+              onClick={onDelete}
+              disabled={anyBusy}
+            >
+              Löschen
+            </button>
+            <button
+              className="titlebar-no-drag rounded-md bg-primary px-3 py-1.5 text-sm text-white hover:bg-primary-hover disabled:opacity-50"
+              onClick={onActivate}
+              disabled={anyBusy}
+            >
+              Aktivieren
+            </button>
+          </>
+        )}
+        {!downloading && model.isInstalled && model.isActive && (
+          <span className="text-xs text-text-tertiary">Wird für Transkription verwendet</span>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/settings/ModelsSettings.tsx
+++ b/src/renderer/src/components/settings/ModelsSettings.tsx
@@ -3,12 +3,8 @@ import type { ModelCatalogEntry } from '../../../../shared/validation/model-cata
 import type { ModelDownloadStatus } from '../../../../shared/types/IpcApi'
 import { useToast } from '../../hooks/useToast'
 import { ConfirmDialog } from '../ConfirmDialog'
+import { formatBytes } from '../../utils/formatBytes'
 import AsrModelCard from './AsrModelCard'
-
-function formatBytesShort(bytes: number): string {
-  if (bytes < 1024 * 1024 * 1024) return `${Math.round(bytes / (1024 * 1024))} MB`
-  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`
-}
 
 export default function ModelsSettings(): React.JSX.Element {
   const toast = useToast()
@@ -64,7 +60,7 @@ export default function ModelsSettings(): React.JSX.Element {
       const updated = await window.api.modelCatalog.delete(model.id)
       setModels(updated)
       toast.success(
-        `"${model.label}" gelöscht — ${formatBytesShort(model.sizeBytes)} freigegeben.`
+        `"${model.label}" gelöscht — ${formatBytes(model.sizeBytes)} freigegeben.`
       )
     } catch (err) {
       toast.error(err instanceof Error ? err.message : String(err))
@@ -154,7 +150,7 @@ export default function ModelsSettings(): React.JSX.Element {
       {deleteCandidate && (
         <ConfirmDialog
           title={`${deleteCandidate.label} löschen?`}
-          message={`${formatBytesShort(deleteCandidate.sizeBytes)} werden freigegeben. Du kannst das Modell später jederzeit erneut herunterladen.`}
+          message={`${formatBytes(deleteCandidate.sizeBytes)} werden freigegeben. Du kannst das Modell später jederzeit erneut herunterladen.`}
           confirmLabel="Löschen"
           destructive
           onConfirm={() => handleDeleteConfirmed(deleteCandidate)}

--- a/src/renderer/src/components/settings/ModelsSettings.tsx
+++ b/src/renderer/src/components/settings/ModelsSettings.tsx
@@ -1,0 +1,166 @@
+import { useEffect, useState } from 'react'
+import type { ModelCatalogEntry } from '../../../../shared/validation/model-catalog-schemas'
+import type { ModelDownloadStatus } from '../../../../shared/types/IpcApi'
+import { useToast } from '../../hooks/useToast'
+import { ConfirmDialog } from '../ConfirmDialog'
+import AsrModelCard from './AsrModelCard'
+
+function formatBytesShort(bytes: number): string {
+  if (bytes < 1024 * 1024 * 1024) return `${Math.round(bytes / (1024 * 1024))} MB`
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`
+}
+
+export default function ModelsSettings(): React.JSX.Element {
+  const toast = useToast()
+  const [models, setModels] = useState<ModelCatalogEntry[]>([])
+  const [downloadingId, setDownloadingId] = useState<string | null>(null)
+  const [progress, setProgress] = useState<number | undefined>(undefined)
+  const [deleteCandidate, setDeleteCandidate] = useState<ModelCatalogEntry | null>(null)
+
+  const reload = async (): Promise<void> => {
+    const list = await window.api.modelCatalog.listAsr()
+    setModels(list)
+  }
+
+  useEffect(() => {
+    reload()
+    const unsubscribe = window.api.modelDownload.onStatus((status: ModelDownloadStatus) => {
+      if (status.state === 'downloading') {
+        setProgress(status.progress.currentModelProgress)
+      } else if (status.state === 'complete') {
+        setProgress(undefined)
+        setDownloadingId(null)
+        reload()
+      } else if (status.state === 'error') {
+        toast.error(status.error)
+        setProgress(undefined)
+        setDownloadingId(null)
+      }
+    })
+    return unsubscribe
+  }, [toast])
+
+  const handleDownload = async (id: string): Promise<void> => {
+    setDownloadingId(id)
+    try {
+      const updated = await window.api.modelCatalog.download(id)
+      setModels(updated)
+      toast.success('Modell erfolgreich heruntergeladen.')
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : String(err))
+      setDownloadingId(null)
+    }
+  }
+
+  const handleCancelDownload = async (): Promise<void> => {
+    await window.api.modelCatalog.cancelDownload()
+    setDownloadingId(null)
+    setProgress(undefined)
+  }
+
+  const handleDeleteConfirmed = async (model: ModelCatalogEntry): Promise<void> => {
+    setDeleteCandidate(null)
+    try {
+      const updated = await window.api.modelCatalog.delete(model.id)
+      setModels(updated)
+      toast.success(
+        `"${model.label}" gelöscht — ${formatBytesShort(model.sizeBytes)} freigegeben.`
+      )
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  const handleActivate = async (model: ModelCatalogEntry): Promise<void> => {
+    try {
+      const updated = await window.api.modelCatalog.setActive(model.id)
+      setModels(updated)
+      toast.success(
+        `"${model.label}" aktiviert. Neue Transkriptionen verwenden ab jetzt dieses Modell — bereits verarbeitete Sitzungen bleiben unverändert.`
+      )
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  const installed = models.filter((m) => m.isInstalled)
+  const available = models.filter((m) => !m.isInstalled)
+  const anyBusy = downloadingId !== null
+
+  return (
+    <div className="space-y-6 p-6">
+      <section>
+        <h2 className="mb-1 text-lg font-semibold">Transkriptions-Modelle</h2>
+        <p className="text-sm text-text-secondary">
+          Wähle das Modell, das für die Transkription deiner Sitzungen verwendet werden soll.
+          Ein Modellwechsel wirkt sich nur auf neue Transkriptionen aus.
+        </p>
+      </section>
+
+      {installed.length > 0 && (
+        <section>
+          <h3 className="mb-2 text-sm font-medium text-text-tertiary">Installiert</h3>
+          <div className="space-y-3">
+            {installed.map((m) => (
+              <AsrModelCard
+                key={m.id}
+                model={m}
+                downloading={downloadingId === m.id}
+                progress={downloadingId === m.id ? progress : undefined}
+                anyBusy={anyBusy}
+                onDownload={() => handleDownload(m.id)}
+                onCancelDownload={handleCancelDownload}
+                onDelete={() => setDeleteCandidate(m)}
+                onActivate={() => handleActivate(m)}
+              />
+            ))}
+          </div>
+        </section>
+      )}
+
+      {available.length > 0 && (
+        <section>
+          <h3 className="mb-2 text-sm font-medium text-text-tertiary">Zum Download verfügbar</h3>
+          <div className="space-y-3">
+            {available.map((m) => (
+              <AsrModelCard
+                key={m.id}
+                model={m}
+                downloading={downloadingId === m.id}
+                progress={downloadingId === m.id ? progress : undefined}
+                anyBusy={anyBusy}
+                onDownload={() => handleDownload(m.id)}
+                onCancelDownload={handleCancelDownload}
+                onDelete={() => setDeleteCandidate(m)}
+                onActivate={() => handleActivate(m)}
+              />
+            ))}
+          </div>
+        </section>
+      )}
+
+      <section>
+        <h3 className="mb-2 text-sm font-medium text-text-tertiary">Pflicht-Modelle</h3>
+        <p className="mb-2 text-xs text-text-tertiary">
+          Diese Modelle sind für die Anonymisierung zwingend erforderlich und werden
+          automatisch aktuell gehalten.
+        </p>
+        <ul className="space-y-1 rounded-md border border-border bg-surface-1 p-3 text-xs text-text-tertiary">
+          <li>Sprechererkennung (pyannote-community-1)</li>
+          <li>Anonymisierung (flair-ner-german-large)</li>
+        </ul>
+      </section>
+
+      {deleteCandidate && (
+        <ConfirmDialog
+          title={`${deleteCandidate.label} löschen?`}
+          message={`${formatBytesShort(deleteCandidate.sizeBytes)} werden freigegeben. Du kannst das Modell später jederzeit erneut herunterladen.`}
+          confirmLabel="Löschen"
+          destructive
+          onConfirm={() => handleDeleteConfirmed(deleteCandidate)}
+          onCancel={() => setDeleteCandidate(null)}
+        />
+      )}
+    </div>
+  )
+}

--- a/src/renderer/src/views/Settings.tsx
+++ b/src/renderer/src/views/Settings.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import BlocklistManager from '../components/BlocklistManager'
 import AppearanceSettings from '../components/AppearanceSettings'
 import AboutPage from '../components/AboutPage'
+import ModelsSettings from '../components/settings/ModelsSettings'
 
 type Tab = 'sperrliste' | 'darstellung' | 'modelle' | 'ueber'
 
@@ -40,13 +41,7 @@ export default function Settings(): React.JSX.Element {
       <div className="flex-1 overflow-y-auto">
         {currentTab === 'sperrliste' && <BlocklistManager />}
         {currentTab === 'darstellung' && <AppearanceSettings />}
-        {currentTab === 'modelle' && (
-          <div className="flex flex-1 items-center justify-center p-8">
-            <p className="text-sm text-text-tertiary">
-              Modell-Verwaltung — noch nicht implementiert
-            </p>
-          </div>
-        )}
+        {currentTab === 'modelle' && <ModelsSettings />}
         {currentTab === 'ueber' && <AboutPage />}
       </div>
     </div>

--- a/src/shared/types/IpcApi.ts
+++ b/src/shared/types/IpcApi.ts
@@ -4,6 +4,7 @@ import type { BlocklistEntry } from './NerTypes'
 import type { EntityMap, PlaceholderType } from './EntityMap'
 import type { TipTapDocument } from './TipTapDocument'
 import type { PendingModelUpdate, AppUpdateStatus, CheckResult } from './ModelUpdate'
+import type { ModelCatalogEntry } from '../validation/model-catalog-schemas'
 
 export interface SessionApi {
   list(): Promise<Session[]>
@@ -156,6 +157,14 @@ export interface AppUpdateApi {
   onStatus(callback: (status: AppUpdateStatus) => void): () => void
 }
 
+export interface ModelCatalogApi {
+  listAsr(): Promise<ModelCatalogEntry[]>
+  download(id: string): Promise<ModelCatalogEntry[]>
+  delete(id: string): Promise<ModelCatalogEntry[]>
+  setActive(id: string): Promise<ModelCatalogEntry[]>
+  cancelDownload(): Promise<void>
+}
+
 export interface IpcApi {
   sessions: SessionApi
   recording: RecordingApi
@@ -166,6 +175,7 @@ export interface IpcApi {
   review: ReviewApi
   system: SystemApi
   modelDownload: ModelDownloadApi
+  modelCatalog: ModelCatalogApi
   modelUpdate: ModelUpdateApi
   appUpdate: AppUpdateApi
 }

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -31,6 +31,7 @@ export type {
   ModelStatusInfo,
   DiskSpaceInfo,
   ModelDownloadApi,
+  ModelCatalogApi,
   ModelUpdateRestartResult,
   ModelUpdateApi,
   AppUpdateApi,

--- a/src/shared/validation/model-catalog-schemas.ts
+++ b/src/shared/validation/model-catalog-schemas.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod'
+
+export const ModelGroupSchema = z.enum(['asr', 'diarization', 'ner'])
+
+export const ModelCatalogEntrySchema = z.object({
+  id: z.string().min(1).max(64),
+  label: z.string(),
+  description: z.string().optional(),
+  sizeBytes: z.number().int().nonnegative(),
+  group: ModelGroupSchema,
+  isRequired: z.boolean(),
+  languages: z.array(z.string()).optional(),
+  accuracyScore: z.number().min(0).max(1).optional(),
+  speedScore: z.number().min(0).max(1).optional(),
+  isInstalled: z.boolean(),
+  isActive: z.boolean()
+})
+
+export type ModelCatalogEntry = z.infer<typeof ModelCatalogEntrySchema>
+
+export const ModelIdPayloadSchema = z.object({
+  id: z
+    .string()
+    .min(1)
+    .max(64)
+    .regex(/^[a-z0-9-]+$/i, 'nur a-z, 0-9 und Bindestrich erlaubt')
+})


### PR DESCRIPTION
## Summary

- Adds a user-selectable ASR model catalog to Therascript, following the Handy-app UX pattern
- Registers a Swiss-German Whisper fine-tune (Flurin17/whisper-large-v3-turbo-swiss-german) alongside the existing multilingual Turbo model
- First-launch scope narrowed from "all models" to "required models + active ASR model" so users only download what they need

## What changed

**Catalog foundation** ([ModelDownloadService.ts](src/main/services/ModelDownloadService.ts))
- `ModelDefinition` gains `group: 'asr' | 'diarization' | 'ner'`, `isRequired`, and optional UI fields (`description`, `languages`, `accuracyScore`, `speedScore`).
- New query helpers: `getAsrModels`, `getRequiredModels`, `getModelById`, `getModelsToLoadOnFirstLaunch`, `checkRequiredAndActiveAsrExist`, `isModelInstalled`.
- New CRUD: `downloadSingleModel`, `deleteModel`, `setActiveAsrModel` — all with guards (not required, not active, installed, etc.).

**WhisperService** now resolves its model path via `getSettings().get('activeModels').transcription` → catalog lookup, instead of a hardcoded filename.

**UpdateCheckService** skips models that aren't installed, so optional ASR alternatives don't appear as "update available".

**IPC + Preload** — new `modelCatalog` API surface with Zod validation:
- `listAsr`, `download`, `delete`, `setActive`, `cancelDownload`

**UI** — new Settings → Modelle tab:
- `AsrModelCard.tsx` — active-badge, language chips, prose description, progress + cancel during download
- `ModelsSettings.tsx` — uses existing `useToast()` + `ConfirmDialog` for feedback, not `window.confirm()`

**Tooling**
- `scripts/convert-hf-whisper.sh` converts a HuggingFace Whisper repo → ggml → q5_0, handling BFloat16 tensors and deprecated `huggingface-cli`. Uses Homebrew's `whisper-quantize` first (avoids broken Xcode SDK builds).
- `scripts/publish-manifest.sh` extended to publish both Turbo variants.

**Docs** — CLAUDE.md + [docs/product/features/model-management.md](docs/product/features/model-management.md) describe the catalog, first-launch scope, IPC channels, and release flow for new ASR models.

## Release state

- Swiss-German binary uploaded to R2 at `whisper-ggml-large-v3-turbo-swiss-q5_0.bin`
- R2 manifest patched additively (Swiss entry added, existing entries untouched, `latestAppVersion` preserved at 0.4.2)

## Test plan

- [x] Unit tests: 571/571 pass (13 new tests cover catalog helpers + CRUD guards)
- [x] Typecheck clean (node + web)
- [x] Build clean
- [ ] Manual dev-mode E2E (requires running app):
  - [ ] First launch downloads only required + active model (2.3 GB, not 2.9 GB)
  - [ ] Settings → Modelle shows both ASR models with correct active/available split
  - [ ] Download Swiss-German → Progress + Cancel → Activation toast
  - [ ] Transcribe a Swiss-German session, verify output quality improves vs. multilingual
  - [ ] Delete guard: active model cannot be deleted; confirm dialog fires on optional model

🤖 Generated with [Claude Code](https://claude.ai/code)