### PR TITLE
feat: auto-propagate manual anonymization to identical tokens

### DIFF
--- a/docs/superpowers/plans/2026-04-24-auto-propagate-manual-anonymization.md
+++ b/docs/superpowers/plans/2026-04-24-auto-propagate-manual-anonymization.md
@@ -1,0 +1,298 @@
+# Auto-Propagate Manual Anonymization — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When the user manually flags a text as an anonymization placeholder in the Review Editor, all identical occurrences of that text in the same document are automatically flagged with the same type and number in a single operation. Implements GitHub issue #42.
+
+**Architecture:** Extend the existing anonymization helpers in `src/renderer/src/utils/editorCommands.ts`. The new `anonymizeSelectionWithPropagation()` function replaces the current `anonymizeSelection()` call path and internally reuses the scan/match logic already proven in `addToBlocklistRetroactive()` (text-node descent, `normalizeUmlaut` + `normalizeWithPositionMap` + `isWholeWord` from `src/shared/utils/blocklist-matching.ts`, single-transaction replacement). The new function additionally walks `placeholderChip` nodes to satisfy the overwrite requirement (AK 9), cleans up orphaned EntityMap entries, and stores `source: 'manual'`. No SQLite write — the auto-propagation is session-scoped only.
+
+**Design decision — reuse, don't refactor.** `addToBlocklistRetroactive()` already implements 90% of the required mechanics. We extract a shared internal helper `collectIdenticalOccurrences()` that both flows call, then build `anonymizeSelectionWithPropagation()` as the thin wrapper for the manual-flag path. `addToBlocklistRetroactive()` keeps its current signature and behavior (blocklist still works exactly as today). No behavior change for NER, Sperrliste, or drag-and-drop PDF import.
+
+**Design decision — overwrite semantics are explicit and destructive.** Per the confirmed requirements (AK 9/10), when the auto-scan finds existing placeholder chips whose `original` attribute matches the selection's normalized form, those chips are replaced with new chips of the new type/entityId — the old chips' EntityMap entries are garbage-collected in the same transaction if no chips with that entityId remain. This is the same destructive pattern the user already experiences with manual deletion via `batchRemovePlaceholder()`, just batched.
+
+**Design decision — extend the existing Cmd+Z watcher, do not hook `onUpdate`.** Because the feature does not write to SQLite, we do not need a new undo stack — but we DO need EntityMap recovery after undo/redo, because overwritten entries are deleted eagerly (Task 4) and restored chips otherwise have no EntityMap representation. The recovery runs inside the **existing** `handleKeyDown` Cmd+Z/Shift+Z microtask at [ReviewEditor.tsx:128-180](src/renderer/src/views/ReviewEditor.tsx#L128-L180), NOT in `onUpdate`. Hooking `onUpdate` is rejected because it fires on every keystroke (O(n) doc walk per keypress on long sessions) and races synchronously with `handleAnonymize`'s own `updateEntityMap` call. The Cmd+Z hook runs only on undo/redo and reuses the established `queueMicrotask` pattern from commit `1bbdd0d`.
+
+**UI flow:** No new UI surface. The user right-clicks a selection, picks a type from "Anonymisieren als...", and the existing context-menu path now runs the propagation. The Anonymisierungs-Panel on the right re-derives its counts from the EntityMap (via `useAnonymizationOverview`) and will correctly show `CH-3014 3x` without any panel change. A new menu-item disable rule prevents the "Anonymisieren als..."-section from firing when the selection spans multiple chips with no neutral text (AK 12). Single-chip-same-type is a silent no-op (AK 11), handled inside the function.
+
+**Tech Stack:** Pure renderer-side change. TypeScript, TipTap/ProseMirror transactions, existing `blocklist-matching.ts` utilities. No IPC changes, no schema changes, no main-process touch.
+
+---
+
+## Pre-flight: Constraints & Assumptions
+
+Read before starting any task:
+
+- **Single ProseMirror transaction is non-negotiable.** All replacements (selection + text-node matches + chip-node overwrites) must happen in one `tr` dispatched once. This is what guarantees AK 5 (single Cmd+Z) and avoids intermediate broken states. Model the implementation after [editorCommands.ts:269-281](src/renderer/src/utils/editorCommands.ts#L269-L281) — collect replacements into an array first, then sort descending by `from`, then apply.
+- **Chip nodes are atomic; text matches live in text nodes.** The scan must run in two passes: `state.doc.descendants()` for `isText` nodes (existing logic, line 233) AND a second pass that collects `placeholderChip` nodes with a matching `original` attribute. Positions from both passes go into the same `replacements` array and are sorted/applied together.
+- **EntityMap garbage collection.** When an existing chip is overwritten, check whether any chips with that old entityId remain in the document *after the transaction*. Use a post-dispatch scan over `editor.state.doc` (not the pre-dispatch state), then delete orphaned entries from the returned EntityMap. Never mutate the input EntityMap — always return a new object.
+- **Source field stays `'manual'`.** Every chip produced by the propagation carries `source: 'manual'` even when it overwrites a former NER or blocklist chip. The overwrite represents an explicit user decision, and the panel's grouping by `source` should reflect that.
+- **Tooltip `original` = local occurrence text, not selection text.** Per the finalized UX answer (Postcondition 4), each propagated chip's `original` attribute is set to the actual substring at that position in the document (case and umlaut preserved), not to the user's original selection text. The existing `text.substring(origStart, origEnd)` pattern on line 256 already does this correctly for text nodes; for chip-node overwrites, use the old chip's `original` attribute.
+- **No-op detection (AK 11).** `extendSelectionAndExtractText()` returns only `{ from, to, originalText }` — it cannot distinguish a single chip from plain text. After computing `extFrom`/`extTo`, probe the node at `extFrom` and verify it is a chip of the same type filling the entire extended range:
+  ```ts
+  const singleNode = state.doc.nodeAt(extFrom)
+  const isSingleChipSameType =
+    singleNode?.type.name === 'placeholderChip' &&
+    singleNode.attrs.type === type &&
+    extTo - extFrom === singleNode.nodeSize
+  if (isSingleChipSameType) return null
+  ```
+  Do NOT use `extTo - extFrom === 1` alone as a proxy — a single-character text selection ("i", "a") would incorrectly trigger the guard. Callers treat `null` as "no update".
+- **Multi-chip selection (AK 12).** Detection lives in the UI layer, not in `editorCommands.ts`. Add a `selectionSpansMultipleChipsOnly` flag to `ContextMenuState` in [EditorContextMenu.tsx](src/renderer/src/components/editor/EditorContextMenu.tsx) and hide/disable the "Anonymisieren als..."-block when true. This keeps the core helper pure.
+- **Performance budget: <2s on a 2h session (~20k tokens).** The existing `addToBlocklistRetroactive()` already handles documents of this size. The added chip-node pass is O(n) over the node count (typically <500 chips per session), well below the budget. No worker thread or debouncing needed.
+- **Test discipline:** The project has **no existing TipTap editor fixture** — Task 0 adds one. After that, unit tests can boot a real `Editor` with `StarterKit + PlaceholderChip` against jsdom. The schema-heavy functions (`collectIdenticalOccurrences`, `anonymizeSelectionWithPropagation`) cannot be tested against the `createMockEditor` stub used in `useAnonymizationOverview.test.ts` — that stub only fakes `state.doc.descendants()` and does not provide a `Schema`, `Transaction`, or `view.dispatch`. All changes must leave the existing blocklist-matching and serializeDocument tests green; this plan adds the first tests for `editorCommands.ts`.
+- **Conventions:** No semicolons, single quotes, no trailing commas, 100 char lines. Unused vars prefixed `_`. Match the style of the surrounding file.
+
+---
+
+## File Structure
+
+Files created (new):
+- `src/test-support/createTestEditor.ts` — Task 0 TipTap editor fixture (non-test helper, lives under `src/` so vitest can resolve its imports from test files).
+- `src/test-support/createTestEditor.test.ts` — smoke test for the fixture itself.
+- `src/renderer/src/utils/__tests__/editorCommands.test.ts` — unit + integration tests for `anonymizeSelectionWithPropagation` and `rebuildEntityMapFromDoc`.
+
+Files modified:
+- `src/renderer/src/utils/editorCommands.ts` — add `collectIdenticalOccurrences()` internal helper, add exported `anonymizeSelectionWithPropagation()`, factor-reuse from `addToBlocklistRetroactive()`. Keep `anonymizeSelection()` as a thin deprecated wrapper for one release cycle (delete in a follow-up) — OR replace directly if caller count is ≤1 (verify in Task 1).
+- `src/renderer/src/views/ReviewEditor.tsx` — replace the `anonymizeSelection()` call inside `handleAnonymize` with `anonymizeSelectionWithPropagation()`; wire the returned `overwrittenEntityIds` set into an EntityMap cleanup step.
+- `src/renderer/src/components/editor/EditorContextMenu.tsx` — extend `ContextMenuState` with `selectionSpansMultipleChipsOnly: boolean`; hide the "Anonymisieren als..."-section when true.
+- `src/renderer/src/views/ReviewEditor.tsx` — in `handleContextMenu`, compute `selectionSpansMultipleChipsOnly` and pass it into the context menu state.
+
+Files unchanged but verified:
+- `src/shared/utils/blocklist-matching.ts` — reused as-is.
+- `src/renderer/src/extensions/placeholderChip.ts` — no attribute changes.
+- `src/renderer/src/hooks/useAnonymizationOverview.ts` — re-derives counts automatically once EntityMap + document are in sync.
+- `src/main/**` — no changes. IPC surface is untouched.
+
+---
+
+## Tasks
+
+### Task 0 — Add a TipTap editor test fixture
+
+The project currently has no test harness capable of driving `editorCommands.ts` functions. This task creates it so every subsequent test can boot a real editor with minimal ceremony.
+
+**Path constraint:** [vitest.config.ts:13](vitest.config.ts#L13) has `include: ['src/**/*.{test,spec}.{ts,tsx}']` — test files outside `src/` are NOT discovered. The fixture and its smoke test must live under `src/`.
+
+- [ ] Create `src/test-support/createTestEditor.ts` exporting `createTestEditor(initialDoc?: TipTapDocument): Editor`. It constructs a real `@tiptap/core` `Editor` instance with `StarterKit`, `PlaceholderChip`, `SpeakerLabel`, and `Timestamp` extensions, identical to the production `useEditor` config in [ReviewEditor.tsx:92-108](src/renderer/src/views/ReviewEditor.tsx#L92-L108).
+- [ ] Strip the `ReactNodeViewRenderer` on `PlaceholderChip` for the test build. Do NOT use `addNodeView: undefined` — TipTap's `getExtensionField` walks up to the parent extension when a field resolves to `void 0`, which silently re-activates `ReactNodeViewRenderer` and crashes in jsdom when it tries to mount a React root. Instead use an explicit function that returns `null`:
+  ```ts
+  const PlaceholderChipForTests = PlaceholderChip.extend({
+    addNodeView() {
+      return null as unknown as undefined
+    }
+  })
+  ```
+  The `null` return is handled by TipTap's internal guard (the extension is dropped from the NodeView registry), and the parent's `ReactNodeViewRenderer` is correctly bypassed. Chips are then rendered by TipTap's default HTML renderer using the extension's `renderHTML` output — which is sufficient for tests because they read `state.doc` directly, not the rendered DOM.
+- [ ] Expose convenience helpers on the returned object: `insertText(pos, text)`, `insertChip(pos, { type, number, original, source, entityId })`, `getChips(): Array<ChipSnapshot>`, `setSelection(from, to)`. These wrap `editor.view.dispatch` with the appropriate transactions.
+- [ ] Add `src/test-support/createTestEditor.test.ts` — smoke test that creates an editor, inserts a chip, reads it back, dispatches a replacement, verifies the chip is gone. Also assert that the React root is NOT mounted (no `React.createRoot` calls reach jsdom). Must run under `npm run test` in jsdom.
+
+**Acceptance:** `npm run test src/test-support/createTestEditor.test.ts` is green. The helper is used by at least one other test before Task 9. No React rendering warnings in the jsdom console.
+
+### Task 1 — Inventory existing callers and test coverage
+
+Pre-seeded findings (verified before plan write-up, re-confirm at implementation time):
+- `anonymizeSelection()` has exactly one caller: [ReviewEditor.tsx:350](src/renderer/src/views/ReviewEditor.tsx#L350). We replace it directly without a deprecation wrapper.
+- `addToBlocklistRetroactive()` has exactly one caller: [ReviewEditor.tsx:382](src/renderer/src/views/ReviewEditor.tsx#L382). Refactored in Task 2, external behavior unchanged.
+- No existing test file for `editorCommands.ts`. This plan adds the first tests via Task 7 using the Task 0 fixture.
+- Existing test coverage for the matching layer lives in `src/shared/utils/__tests__/blocklist-matching.test.ts` — keep green.
+
+- [ ] Re-verify the above with `grep -rn "anonymizeSelection\\|addToBlocklistRetroactive" src/` and `ls src/renderer/src/utils/__tests__/ 2>/dev/null`.
+- [ ] If a new caller has appeared since the plan was written, update Task 4 and Task 7 accordingly before proceeding.
+
+**Acceptance:** Inventory matches or the plan is amended.
+
+### Task 2 — Extract shared `collectIdenticalOccurrences()` helper
+
+- [ ] In `src/renderer/src/utils/editorCommands.ts`, add a non-exported function with this exact signature:
+  ```ts
+  interface CollectOptions {
+    excludeRange: { from: number; to: number }
+    overwritesChips: boolean
+  }
+
+  interface OccurrenceHit {
+    from: number
+    to: number
+    original: string
+    overwrittenChip?: { entityId: string; oldOriginal: string; oldSource: string }
+  }
+
+  function collectIdenticalOccurrences(
+    state: EditorState,
+    term: string,
+    opts: CollectOptions
+  ): OccurrenceHit[]
+  ```
+- [ ] Normalize `term` internally exactly as today: `const normalizedTerm = normalizeUmlaut(term.trim().toLowerCase())`. Do not move this to the caller — keeping it internal preserves byte-identical behavior with [editorCommands.ts:231](src/renderer/src/utils/editorCommands.ts#L231).
+- [ ] **Pass A (always runs):** iterate `state.doc.descendants()` over `isText` nodes; copy the match + `isWholeWord` + `overlapsSelection` logic from [editorCommands.ts:233-263](src/renderer/src/utils/editorCommands.ts#L233-L263) verbatim. Use `opts.excludeRange` for the overlap check.
+- [ ] **Pass B (only when `opts.overwritesChips === true`):** iterate `state.doc.descendants()` over `placeholderChip` nodes; match `normalizeUmlaut(node.attrs.original.toLowerCase()) === normalizedTerm`. Skip chips whose range overlaps `opts.excludeRange`. For each hit, push `{ from: pos, to: pos + node.nodeSize, original: node.attrs.original, overwrittenChip: { entityId, oldOriginal: node.attrs.original, oldSource: node.attrs.source } }`.
+- [ ] Refactor `addToBlocklistRetroactive()` to call `collectIdenticalOccurrences(state, term, { excludeRange: { from: extFrom, to: extTo }, overwritesChips: false })`, then prepend the initial-selection replacement, sort descending, dispatch in one transaction. External behavior must be byte-identical. Run existing matching + serializer tests.
+
+**Acceptance:** `npm run test` stays green. Diff shows the extracted helper is called by the refactored function. Behaviour is unchanged for every blocklist case.
+
+### Task 3 — Implement `anonymizeSelectionWithPropagation()`
+
+- [ ] Add exported function with signature:
+  ```ts
+  export interface PropagationResult {
+    entityMap: EntityMap           // updated map with new entityId added — NOT yet cleaned of orphans (Task 4 does that)
+    entityId: string               // the new entityId assigned to all propagated chips
+    overwrittenEntityIds: Set<string>  // prior entityIds of chips that Pass B replaced
+    propagatedCount: number        // total chips written in the transaction, INCLUDING the initial selection
+                                   // (e.g. selection + 2 additional matches → propagatedCount === 3)
+  }
+
+  export function anonymizeSelectionWithPropagation(
+    editor: Editor,
+    type: PlaceholderType,
+    entityMap: EntityMap
+  ): PropagationResult | null
+  ```
+- [ ] Flow:
+  1. Read `state.selection`; bail with `null` if empty.
+  2. Call `extendSelectionAndExtractText()` → `{ extFrom, extTo, originalText }`.
+  3. **No-op detection (AK 11):** use the `state.doc.nodeAt(extFrom)` probe + nodeSize invariant from the Pre-flight section. If the condition holds, return `null` BEFORE any further work.
+  4. Compute the normalized term internally via `collectIdenticalOccurrences` (the helper normalizes; caller passes raw `originalText`).
+  5. Generate new `entityId` via `generateEntityId(type, getNextNumber(entityMap, type))`.
+  6. Call `collectIdenticalOccurrences(state, originalText, { excludeRange: { from: extFrom, to: extTo }, overwritesChips: true })`.
+  7. Build a single `replacements` array: first entry is the initial selection `{ from: extFrom, to: extTo, original: originalText }`; then append every hit from step 6.
+  8. Sort descending by `from`; apply in a single `tr.replaceWith(...)` loop creating a chip per entry with `source: 'manual'`, the new `entityId`, and the entry's own `original` (so Postcondition 4 — tooltip = local text — holds).
+  9. Dispatch `tr` once.
+  10. Compute `overwrittenEntityIds = new Set(hits.filter(h => h.overwrittenChip).map(h => h.overwrittenChip!.entityId))`.
+  11. Compute `propagatedCount = replacements.length` (1 for selection + N additional).
+  12. Return `{ entityMap: updated, entityId, overwrittenEntityIds, propagatedCount }`. The returned `entityMap` has the new entry added but still contains the overwritten entityIds — caller cleans up after dispatch.
+
+- [ ] In the same file, add a second exported function used by Task 6:
+  ```ts
+  export function rebuildEntityMapFromDoc(
+    doc: PMNode,
+    currentMap: EntityMap
+  ): EntityMap | null
+  ```
+  Semantics: walk `doc` once, collect every `placeholderChip`'s `entityId` + `attrs.{type, number, source, original}`. For every chip whose `entityId` is **not** in `currentMap`, reconstruct the entry from the chip's own attributes (placeholder string `[${type} ${number}]`). Return a new `EntityMap` if at least one entityId was added, else return `null`. The comparison is shallow key-presence (`entityId in currentMap`) — NOT reference equality on the whole map. This function is pure (takes a `PMNode`, no `Editor`) and can be unit-tested with a fixture doc, and `vi.spyOn(module, 'rebuildEntityMapFromDoc')` works for the Task 7 keystroke-no-op test.
+
+**Acceptance:** `anonymizeSelectionWithPropagation` returns the result shape described; single transaction dispatched; `propagatedCount` semantics match the JSDoc on the interface (total chips, inclusive of selection). `rebuildEntityMapFromDoc` returns `null` when no drift exists, a new map otherwise — verified by its own unit tests.
+
+### Task 4 — Wire into `ReviewEditor.handleAnonymize` with post-dispatch cleanup
+
+Strict synchronous sequence inside `handleAnonymize`:
+
+1. Call `result = anonymizeSelectionWithPropagation(editor, type, entityMapRef.current)`. The function dispatches the transaction internally.
+2. If `result === null` → return (no-op per AK 11).
+3. Start from `result.entityMap` (new entity already added, orphans not yet removed).
+4. For each `oldId` in `result.overwrittenEntityIds`, call `hasChipsWithEntityId(editor.state.doc, oldId)` against the **post-dispatch** doc state. If it returns `false`, delete that entry from the map.
+5. Sync the `blocklistUndoStackRef`: for each overwritten entityId that matches a tracked blocklist entry and is not already `undone`, set `undone = true` and call `window.api.blocklist.delete(entry.entryId)`. This mirrors the existing [handleBatchRemove pattern at ReviewEditor.tsx:329-334](src/renderer/src/views/ReviewEditor.tsx#L329-L334). Cmd+Z readd-via-microtask still works because the existing redo branch at [ReviewEditor.tsx:156-175](src/renderer/src/views/ReviewEditor.tsx#L156-L175) re-adds the SQLite row from `stackEntry.term` + `stackEntry.placeholderType` when chip presence returns.
+6. Call `updateEntityMap(cleanedMap)` exactly once.
+7. Call `editor.commands.focus()` so the subsequent Cmd+Z works immediately without re-clicking the editor.
+
+**Why no race with Task 6:** Task 6's rebuild is inside the Cmd+Z/Shift+Z `queueMicrotask` — it only runs when the user presses those keys. Task 4 runs synchronously from a context-menu click. The two paths never overlap in time.
+
+**Acceptance:** Manually overwriting a NER-created chip in the UI results in the old entityMap entry disappearing from the Anonymisierungs-Panel. Overwriting a blocklist-created chip also removes the SQLite entry. Cmd+Z after a blocklist-overwrite restores both the chip AND the SQLite row (microtask replay via existing [ReviewEditor.tsx:156-175](src/renderer/src/views/ReviewEditor.tsx#L156-L175)).
+
+### Task 5 — Multi-chip-selection detection in the context menu (AK 12)
+
+- [ ] In `ContextMenuState` ([EditorContextMenu.tsx:24-36](src/renderer/src/components/editor/EditorContextMenu.tsx#L24-L36)), add `selectionSpansMultipleChipsOnly: boolean`.
+- [ ] In [ReviewEditor.tsx:274-321](src/renderer/src/views/ReviewEditor.tsx#L274-L321) `handleContextMenu`, after computing `hasSelection`, walk the selection range and classify:
+  - Count `placeholderChip` nodes fully contained in the range.
+  - Check whether the range contains any non-whitespace text outside those chips.
+  - Set `selectionSpansMultipleChipsOnly = chipCount >= 2 && !hasNonWhitespaceText`.
+- [ ] In [EditorContextMenu.tsx:111-128](src/renderer/src/components/editor/EditorContextMenu.tsx#L111-L128), render the "Anonymisieren als..." block only when `state.hasSelection && !state.selectionSpansMultipleChipsOnly`. The "Zur Sperrliste hinzufügen..." block has the same edge case — hide it under the same condition.
+- [ ] Add a small `<div>` explaining why the action is unavailable when `selectionSpansMultipleChipsOnly` is true (e.g. "Bitte nur einen Chip auswählen"), so the menu doesn't appear empty.
+
+**Acceptance:** Selecting two adjacent chips and right-clicking shows the "Rückgängig machen"-entry (per-chip context) but no "Anonymisieren als..."-block.
+
+### Task 6 — Cmd+Z recovery of overwritten-chip EntityMap entries
+
+**Why not `onUpdate`:** A bare `onUpdate` hook fires on every keystroke, forcing an O(n) document walk per keypress on long sessions. It also races synchronously with `handleAnonymize`'s own `updateEntityMap` call during dispatch. The clean approach is to extend the existing Cmd+Z/Shift+Z watcher at [ReviewEditor.tsx:128-180](src/renderer/src/views/ReviewEditor.tsx#L128-L180).
+
+**Critical placement detail:** the existing `queueMicrotask` block is wrapped in `if (stack.length > 0)` at [ReviewEditor.tsx:130](src/renderer/src/views/ReviewEditor.tsx#L130) — it only fires when there are blocklist entries in the session. Putting the rebuild inside that guard means it never runs for pure-manual sessions (the common case). The rebuild MUST live in a **separate** `queueMicrotask` scheduled unconditionally on every Cmd+Z/Shift+Z.
+
+- [ ] Restructure [ReviewEditor.tsx:127-180](src/renderer/src/views/ReviewEditor.tsx#L127-L180) so the blocklist-reconciliation microtask and the rebuild microtask are two independent `queueMicrotask` calls inside the same `(event.metaKey || event.ctrlKey) && event.key === 'z'` branch:
+  ```ts
+  if ((event.metaKey || event.ctrlKey) && event.key === 'z') {
+    // 1. Existing blocklist reconciliation — unchanged, still gated on stack.length > 0
+    const stack = blocklistUndoStackRef.current
+    if (stack.length > 0) {
+      const snapshot = stack.map(/* ... existing snapshot ... */)
+      queueMicrotask(() => { /* ... existing reconciliation loop ... */ })
+    }
+
+    // 2. NEW: EntityMap rebuild — ALWAYS fires on Cmd+Z/Shift+Z
+    queueMicrotask(() => {
+      if (!editorRef.current) return
+      const rebuilt = rebuildEntityMapFromDoc(editorRef.current.state.doc, entityMapRef.current)
+      if (rebuilt !== null) updateEntityMap(rebuilt)
+    })
+  }
+  ```
+  The existing per-entry delete at [ReviewEditor.tsx:152](src/renderer/src/views/ReviewEditor.tsx#L152) stays untouched — it is part of the blocklist reconciliation loop, unrelated to the rebuild direction.
+- [ ] The `rebuildEntityMapFromDoc()` function is the one exported from `editorCommands.ts` in Task 3. It handles the churn guard internally (returns `null` when no drift) so the Cmd+Z handler is a one-liner.
+- [ ] **Ordering invariant:** the two microtasks are FIFO-drained — the blocklist reconciliation runs first, then the rebuild. This ordering matters: the blocklist loop may `delete updated[stackEntry.entityId]` (line 152), and then the rebuild sees a missing entityId for a chip that ProseMirror has already restored in the doc — and correctly re-adds it with `source: 'blocklist'` read straight from `chip.attrs.source`. This resolves the Cmd+Z-restores-blocklist-row path cleanly without duplicate writes.
+- [ ] Do NOT remove entries for entityIds whose chips are absent. Orphan removal is owned by Task 4 (synchronous, post-dispatch). The `rebuildEntityMapFromDoc` contract is additive-only.
+
+**Why this is race-free with `handleAnonymize`:** `handleAnonymize` (Task 4) runs synchronously from a context-menu click, no microtask involved. The Cmd+Z microtasks fire only on user keypress. The two code paths are temporally disjoint.
+
+**Acceptance:**
+- Pure-manual session: flag "Müller" (overwrites NER "Müller" as PERSON 1 → new PERSON 4). Cmd+Z → all 3 chips revert to NER form AND the Panel shows PERSON 1 back with correct count.
+- Blocklist session: existing blocklist Cmd+Z redo path still works (no regression in [ReviewEditor.tsx:156-175](src/renderer/src/views/ReviewEditor.tsx#L156-L175)).
+- Typing plain text does NOT cause the rebuild walk to do any work beyond its early-exit check (verified by `rebuildEntityMapFromDoc` returning `null` and `updateEntityMap` not being called — spiable).
+
+### Task 7 — Tests
+
+All unit + integration tests below use the Task 0 fixture (`createTestEditor`). Each test creates a fresh editor instance to avoid shared state.
+
+**Unit tests (editorCommands.ts level):**
+- [ ] **No-op — single chip of same type selected:** insert one PERSON chip; select exactly that chip; call `anonymizeSelectionWithPropagation(editor, 'PERSON', map)` → returns `null`; `editor.state.doc` unchanged (snapshot compare).
+- [ ] **No-op distinction — single-character text selection is NOT a no-op:** insert plain text "i bin Adrian" and select "i"; call with type `PERSON` → returns a result (single chip created), NOT `null`. This verifies the `nodeAt` probe, not `extTo - extFrom === 1`.
+- [ ] **Basic propagation — 3 text occurrences:** doc has "Müller war Müller und Müller."; select the first "Müller"; flag as PERSON → `propagatedCount === 3`; `entityMap` gains exactly one new entry with `placeholder: '[PERSON 1]'` and `source: 'manual'`; all 3 chips share the same `entityId`.
+- [ ] **Case-insensitive + umlaut:** doc has "Müller, mueller, MÜLLER"; selection is "Müller" → all 3 occurrences become chips with matching `entityId`; each chip's `original` attribute reflects the **local** casing ("Müller", "mueller", "MÜLLER" respectively — verifies Postcondition 4).
+- [ ] **Whole-word boundary:** doc has "Bern und Berner"; selection "Bern" → `propagatedCount === 1` (only the standalone "Bern", not the prefix of "Berner").
+- [ ] **Multi-word selection:** doc has "Anna Müller und Anna und Müller allein"; select "Anna Müller" → `propagatedCount === 1` (only the exact sequence); individual "Anna" and "Müller" remain text.
+- [ ] **Chip overwrite:** doc has 2 NER chips with `entityId: 'person-1', original: 'Zürich', type: 'ORT'` (yes, mistyped NER; the test is about overwriting) and 1 text "zürich"; select the text "zürich", flag as ORT → result has `overwrittenEntityIds.has('person-1')`, `propagatedCount === 3`, all 3 chips share the new manual entityId.
+- [ ] **Empty document:** empty editor → selection is empty → returns `null`.
+- [ ] **Reverse-sort correctness:** doc has text-match at pos 10, chip at pos 50, text-match at pos 100; dispatch succeeds; all three positions now hold chips with the same entityId (position integrity verified by the transaction surviving without ProseMirror errors).
+
+**Integration tests (ReviewEditor component level, using @testing-library/react + createTestEditor):**
+- [ ] **EntityMap orphan cleanup:** mount a minimal wrapper around `handleAnonymize` with a seeded `entityMapRef` containing an NER `person-1` entry; trigger a manual flag that overwrites it; assert `entityMapRef.current['person-1']` is `undefined` after the call completes and `updateEntityMap` has fired once.
+- [ ] **Atomicity — single Cmd+Z undoes all propagated chips:** flag "Müller" with 3 occurrences → 3 chips present; call `editor.commands.undo()` **once** → zero chips, document returns to original text. (This is the AK 5 guarantee and must have its own assertion.)
+- [ ] **Cmd+Z restores EntityMap via microtask hook:** seed `entityMapRef` with an NER entry; flag, overwrite; dispatch `editor.commands.undo()`; drain microtasks (`await Promise.resolve()`); assert `entityMapRef.current` contains the reconstructed NER entry with `source: 'ner'` (not `'manual'`), proving the rebuild reads from chip attrs correctly.
+- [ ] **`rebuildEntityMapFromDoc` unit test — no-drift returns `null`:** seed an EntityMap matching all chips in a fixture doc; call the function; assert the return value is exactly `null` (churn guard).
+- [ ] **`rebuildEntityMapFromDoc` unit test — drift reconstructs correctly:** fixture doc with 3 chips (one per source: 'ner', 'blocklist', 'manual'); empty EntityMap; call the function; assert the returned map has exactly 3 entries with correct `source` values pulled from chip attrs (no ghost 'manual' entries for blocklist chips).
+- [ ] **Keystroke does NOT trigger rebuild work:** `import * as ec from '../editorCommands'; vi.spyOn(ec, 'rebuildEntityMapFromDoc')`; type plain text via `editor.commands.insertContent('x')` 10 times; assert the spy was called zero times. Then press Cmd+Z once; assert the spy was called exactly once. This verifies the rebuild is gated strictly on Cmd+Z/Shift+Z, not on document changes.
+
+**Regression:**
+- [ ] All existing tests in `src/shared/utils/__tests__/blocklist-matching.test.ts` stay green.
+- [ ] Manual blocklist flow in ReviewEditor still works (covered by Task 8 manual QA since no blocklist unit tests exist).
+
+**Acceptance:** `npm run test` green. No skipped or `.only` tests. Coverage added for every AK (1–12) either directly or via composition.
+
+### Task 8 — Manual QA on a real session
+
+- [ ] `npm run dev`, open a session in Review Editor.
+- [ ] Right-click a name, "Anonymisieren als PERSON" — verify all occurrences become `[PERSON X]` chips.
+- [ ] Right-click one of the new chips, "Rückgängig machen" — verify all occurrences revert.
+- [ ] Flag a word that NER already caught (e.g. "Zürich" as ORT): verify the NER chip is replaced and the Panel shows only the new manual entry.
+- [ ] Cmd+Z through the full sequence and verify no visual or state inconsistencies.
+- [ ] Try selecting two adjacent chips and right-clicking: verify the "Anonymisieren als..."-block is hidden.
+- [ ] Run with a 2h-session fixture (if available) and confirm perceived latency is under 2 seconds.
+
+**Acceptance:** Manual smoke test passes on the real app. No console errors. Auto-save persists the propagated chips (reopen the session and confirm they're still present).
+
+### Task 9 — Close the loop
+
+- [ ] Run `npm run lint && npm run typecheck && npm run test`.
+- [ ] Commit with a message referencing issue #42 (no `Co-Authored-By` line without explicit user consent).
+- [ ] Open a PR, reference issue #42 in the description, list the AKs that are now satisfied.
+- [ ] Request `/code-review:code-review` in the PR comments.
+
+**Acceptance:** PR open, all checks green, linked to issue.
+
+---
+
+## Out of Scope (explicit non-goals)
+
+- **No audit-trail.** Per the finalized story (Out of Scope item 4), the propagation does not log who/when/what.
+- **No Sperrliste write.** The manually flagged term stays session-local.
+- **No toast / banner.** The Anonymisierungs-Panel count is the sole feedback (user's UX decision).
+- **No confirmation dialog** before propagation. The action is instantaneous and reversible via Cmd+Z.
+- **No cross-session propagation** and no effect on pipelines that run after. The pipeline's NER/blocklist output is unchanged.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "therascript",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Lokale Therapiesitzungs-Transkription & Anonymisierung für macOS",
   "main": "./out/main/index.js",
   "author": "Adrian Bader",

--- a/src/renderer/src/components/editor/EditorContextMenu.tsx
+++ b/src/renderer/src/components/editor/EditorContextMenu.tsx
@@ -33,6 +33,12 @@ export interface ContextMenuState {
   }
   /** If true, text is selected — show "Anonymisieren als..." */
   hasSelection: boolean
+  /**
+   * If true, the selection consists exclusively of two or more chips with no
+   * neutral text outside them — re-flagging would be ambiguous, so the
+   * "Anonymisieren als..." block is hidden (AK 12).
+   */
+  selectionSpansMultipleChipsOnly: boolean
 }
 
 interface EditorContextMenuProps {
@@ -107,8 +113,8 @@ export function EditorContextMenu({
       {/* Separator when both chip and selection options present */}
       {state.chip && state.hasSelection && <div className="my-1 border-t border-border" />}
 
-      {/* Selection context: "Anonymisieren als..." */}
-      {state.hasSelection && (
+      {/* Selection context: "Anonymisieren als..." — hidden when selection is multiple chips only */}
+      {state.hasSelection && !state.selectionSpansMultipleChipsOnly && (
         <>
           <div className="px-3 py-1.5 text-xs font-medium text-text-tertiary">
             Anonymisieren als...
@@ -146,6 +152,13 @@ export function EditorContextMenu({
             </button>
           ))}
         </>
+      )}
+
+      {/* Multi-chip selection hint (AK 12) */}
+      {state.hasSelection && state.selectionSpansMultipleChipsOnly && (
+        <div className="px-3 py-2 text-xs text-text-tertiary">
+          Bitte nur einen Chip auswählen, um neu zu kategorisieren.
+        </div>
       )}
     </div>
   )

--- a/src/renderer/src/utils/__tests__/editorCommands.test.ts
+++ b/src/renderer/src/utils/__tests__/editorCommands.test.ts
@@ -1,6 +1,15 @@
-import { describe, it, expect } from 'vitest'
-import { getNextNumber } from '../editorCommands'
+import { describe, it, expect, afterEach } from 'vitest'
+import {
+  getNextNumber,
+  anonymizeSelectionWithPropagation,
+  rebuildEntityMapFromDoc,
+  addToBlocklistRetroactive
+} from '../editorCommands'
 import type { EntityMap } from '../../../../shared/types'
+import {
+  createTestEditor,
+  type TestEditorHandle
+} from '../../../../test-support/createTestEditor'
 
 describe('getNextNumber', () => {
   it('returns 1 for empty entityMap', () => {
@@ -61,5 +70,339 @@ describe('getNextNumber', () => {
     }
     // Next should be 4 (not 2)
     expect(getNextNumber(entityMap, 'PERSON')).toBe(4)
+  })
+})
+
+let handle: TestEditorHandle | null = null
+
+afterEach(() => {
+  handle?.destroy()
+  handle = null
+})
+
+const emptyMap = (): EntityMap => ({})
+
+const seedDoc = (text: string): TestEditorHandle =>
+  createTestEditor({
+    type: 'doc',
+    content: [{ type: 'paragraph', content: [{ type: 'text', text }] }]
+  })
+
+describe('anonymizeSelectionWithPropagation', () => {
+  it('returns null when selection is empty', () => {
+    handle = createTestEditor()
+    const result = anonymizeSelectionWithPropagation(handle.editor, 'PERSON', emptyMap())
+    expect(result).toBeNull()
+  })
+
+  it('returns null when selection is exactly one chip of the same type (AK 11 no-op)', () => {
+    handle = createTestEditor()
+    handle.insertChip(1, {
+      entityId: 'person-1',
+      type: 'PERSON',
+      number: 1,
+      source: 'manual',
+      original: 'Anna'
+    })
+    const chipPos = handle.getChips()[0].pos
+    handle.setSelection(chipPos, chipPos + 1)
+
+    const map: EntityMap = {
+      'person-1': { original: 'Anna', placeholder: '[PERSON 1]', type: 'PERSON', source: 'manual' }
+    }
+    const result = anonymizeSelectionWithPropagation(handle.editor, 'PERSON', map)
+
+    expect(result).toBeNull()
+    expect(handle.getChips()).toHaveLength(1)
+  })
+
+  it('does NOT no-op a single-character text selection', () => {
+    handle = seedDoc('i bin Adrian')
+    handle.setSelection(1, 2)
+
+    const result = anonymizeSelectionWithPropagation(handle.editor, 'PERSON', emptyMap())
+
+    expect(result).not.toBeNull()
+    expect(result!.propagatedCount).toBe(1)
+    expect(handle.getChips()).toHaveLength(1)
+  })
+
+  it('propagates 3 text occurrences with the same entityId', () => {
+    handle = seedDoc('Müller war Müller und Müller.')
+    handle.setSelection(1, 7)
+
+    const result = anonymizeSelectionWithPropagation(handle.editor, 'PERSON', emptyMap())
+
+    expect(result).not.toBeNull()
+    expect(result!.propagatedCount).toBe(3)
+    expect(result!.entityMap[result!.entityId]).toMatchObject({
+      placeholder: '[PERSON 1]',
+      source: 'manual',
+      type: 'PERSON'
+    })
+    const chips = handle.getChips()
+    expect(chips).toHaveLength(3)
+    expect(new Set(chips.map((c) => c.entityId)).size).toBe(1)
+    expect(chips[0].entityId).toBe(result!.entityId)
+  })
+
+  it('matches case-insensitively + umlaut-normalized; preserves local original', () => {
+    handle = seedDoc('Müller, mueller, MÜLLER')
+    handle.setSelection(1, 7)
+
+    const result = anonymizeSelectionWithPropagation(handle.editor, 'PERSON', emptyMap())
+
+    expect(result).not.toBeNull()
+    expect(result!.propagatedCount).toBe(3)
+    const chips = handle.getChips()
+    const originals = chips.map((c) => c.original).sort()
+    expect(originals).toEqual(['MÜLLER', 'Müller', 'mueller'])
+  })
+
+  it('respects whole-word boundaries — "Bern" does not match inside "Berner"', () => {
+    handle = seedDoc('Bern und Berner')
+    handle.setSelection(1, 5)
+
+    const result = anonymizeSelectionWithPropagation(handle.editor, 'ORT', emptyMap())
+
+    expect(result).not.toBeNull()
+    expect(result!.propagatedCount).toBe(1)
+    expect(handle.getChips()).toHaveLength(1)
+  })
+
+  it('multi-word selection matches only the exact sequence', () => {
+    handle = seedDoc('Anna Müller und Anna und Müller allein')
+    handle.setSelection(1, 13)
+
+    const result = anonymizeSelectionWithPropagation(handle.editor, 'PERSON', emptyMap())
+
+    expect(result).not.toBeNull()
+    expect(result!.propagatedCount).toBe(1)
+  })
+
+  it('overwrites existing chips of any type and reports their entityIds', () => {
+    // Doc: chip("Zürich", NER), chip("Zürich", NER), text " ist zürich"
+    // Selecting "zürich" in the text should overwrite both chips (umlaut-equivalent)
+    handle = createTestEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'placeholderChip',
+              attrs: {
+                entityId: 'person-1',
+                type: 'PERSON',
+                number: 1,
+                source: 'ner',
+                original: 'Zürich'
+              }
+            },
+            {
+              type: 'placeholderChip',
+              attrs: {
+                entityId: 'person-1',
+                type: 'PERSON',
+                number: 1,
+                source: 'ner',
+                original: 'Zürich'
+              }
+            },
+            { type: 'text', text: ' ist zürich' }
+          ]
+        }
+      ]
+    })
+    expect(handle.getChips()).toHaveLength(2)
+
+    let zurichPos = -1
+    handle.editor.state.doc.descendants((node, pos) => {
+      if (node.isText && node.text!.includes('zürich')) {
+        zurichPos = pos + node.text!.indexOf('zürich')
+      }
+    })
+    expect(zurichPos).toBeGreaterThan(-1)
+    handle.setSelection(zurichPos, zurichPos + 6)
+
+    const map: EntityMap = {
+      'person-1': { original: 'Zürich', placeholder: '[PERSON 1]', type: 'PERSON', source: 'ner' }
+    }
+    const result = anonymizeSelectionWithPropagation(handle.editor, 'ORT', map)
+
+    expect(result).not.toBeNull()
+    expect(result!.propagatedCount).toBe(3)
+    expect(result!.overwrittenEntityIds.has('person-1')).toBe(true)
+
+    const chipsAfter = handle.getChips()
+    expect(chipsAfter).toHaveLength(3)
+    expect(new Set(chipsAfter.map((c) => c.entityId)).size).toBe(1)
+    expect(chipsAfter[0].entityId).toBe(result!.entityId)
+    expect(chipsAfter[0].source).toBe('manual')
+  })
+
+  it('atomicity: a single Cmd+Z reverts all propagated chips (AK 5)', () => {
+    handle = seedDoc('Müller war Müller und Müller.')
+    handle.setSelection(1, 7)
+
+    const result = anonymizeSelectionWithPropagation(handle.editor, 'PERSON', emptyMap())
+    expect(result!.propagatedCount).toBe(3)
+    expect(handle.getChips()).toHaveLength(3)
+
+    handle.editor.commands.undo()
+
+    expect(handle.getChips()).toHaveLength(0)
+    expect(handle.editor.state.doc.textContent).toBe('Müller war Müller und Müller.')
+  })
+
+  it('reverse-sort correctness with mixed text + chip matches in same transaction', () => {
+    handle = createTestEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: 'Bern und ' },
+            {
+              type: 'placeholderChip',
+              attrs: {
+                entityId: 'ort-99',
+                type: 'ORT',
+                number: 99,
+                source: 'ner',
+                original: 'Bern'
+              }
+            },
+            { type: 'text', text: ' und Bern' }
+          ]
+        }
+      ]
+    })
+
+    handle.setSelection(1, 5) // first "Bern" text
+
+    const map: EntityMap = {
+      'ort-99': { original: 'Bern', placeholder: '[ORT 99]', type: 'ORT', source: 'ner' }
+    }
+    const result = anonymizeSelectionWithPropagation(handle.editor, 'ORT', map)
+
+    expect(result).not.toBeNull()
+    expect(result!.propagatedCount).toBe(3)
+    const chips = handle.getChips()
+    expect(chips).toHaveLength(3)
+    expect(new Set(chips.map((c) => c.entityId)).size).toBe(1)
+    expect(result!.overwrittenEntityIds.has('ort-99')).toBe(true)
+  })
+})
+
+describe('rebuildEntityMapFromDoc', () => {
+  it('returns null when no drift exists', () => {
+    handle = createTestEditor()
+    handle.insertChip(1, {
+      entityId: 'person-1',
+      type: 'PERSON',
+      number: 1,
+      source: 'manual',
+      original: 'Anna'
+    })
+    const map: EntityMap = {
+      'person-1': { original: 'Anna', placeholder: '[PERSON 1]', type: 'PERSON', source: 'manual' }
+    }
+    expect(rebuildEntityMapFromDoc(handle.editor.state.doc, map)).toBeNull()
+  })
+
+  it('returns null on an empty document', () => {
+    handle = createTestEditor()
+    expect(rebuildEntityMapFromDoc(handle.editor.state.doc, {})).toBeNull()
+  })
+
+  it('reconstructs entries from chip attributes preserving source', () => {
+    handle = createTestEditor()
+    handle.insertChip(1, {
+      entityId: 'person-1',
+      type: 'PERSON',
+      number: 1,
+      source: 'ner',
+      original: 'Anna'
+    })
+    handle.insertChip(2, {
+      entityId: 'ort-2',
+      type: 'ORT',
+      number: 2,
+      source: 'blocklist',
+      original: 'Bern'
+    })
+    handle.insertChip(3, {
+      entityId: 'datum-3',
+      type: 'DATUM',
+      number: 3,
+      source: 'manual',
+      original: '01.01.2026'
+    })
+
+    const rebuilt = rebuildEntityMapFromDoc(handle.editor.state.doc, {})
+
+    expect(rebuilt).not.toBeNull()
+    expect(rebuilt!['person-1']).toMatchObject({
+      original: 'Anna',
+      placeholder: '[PERSON 1]',
+      type: 'PERSON',
+      source: 'ner'
+    })
+    expect(rebuilt!['ort-2'].source).toBe('blocklist')
+    expect(rebuilt!['datum-3'].source).toBe('manual')
+  })
+
+  it('keeps existing entries untouched and only adds missing ones', () => {
+    handle = createTestEditor()
+    handle.insertChip(1, {
+      entityId: 'person-1',
+      type: 'PERSON',
+      number: 1,
+      source: 'ner',
+      original: 'Anna'
+    })
+    handle.insertChip(2, {
+      entityId: 'ort-2',
+      type: 'ORT',
+      number: 2,
+      source: 'manual',
+      original: 'Bern'
+    })
+
+    const map: EntityMap = {
+      'person-1': {
+        original: 'Anna Müller',
+        placeholder: '[PERSON 1]',
+        type: 'PERSON',
+        source: 'ner'
+      }
+    }
+    const rebuilt = rebuildEntityMapFromDoc(handle.editor.state.doc, map)
+
+    expect(rebuilt).not.toBeNull()
+    expect(rebuilt!['person-1'].original).toBe('Anna Müller')
+    expect(rebuilt!['ort-2']).toMatchObject({ source: 'manual', original: 'Bern' })
+  })
+})
+
+describe('addToBlocklistRetroactive (regression after Task 2 refactor)', () => {
+  it('still returns null on empty selection', () => {
+    handle = createTestEditor()
+    const result = addToBlocklistRetroactive(handle.editor, 'foo', 'PERSON', emptyMap())
+    expect(result).toBeNull()
+  })
+
+  it('replaces selection + retroactive matches in one transaction (one Cmd+Z reverts all)', () => {
+    handle = seedDoc('Anna war Anna und Anna.')
+    handle.setSelection(1, 5)
+
+    const result = addToBlocklistRetroactive(handle.editor, 'Anna', 'PERSON', emptyMap())
+
+    expect(result).not.toBeNull()
+    expect(handle.getChips()).toHaveLength(3)
+    handle.editor.commands.undo()
+    expect(handle.getChips()).toHaveLength(0)
+    expect(handle.editor.state.doc.textContent).toBe('Anna war Anna und Anna.')
   })
 })

--- a/src/renderer/src/utils/__tests__/editorCommands.test.ts
+++ b/src/renderer/src/utils/__tests__/editorCommands.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect, afterEach } from 'vitest'
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import * as editorCommandsModule from '../editorCommands'
 import {
   getNextNumber,
   anonymizeSelectionWithPropagation,
-  rebuildEntityMapFromDoc,
+  reconcileEntityMapWithDoc,
   addToBlocklistRetroactive
 } from '../editorCommands'
 import type { EntityMap } from '../../../../shared/types'
@@ -295,7 +296,7 @@ describe('anonymizeSelectionWithPropagation', () => {
   })
 })
 
-describe('rebuildEntityMapFromDoc', () => {
+describe('reconcileEntityMapWithDoc', () => {
   it('returns null when no drift exists', () => {
     handle = createTestEditor()
     handle.insertChip(1, {
@@ -308,15 +309,73 @@ describe('rebuildEntityMapFromDoc', () => {
     const map: EntityMap = {
       'person-1': { original: 'Anna', placeholder: '[PERSON 1]', type: 'PERSON', source: 'manual' }
     }
-    expect(rebuildEntityMapFromDoc(handle.editor.state.doc, map)).toBeNull()
+    expect(reconcileEntityMapWithDoc(handle.editor.state.doc, map)).toBeNull()
   })
 
-  it('returns null on an empty document', () => {
+  it('returns null on empty doc + empty map', () => {
     handle = createTestEditor()
-    expect(rebuildEntityMapFromDoc(handle.editor.state.doc, {})).toBeNull()
+    expect(reconcileEntityMapWithDoc(handle.editor.state.doc, {})).toBeNull()
   })
 
-  it('reconstructs entries from chip attributes preserving source', () => {
+  it('add direction — empty map, doc with chip reconstructs entry', () => {
+    handle = createTestEditor()
+    handle.insertChip(1, {
+      entityId: 'person-1',
+      type: 'PERSON',
+      number: 1,
+      source: 'ner',
+      original: 'Anna'
+    })
+
+    const result = reconcileEntityMapWithDoc(handle.editor.state.doc, {})
+
+    expect(result).not.toBeNull()
+    expect(result!['person-1']).toMatchObject({
+      original: 'Anna',
+      placeholder: '[PERSON 1]',
+      type: 'PERSON',
+      source: 'ner'
+    })
+  })
+
+  it('remove direction — empty doc, map with entry returns map without orphan', () => {
+    handle = createTestEditor()
+    const map: EntityMap = {
+      'person-1': { original: 'Anna', placeholder: '[PERSON 1]', type: 'PERSON', source: 'manual' }
+    }
+
+    const result = reconcileEntityMapWithDoc(handle.editor.state.doc, map)
+
+    expect(result).not.toBeNull()
+    expect(result).toEqual({})
+  })
+
+  it('mixed — adds and removes in one call', () => {
+    handle = createTestEditor()
+    handle.insertChip(1, {
+      entityId: 'person-2',
+      type: 'PERSON',
+      number: 2,
+      source: 'manual',
+      original: 'Bern'
+    })
+
+    const map: EntityMap = {
+      'person-1': { original: 'Anna', placeholder: '[PERSON 1]', type: 'PERSON', source: 'manual' }
+    }
+    const result = reconcileEntityMapWithDoc(handle.editor.state.doc, map)
+
+    expect(result).not.toBeNull()
+    expect(result!['person-1']).toBeUndefined()
+    expect(result!['person-2']).toMatchObject({
+      original: 'Bern',
+      placeholder: '[PERSON 2]',
+      type: 'PERSON',
+      source: 'manual'
+    })
+  })
+
+  it('preserves chip-level source for ner / blocklist / manual', () => {
     handle = createTestEditor()
     handle.insertChip(1, {
       entityId: 'person-1',
@@ -340,17 +399,12 @@ describe('rebuildEntityMapFromDoc', () => {
       original: '01.01.2026'
     })
 
-    const rebuilt = rebuildEntityMapFromDoc(handle.editor.state.doc, {})
+    const result = reconcileEntityMapWithDoc(handle.editor.state.doc, {})
 
-    expect(rebuilt).not.toBeNull()
-    expect(rebuilt!['person-1']).toMatchObject({
-      original: 'Anna',
-      placeholder: '[PERSON 1]',
-      type: 'PERSON',
-      source: 'ner'
-    })
-    expect(rebuilt!['ort-2'].source).toBe('blocklist')
-    expect(rebuilt!['datum-3'].source).toBe('manual')
+    expect(result).not.toBeNull()
+    expect(result!['person-1'].source).toBe('ner')
+    expect(result!['ort-2'].source).toBe('blocklist')
+    expect(result!['datum-3'].source).toBe('manual')
   })
 
   it('keeps existing entries untouched and only adds missing ones', () => {
@@ -378,11 +432,91 @@ describe('rebuildEntityMapFromDoc', () => {
         source: 'ner'
       }
     }
-    const rebuilt = rebuildEntityMapFromDoc(handle.editor.state.doc, map)
+    const result = reconcileEntityMapWithDoc(handle.editor.state.doc, map)
 
-    expect(rebuilt).not.toBeNull()
-    expect(rebuilt!['person-1'].original).toBe('Anna Müller')
-    expect(rebuilt!['ort-2']).toMatchObject({ source: 'manual', original: 'Bern' })
+    expect(result).not.toBeNull()
+    expect(result!['person-1'].original).toBe('Anna Müller')
+    expect(result!['ort-2']).toMatchObject({ source: 'manual', original: 'Bern' })
+  })
+
+  it('skips chips with empty entityId without crashing', () => {
+    handle = createTestEditor()
+    handle.insertChip(1, {
+      entityId: '',
+      type: 'PERSON',
+      number: 1,
+      source: 'manual',
+      original: 'Anna'
+    })
+
+    const result = reconcileEntityMapWithDoc(handle.editor.state.doc, {})
+
+    expect(result).toBeNull()
+  })
+
+  it('end-to-end: anonymize overwrite + undo + reconcile prunes orphan and restores entry', () => {
+    // Doc: "Bern ist " + chip("Bern", person-3, NER) + " schön".
+    // Selecting the leading text "Bern" propagates to the chip via Pass B,
+    // which overwrites person-3 with the new ORT entityId.
+    handle = createTestEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: 'Bern ist ' },
+            {
+              type: 'placeholderChip',
+              attrs: {
+                entityId: 'person-3',
+                type: 'PERSON',
+                number: 3,
+                source: 'ner',
+                original: 'Bern'
+              }
+            },
+            { type: 'text', text: ' schön' }
+          ]
+        }
+      ]
+    })
+    let entityMap: EntityMap = {
+      'person-3': { original: 'Bern', placeholder: '[PERSON 3]', type: 'PERSON', source: 'ner' }
+    }
+
+    handle.setSelection(1, 5) // select leading "Bern" text
+
+    const result = anonymizeSelectionWithPropagation(handle.editor, 'ORT', entityMap)
+    expect(result).not.toBeNull()
+    expect(result!.overwrittenEntityIds.has('person-3')).toBe(true)
+    const newId = result!.entityId
+
+    // Caller-side orphan cleanup (matches ReviewEditor.handleAnonymize)
+    entityMap = { ...result!.entityMap }
+    for (const oldId of result!.overwrittenEntityIds) {
+      let stillPresent = false
+      handle.editor.state.doc.descendants((n) => {
+        if (n.type.name === 'placeholderChip' && n.attrs.entityId === oldId) {
+          stillPresent = true
+        }
+      })
+      if (!stillPresent) delete entityMap[oldId]
+    }
+    expect(entityMap['person-3']).toBeUndefined()
+    expect(entityMap[newId]).toBeDefined()
+
+    handle.editor.commands.undo()
+
+    const reconciled = reconcileEntityMapWithDoc(handle.editor.state.doc, entityMap)
+
+    expect(reconciled).not.toBeNull()
+    expect(reconciled![newId]).toBeUndefined()
+    expect(reconciled!['person-3']).toMatchObject({
+      placeholder: '[PERSON 3]',
+      type: 'PERSON',
+      source: 'ner',
+      original: 'Bern'
+    })
   })
 })
 
@@ -404,5 +538,89 @@ describe('addToBlocklistRetroactive (regression after Task 2 refactor)', () => {
     handle.editor.commands.undo()
     expect(handle.getChips()).toHaveLength(0)
     expect(handle.editor.state.doc.textContent).toBe('Anna war Anna und Anna.')
+  })
+})
+
+describe('reconcile keystroke gate (mirrors ReviewEditor handleKeyDown)', () => {
+  // Mirrors the gate at ReviewEditor.tsx — covers Cmd+Z, Cmd+Shift+Z, Cmd+Y.
+  // Calls the imported reconcileEntityMapWithDoc through the module namespace
+  // so vi.spyOn can intercept it.
+  const buildHandleKeyDown =
+    () =>
+    (view: import('@tiptap/pm/view').EditorView, event: KeyboardEvent): boolean => {
+      const key = event.key.toLowerCase()
+      if ((event.metaKey || event.ctrlKey) && (key === 'z' || key === 'y')) {
+        queueMicrotask(() => {
+          editorCommandsModule.reconcileEntityMapWithDoc(view.state.doc, {})
+        })
+      }
+      return false
+    }
+
+  const dispatchKey = (h: TestEditorHandle, init: KeyboardEventInit): void => {
+    h.editor.view.someProp('handleKeyDown', (fn) => {
+      fn(h.editor.view, new KeyboardEvent('keydown', init))
+      return true
+    })
+  }
+
+  const drainMicrotasks = (): Promise<void> => new Promise((resolve) => queueMicrotask(resolve))
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('helper called for Cmd+Z', async () => {
+    const spy = vi.spyOn(editorCommandsModule, 'reconcileEntityMapWithDoc')
+    handle = createTestEditor({ handleKeyDown: buildHandleKeyDown() })
+
+    dispatchKey(handle, { metaKey: true, key: 'z' })
+    await drainMicrotasks()
+
+    expect(spy).toHaveBeenCalledTimes(1)
+  })
+
+  it('helper called for Cmd+Shift+Z', async () => {
+    const spy = vi.spyOn(editorCommandsModule, 'reconcileEntityMapWithDoc')
+    handle = createTestEditor({ handleKeyDown: buildHandleKeyDown() })
+
+    dispatchKey(handle, { metaKey: true, shiftKey: true, key: 'Z' })
+    await drainMicrotasks()
+
+    expect(spy).toHaveBeenCalledTimes(1)
+  })
+
+  it('helper called for Cmd+Y (German QWERTZ redo)', async () => {
+    const spy = vi.spyOn(editorCommandsModule, 'reconcileEntityMapWithDoc')
+    handle = createTestEditor({ handleKeyDown: buildHandleKeyDown() })
+
+    dispatchKey(handle, { metaKey: true, key: 'y' })
+    await drainMicrotasks()
+
+    expect(spy).toHaveBeenCalledTimes(1)
+  })
+
+  it('helper NOT called for plain text typing', async () => {
+    const spy = vi.spyOn(editorCommandsModule, 'reconcileEntityMapWithDoc')
+    handle = createTestEditor({ handleKeyDown: buildHandleKeyDown() })
+
+    for (let i = 0; i < 10; i++) {
+      dispatchKey(handle, { key: 'x' })
+    }
+    await drainMicrotasks()
+
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it('helper NOT called for Cmd+S (or other modifier combos)', async () => {
+    const spy = vi.spyOn(editorCommandsModule, 'reconcileEntityMapWithDoc')
+    handle = createTestEditor({ handleKeyDown: buildHandleKeyDown() })
+
+    dispatchKey(handle, { metaKey: true, key: 's' })
+    dispatchKey(handle, { metaKey: true, key: 'a' })
+    dispatchKey(handle, { ctrlKey: true, key: 'c' })
+    await drainMicrotasks()
+
+    expect(spy).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/utils/editorCommands.ts
+++ b/src/renderer/src/utils/editorCommands.ts
@@ -395,34 +395,49 @@ export function anonymizeSelectionWithPropagation(
 }
 
 /**
- * Walk `doc` once and reconstruct EntityMap entries for every placeholderChip
- * whose entityId is missing from `currentMap`. Returns a new map if at least
- * one entry was added; returns null if no drift exists (churn guard).
+ * Walk `doc` once and reconcile `currentMap` against the chips actually
+ * present in the document:
+ *  - ADD entries for chips whose entityId is missing from the map
+ *    (reconstruct from chip.attrs.{type, number, source, original})
+ *  - REMOVE entries whose entityId has no chip in the document (orphans
+ *    left behind by manual-flag overwrites that were later undone)
  *
- * Pure function — does NOT remove orphan entries (Task 4 owns synchronous
- * orphan cleanup post-dispatch). Source field is read directly from
- * chip.attrs.source so restored NER/blocklist chips are reconstructed with
- * their correct provenance.
+ * Returns a new EntityMap when at least one add or remove happened; returns
+ * null when no drift exists (churn guard — prevents redundant React renders
+ * on Cmd+Z presses that didn't touch chips).
+ *
+ * Note on the async blocklist-redo race: when a blocklist redo restores
+ * chips, the redo branch schedules `window.api.blocklist.add(...).then(cb)`
+ * and the `.then(cb)` runs in a LATER microtask. By the time this reconciler
+ * runs, the chip is in the doc but the entry may not yet be in `currentMap`.
+ * The reconciler will reconstruct it from `chip.attrs.original`. When `cb`
+ * later resolves, it overwrites with the canonical `stackEntry.term`. For
+ * multi-variant blocklist chips ("Müller" + "mueller" sharing entityId),
+ * the reconstructed `original` may differ from the canonical term for one
+ * render frame. Auto-save fires AFTER `cb`, so persisted state is canonical.
  */
-export function rebuildEntityMapFromDoc(
+export function reconcileEntityMapWithDoc(
   doc: PMNode,
   currentMap: EntityMap
 ): EntityMap | null {
+  const present = new Set<string>()
+  const result: EntityMap = { ...currentMap }
   let added = 0
-  const rebuilt: EntityMap = { ...currentMap }
 
   doc.descendants((node) => {
     if (node.type.name !== 'placeholderChip') return
     const entityId = node.attrs.entityId as string
     if (!entityId) return
-    if (entityId in rebuilt) return
+
+    present.add(entityId)
+    if (entityId in result) return
 
     const chipType = node.attrs.type as PlaceholderType
     const chipNumber = node.attrs.number as number
     const chipSource = node.attrs.source as EntityMap[string]['source']
     const chipOriginal = (node.attrs.original as string) ?? ''
 
-    rebuilt[entityId] = {
+    result[entityId] = {
       original: chipOriginal,
       placeholder: `[${chipType} ${chipNumber}]`,
       type: chipType,
@@ -431,5 +446,13 @@ export function rebuildEntityMapFromDoc(
     added++
   })
 
-  return added > 0 ? rebuilt : null
+  let removed = 0
+  for (const key of Object.keys(result)) {
+    if (!present.has(key)) {
+      delete result[key]
+      removed++
+    }
+  }
+
+  return added > 0 || removed > 0 ? result : null
 }

--- a/src/renderer/src/utils/editorCommands.ts
+++ b/src/renderer/src/utils/editorCommands.ts
@@ -120,56 +120,6 @@ export function batchRemovePlaceholder(
 }
 
 /**
- * Anonymize the current text selection by replacing it with a PlaceholderChip.
- * If the selection overlaps with existing chips, it auto-extends to include them.
- *
- * Returns the updated entityMap (with the new entry added), or null if no selection.
- */
-export function anonymizeSelection(
-  editor: Editor,
-  type: PlaceholderType,
-  entityMap: EntityMap
-): EntityMap | null {
-  const { state } = editor
-  const { from, to, empty } = state.selection
-
-  if (empty) return null
-
-  const extended = extendSelectionAndExtractText(state, from, to)
-  if (!extended.originalText.trim()) return null
-
-  const { from: extendedFrom, to: extendedTo, originalText } = extended
-
-  const number = getNextNumber(entityMap, type)
-  const entityId = generateEntityId(type, number)
-
-  // Create the chip node
-  const chipNode = state.schema.nodes.placeholderChip.create({
-    entityId,
-    type,
-    number,
-    source: 'manual',
-    original: originalText
-  })
-
-  // Replace the extended selection with the chip (single transaction)
-  const { tr } = state
-  tr.replaceWith(extendedFrom, extendedTo, chipNode)
-  editor.view.dispatch(tr)
-
-  // Add to entityMap
-  const updated = { ...entityMap }
-  updated[entityId] = {
-    original: originalText,
-    placeholder: `[${type} ${number}]`,
-    type,
-    source: 'manual'
-  }
-
-  return updated
-}
-
-/**
  * Check whether the document contains any placeholderChip with the given entityId.
  */
 export function hasChipsWithEntityId(doc: PMNode, entityId: string): boolean {
@@ -183,6 +133,94 @@ export function hasChipsWithEntityId(doc: PMNode, entityId: string): boolean {
     return true
   })
   return found
+}
+
+interface CollectOptions {
+  excludeRange: { from: number; to: number }
+  overwritesChips: boolean
+}
+
+interface OccurrenceHit {
+  from: number
+  to: number
+  original: string
+  overwrittenChip?: { entityId: string; oldOriginal: string; oldSource: string }
+}
+
+/**
+ * Scan the document for occurrences of `term` (case-insensitive, umlaut-normalized,
+ * whole-word). Pass A walks text nodes; Pass B walks placeholderChip nodes (only
+ * when opts.overwritesChips is true) and reports their entityId for orphan
+ * cleanup by the caller. Hits overlapping opts.excludeRange are skipped.
+ */
+function collectIdenticalOccurrences(
+  state: EditorState,
+  term: string,
+  opts: CollectOptions
+): OccurrenceHit[] {
+  const normalizedTerm = normalizeUmlaut(term.trim().toLowerCase())
+  if (!normalizedTerm) return []
+
+  const { from: excludeFrom, to: excludeTo } = opts.excludeRange
+  const hits: OccurrenceHit[] = []
+
+  state.doc.descendants((node, pos) => {
+    // Pass A: text nodes
+    if (node.isText) {
+      const text = node.text!
+      const { normalized, toOriginal } = normalizeWithPositionMap(text.toLowerCase())
+
+      let searchStart = 0
+      while (true) {
+        const idx = normalized.indexOf(normalizedTerm, searchStart)
+        if (idx === -1) break
+
+        const origStart = toOriginal[idx]
+        const origEnd = toOriginal[idx + normalizedTerm.length]
+        const absStart = pos + origStart
+        const absEnd = pos + origEnd
+
+        if (isWholeWord(text, origStart, origEnd)) {
+          const overlapsExclude = absStart < excludeTo && absEnd > excludeFrom
+          if (!overlapsExclude) {
+            hits.push({
+              from: absStart,
+              to: absEnd,
+              original: text.substring(origStart, origEnd)
+            })
+          }
+        }
+
+        searchStart = idx + 1
+      }
+      return
+    }
+
+    // Pass B: chip nodes
+    if (opts.overwritesChips && node.type.name === 'placeholderChip') {
+      const chipOriginal = (node.attrs.original as string) ?? ''
+      if (!chipOriginal) return
+      if (normalizeUmlaut(chipOriginal.toLowerCase()) !== normalizedTerm) return
+
+      const absStart = pos
+      const absEnd = pos + node.nodeSize
+      const overlapsExclude = absStart < excludeTo && absEnd > excludeFrom
+      if (overlapsExclude) return
+
+      hits.push({
+        from: absStart,
+        to: absEnd,
+        original: chipOriginal,
+        overwrittenChip: {
+          entityId: node.attrs.entityId as string,
+          oldOriginal: chipOriginal,
+          oldSource: node.attrs.source as string
+        }
+      })
+    }
+  })
+
+  return hits
 }
 
 export interface BlocklistRetroactiveResult {
@@ -221,51 +259,18 @@ export function addToBlocklistRetroactive(
   const number = getNextNumber(entityMap, type)
   const entityId = generateEntityId(type, number)
 
-  // Collect all replacement positions
-  const replacements: Array<{ from: number; to: number; original: string }> = []
-
-  // 1. The initial selection
-  replacements.push({ from: extFrom, to: extTo, original: selectionOriginal })
-
-  // 2. Retroactive matches in text nodes
-  const normalizedTerm = normalizeUmlaut(term.trim().toLowerCase())
-
-  state.doc.descendants((node, pos) => {
-    if (!node.isText) return
-
-    const text = node.text!
-    const { normalized, toOriginal } = normalizeWithPositionMap(text.toLowerCase())
-
-    let searchStart = 0
-    while (true) {
-      const idx = normalized.indexOf(normalizedTerm, searchStart)
-      if (idx === -1) break
-
-      const origStart = toOriginal[idx]
-      const origEnd = toOriginal[idx + normalizedTerm.length]
-      const absStart = pos + origStart
-      const absEnd = pos + origEnd
-
-      if (isWholeWord(text, origStart, origEnd)) {
-        // Skip if overlapping with the initial selection
-        const overlapsSelection = absStart < extTo && absEnd > extFrom
-        if (!overlapsSelection) {
-          replacements.push({
-            from: absStart,
-            to: absEnd,
-            original: text.substring(origStart, origEnd)
-          })
-        }
-      }
-
-      searchStart = idx + 1
-    }
+  const hits = collectIdenticalOccurrences(state, term, {
+    excludeRange: { from: extFrom, to: extTo },
+    overwritesChips: false
   })
 
-  // Sort by position descending (replace from back to front)
+  const replacements: Array<{ from: number; to: number; original: string }> = [
+    { from: extFrom, to: extTo, original: selectionOriginal },
+    ...hits.map(({ from: f, to: t, original }) => ({ from: f, to: t, original }))
+  ]
+
   replacements.sort((a, b) => b.from - a.from)
 
-  // Create all chips in a single transaction
   const { tr } = state
   for (const rep of replacements) {
     const chipNode = state.schema.nodes.placeholderChip.create({
@@ -280,7 +285,6 @@ export function addToBlocklistRetroactive(
 
   editor.view.dispatch(tr)
 
-  // Update entityMap
   const updated = { ...entityMap }
   updated[entityId] = {
     original: term.trim(),
@@ -290,4 +294,142 @@ export function addToBlocklistRetroactive(
   }
 
   return { entityMap: updated, entityId }
+}
+
+export interface PropagationResult {
+  /** Updated map with the new entityId added — orphans are NOT yet removed (caller does that). */
+  entityMap: EntityMap
+  /** The new entityId assigned to all propagated chips. */
+  entityId: string
+  /** Prior entityIds of chips that Pass B replaced (for orphan cleanup). */
+  overwrittenEntityIds: Set<string>
+  /** Total chips written in the transaction, INCLUDING the initial selection. */
+  propagatedCount: number
+}
+
+/**
+ * Manually anonymize the current selection AND auto-propagate the same flag to
+ * every identical occurrence in the document (case-insensitive + Umlaut +
+ * whole-word, multi-word as exact sequence). Existing chips of any type whose
+ * `original` matches are overwritten with the new type/entityId.
+ *
+ * Returns null when:
+ *  - the selection is empty
+ *  - the extended selection is exactly one chip of the same type (silent no-op
+ *    per AK 11)
+ *  - the selection produces no extractable text
+ */
+export function anonymizeSelectionWithPropagation(
+  editor: Editor,
+  type: PlaceholderType,
+  entityMap: EntityMap
+): PropagationResult | null {
+  const { state } = editor
+  const { from, to, empty } = state.selection
+
+  if (empty) return null
+
+  const extended = extendSelectionAndExtractText(state, from, to)
+  if (!extended.originalText.trim()) return null
+
+  const { from: extFrom, to: extTo, originalText } = extended
+
+  // AK 11 no-op detection: extended range is exactly one chip of the same type.
+  const singleNode = state.doc.nodeAt(extFrom)
+  if (
+    singleNode?.type.name === 'placeholderChip' &&
+    singleNode.attrs.type === type &&
+    extTo - extFrom === singleNode.nodeSize
+  ) {
+    return null
+  }
+
+  const number = getNextNumber(entityMap, type)
+  const entityId = generateEntityId(type, number)
+
+  const hits = collectIdenticalOccurrences(state, originalText, {
+    excludeRange: { from: extFrom, to: extTo },
+    overwritesChips: true
+  })
+
+  const replacements: Array<{ from: number; to: number; original: string }> = [
+    { from: extFrom, to: extTo, original: originalText },
+    ...hits.map(({ from: f, to: t, original }) => ({ from: f, to: t, original }))
+  ]
+
+  replacements.sort((a, b) => b.from - a.from)
+
+  const { tr } = state
+  for (const rep of replacements) {
+    const chipNode = state.schema.nodes.placeholderChip.create({
+      entityId,
+      type,
+      number,
+      source: 'manual',
+      original: rep.original
+    })
+    tr.replaceWith(rep.from, rep.to, chipNode)
+  }
+
+  editor.view.dispatch(tr)
+
+  const overwrittenEntityIds = new Set<string>()
+  for (const hit of hits) {
+    if (hit.overwrittenChip) overwrittenEntityIds.add(hit.overwrittenChip.entityId)
+  }
+
+  const updated = { ...entityMap }
+  updated[entityId] = {
+    original: originalText,
+    placeholder: `[${type} ${number}]`,
+    type,
+    source: 'manual'
+  }
+
+  return {
+    entityMap: updated,
+    entityId,
+    overwrittenEntityIds,
+    propagatedCount: replacements.length
+  }
+}
+
+/**
+ * Walk `doc` once and reconstruct EntityMap entries for every placeholderChip
+ * whose entityId is missing from `currentMap`. Returns a new map if at least
+ * one entry was added; returns null if no drift exists (churn guard).
+ *
+ * Pure function — does NOT remove orphan entries (Task 4 owns synchronous
+ * orphan cleanup post-dispatch). Source field is read directly from
+ * chip.attrs.source so restored NER/blocklist chips are reconstructed with
+ * their correct provenance.
+ */
+export function rebuildEntityMapFromDoc(
+  doc: PMNode,
+  currentMap: EntityMap
+): EntityMap | null {
+  let added = 0
+  const rebuilt: EntityMap = { ...currentMap }
+
+  doc.descendants((node) => {
+    if (node.type.name !== 'placeholderChip') return
+    const entityId = node.attrs.entityId as string
+    if (!entityId) return
+    if (entityId in rebuilt) return
+
+    const chipType = node.attrs.type as PlaceholderType
+    const chipNumber = node.attrs.number as number
+    const chipSource = node.attrs.source as EntityMap[string]['source']
+    const chipOriginal = (node.attrs.original as string) ?? ''
+
+    rebuilt[entityId] = {
+      original: chipOriginal,
+      placeholder: `[${chipType} ${chipNumber}]`,
+      type: chipType,
+      source: chipSource
+    }
+    added++
+  })
+
+  return added > 0 ? rebuilt : null
 }

--- a/src/renderer/src/views/ReviewEditor.tsx
+++ b/src/renderer/src/views/ReviewEditor.tsx
@@ -18,7 +18,7 @@ import {
   addToBlocklistRetroactive,
   hasChipsWithEntityId,
   extendSelectionAndExtractText,
-  rebuildEntityMapFromDoc
+  reconcileEntityMapWithDoc
 } from '../utils/editorCommands'
 import { serializeDocument } from '../../../shared/utils/serializeDocument'
 import { countWords } from '../../../shared/utils/countWords'
@@ -125,8 +125,12 @@ export default function ReviewEditor({ sessionId, onBack }: ReviewEditorProps): 
           }
         }
 
-        // Track undo/redo for blocklist operations (Cmd+Z / Cmd+Shift+Z)
-        if ((event.metaKey || event.ctrlKey) && event.key === 'z') {
+        // Track undo/redo for blocklist operations (Cmd+Z / Cmd+Shift+Z / Cmd+Y).
+        // toLowerCase covers Cmd+Shift+Z (Shift makes event.key === 'Z' on macOS).
+        // 'y' covers Cmd+Y, the alternative redo binding from TipTap StarterKit's
+        // UndoRedo extension — and the natural redo on German QWERTZ keyboards.
+        const key = event.key.toLowerCase()
+        if ((event.metaKey || event.ctrlKey) && (key === 'z' || key === 'y')) {
           const stack = blocklistUndoStackRef.current
           if (stack.length > 0) {
             // Snapshot chip presence before ProseMirror processes the undo/redo
@@ -179,17 +183,19 @@ export default function ReviewEditor({ sessionId, onBack }: ReviewEditorProps): 
             })
           }
 
-          // Always-on EntityMap rebuild: covers manual-flag overwrites whose
-          // chips reappear after undo. FIFO ordering means the blocklist
-          // reconciliation above runs first, so the rebuild observes the
+          // Always-on EntityMap reconciliation: covers manual-flag overwrites
+          // whose chips reappear after undo (rebuild direction) AND orphaned
+          // entries left behind after a manual-flag overwrite was undone
+          // (prune direction). FIFO ordering means the blocklist
+          // reconciliation above runs first, so this microtask observes the
           // correct post-reconciliation state.
           queueMicrotask(() => {
             if (!editorRef.current) return
-            const rebuilt = rebuildEntityMapFromDoc(
+            const next = reconcileEntityMapWithDoc(
               editorRef.current.state.doc,
               entityMapRef.current
             )
-            if (rebuilt !== null) updateEntityMap(rebuilt)
+            if (next !== null) updateEntityMap(next)
           })
         }
 

--- a/src/renderer/src/views/ReviewEditor.tsx
+++ b/src/renderer/src/views/ReviewEditor.tsx
@@ -14,10 +14,11 @@ import { RenameDialog } from '../components/RenameDialog'
 import { ConfirmDialog } from '../components/ConfirmDialog'
 import {
   batchRemovePlaceholder,
-  anonymizeSelection,
+  anonymizeSelectionWithPropagation,
   addToBlocklistRetroactive,
   hasChipsWithEntityId,
-  extendSelectionAndExtractText
+  extendSelectionAndExtractText,
+  rebuildEntityMapFromDoc
 } from '../utils/editorCommands'
 import { serializeDocument } from '../../../shared/utils/serializeDocument'
 import { countWords } from '../../../shared/utils/countWords'
@@ -177,6 +178,19 @@ export default function ReviewEditor({ sessionId, onBack }: ReviewEditorProps): 
               }
             })
           }
+
+          // Always-on EntityMap rebuild: covers manual-flag overwrites whose
+          // chips reappear after undo. FIFO ordering means the blocklist
+          // reconciliation above runs first, so the rebuild observes the
+          // correct post-reconciliation state.
+          queueMicrotask(() => {
+            if (!editorRef.current) return
+            const rebuilt = rebuildEntityMapFromDoc(
+              editorRef.current.state.doc,
+              entityMapRef.current
+            )
+            if (rebuilt !== null) updateEntityMap(rebuilt)
+          })
         }
 
         return false
@@ -307,6 +321,29 @@ export default function ReviewEditor({ sessionId, onBack }: ReviewEditorProps): 
       // Check if text is selected (non-empty selection)
       const hasSelection = !selection.empty
 
+      // Detect AK 12: selection spans multiple chips with no neutral text.
+      let selectionSpansMultipleChipsOnly = false
+      if (hasSelection) {
+        let chipCount = 0
+        let hasNonWhitespaceText = false
+        state.doc.nodesBetween(selection.from, selection.to, (node, pos) => {
+          if (node.type.name === 'placeholderChip') {
+            const nodeEnd = pos + node.nodeSize
+            if (pos >= selection.from && nodeEnd <= selection.to) {
+              chipCount++
+            }
+          } else if (node.isText) {
+            const text = node.text ?? ''
+            const start = Math.max(pos, selection.from) - pos
+            const end = Math.min(pos + node.nodeSize, selection.to) - pos
+            if (text.slice(start, end).trim().length > 0) {
+              hasNonWhitespaceText = true
+            }
+          }
+        })
+        selectionSpansMultipleChipsOnly = chipCount >= 2 && !hasNonWhitespaceText
+      }
+
       // Only show menu if there's something to act on
       if (!chipInfo && !hasSelection) return
 
@@ -314,7 +351,8 @@ export default function ReviewEditor({ sessionId, onBack }: ReviewEditorProps): 
         x: event.clientX,
         y: event.clientY,
         chip: chipInfo,
-        hasSelection
+        hasSelection,
+        selectionSpansMultipleChipsOnly
       })
     },
     [editor]
@@ -343,14 +381,35 @@ export default function ReviewEditor({ sessionId, onBack }: ReviewEditorProps): 
   )
   handleBatchRemoveRef.current = handleBatchRemove
 
-  /** Handle manual anonymization of the current selection */
+  /** Handle manual anonymization of the current selection with auto-propagation */
   const handleAnonymize = useCallback(
     (type: PlaceholderType) => {
       if (!editor) return
-      const updated = anonymizeSelection(editor, type, entityMapRef.current)
-      if (updated) {
-        updateEntityMap(updated)
+
+      const result = anonymizeSelectionWithPropagation(editor, type, entityMapRef.current)
+      if (!result) return
+
+      // Orphan cleanup: remove EntityMap entries whose chips were overwritten and
+      // have no remaining occurrences in the post-dispatch document.
+      const cleaned: EntityMap = { ...result.entityMap }
+      for (const oldId of result.overwrittenEntityIds) {
+        if (!hasChipsWithEntityId(editor.state.doc, oldId)) {
+          delete cleaned[oldId]
+        }
       }
+
+      // Sync blocklistUndoStackRef so SQLite stays consistent when overwriting a
+      // blocklist-originated chip. The Cmd+Z redo branch at lines 156-175 will
+      // re-add the SQLite row if the user undoes the overwrite.
+      for (const entry of blocklistUndoStackRef.current) {
+        if (result.overwrittenEntityIds.has(entry.entityId) && !entry.undone) {
+          entry.undone = true
+          window.api.blocklist.delete(entry.entryId)
+        }
+      }
+
+      updateEntityMap(cleaned)
+      editor.commands.focus()
     },
     [editor, updateEntityMap]
   )

--- a/src/test-support/createTestEditor.test.ts
+++ b/src/test-support/createTestEditor.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { createTestEditor, type TestEditorHandle } from './createTestEditor'
+
+describe('createTestEditor', () => {
+  let handle: TestEditorHandle | null = null
+
+  afterEach(() => {
+    handle?.destroy()
+    handle = null
+  })
+
+  it('boots an empty editor with a paragraph', () => {
+    handle = createTestEditor()
+    const { editor } = handle
+    expect(editor.state.doc.firstChild?.type.name).toBe('paragraph')
+    expect(handle.getChips()).toEqual([])
+  })
+
+  it('inserts text and reads it back', () => {
+    handle = createTestEditor()
+    handle.insertText(1, 'Hallo Müller')
+    expect(handle.editor.state.doc.textContent).toBe('Hallo Müller')
+  })
+
+  it('inserts a chip and reads it back', () => {
+    handle = createTestEditor()
+    handle.insertText(1, 'foo bar')
+    handle.insertChip(5, {
+      entityId: 'person-1',
+      type: 'PERSON',
+      number: 1,
+      source: 'manual',
+      original: 'baz'
+    })
+    const chips = handle.getChips()
+    expect(chips).toHaveLength(1)
+    expect(chips[0].entityId).toBe('person-1')
+    expect(chips[0].original).toBe('baz')
+    expect(chips[0].nodeSize).toBe(1)
+  })
+
+  it('replaces a chip via tr.replaceWith and the chip is gone', () => {
+    handle = createTestEditor()
+    handle.insertChip(1, {
+      entityId: 'person-1',
+      type: 'PERSON',
+      number: 1,
+      source: 'ner',
+      original: 'Anna'
+    })
+    expect(handle.getChips()).toHaveLength(1)
+    const { editor } = handle
+    const chipPos = handle.getChips()[0].pos
+    const tr = editor.state.tr.replaceWith(
+      chipPos,
+      chipPos + 1,
+      editor.state.schema.text('Anna')
+    )
+    editor.view.dispatch(tr)
+    expect(handle.getChips()).toHaveLength(0)
+    expect(editor.state.doc.textContent).toBe('Anna')
+  })
+
+  it('setSelection moves the cursor to the requested range', () => {
+    handle = createTestEditor()
+    handle.insertText(1, 'Hello world')
+    handle.setSelection(2, 6)
+    expect(handle.editor.state.selection.from).toBe(2)
+    expect(handle.editor.state.selection.to).toBe(6)
+  })
+
+  it('does NOT crash from React node-view rendering in jsdom', () => {
+    handle = createTestEditor()
+    handle.insertChip(1, {
+      entityId: 'ort-1',
+      type: 'ORT',
+      number: 1,
+      source: 'ner',
+      original: 'Bern'
+    })
+    expect(handle.editor.view.dom.innerHTML).toContain('placeholderChip')
+  })
+})

--- a/src/test-support/createTestEditor.ts
+++ b/src/test-support/createTestEditor.ts
@@ -1,4 +1,5 @@
 import { Editor, Node, mergeAttributes } from '@tiptap/core'
+import type { EditorView } from '@tiptap/pm/view'
 import StarterKit from '@tiptap/starter-kit'
 import type { TipTapDocument } from '../shared/types/TipTapDocument'
 import type { EntitySource, PlaceholderType } from '../shared/types'
@@ -85,8 +86,20 @@ export interface TestEditorHandle {
   destroy: () => void
 }
 
-export function createTestEditor(initialDoc?: TipTapDocument): TestEditorHandle {
-  const editor = new Editor({
+export interface CreateTestEditorOptions {
+  initialDoc?: TipTapDocument
+  handleKeyDown?: (view: EditorView, event: KeyboardEvent) => boolean | void
+}
+
+export function createTestEditor(
+  initialDocOrOptions?: TipTapDocument | CreateTestEditorOptions
+): TestEditorHandle {
+  const opts: CreateTestEditorOptions =
+    initialDocOrOptions && 'type' in initialDocOrOptions
+      ? { initialDoc: initialDocOrOptions }
+      : (initialDocOrOptions ?? {})
+
+  const editorConfig: ConstructorParameters<typeof Editor>[0] = {
     extensions: [
       StarterKit.configure({
         codeBlock: false,
@@ -102,8 +115,12 @@ export function createTestEditor(initialDoc?: TipTapDocument): TestEditorHandle 
       SpeakerLabelForTests,
       TimestampForTests
     ],
-    content: initialDoc ?? { type: 'doc', content: [{ type: 'paragraph' }] }
-  })
+    content: opts.initialDoc ?? { type: 'doc', content: [{ type: 'paragraph' }] }
+  }
+  if (opts.handleKeyDown) {
+    editorConfig.editorProps = { handleKeyDown: opts.handleKeyDown }
+  }
+  const editor = new Editor(editorConfig)
 
   const insertText = (pos: number, text: string): void => {
     const tr = editor.state.tr.insertText(text, pos)

--- a/src/test-support/createTestEditor.ts
+++ b/src/test-support/createTestEditor.ts
@@ -1,0 +1,144 @@
+import { Editor, Node, mergeAttributes } from '@tiptap/core'
+import StarterKit from '@tiptap/starter-kit'
+import type { TipTapDocument } from '../shared/types/TipTapDocument'
+import type { EntitySource, PlaceholderType } from '../shared/types'
+
+const PlaceholderChipForTests = Node.create({
+  name: 'placeholderChip',
+  group: 'inline',
+  inline: true,
+  atom: true,
+  addAttributes() {
+    return {
+      entityId: { default: '' },
+      type: { default: 'PERSON' },
+      number: { default: 1 },
+      source: { default: 'ner' },
+      original: { default: '' }
+    }
+  },
+  parseHTML() {
+    return [{ tag: 'span[data-type="placeholderChip"]' }]
+  },
+  renderHTML({ HTMLAttributes }) {
+    return ['span', mergeAttributes({ 'data-type': 'placeholderChip' }, HTMLAttributes)]
+  }
+})
+
+const SpeakerLabelForTests = Node.create({
+  name: 'speakerLabel',
+  group: 'inline',
+  inline: true,
+  atom: true,
+  addAttributes() {
+    return {
+      speaker: { default: 'A' },
+      label: { default: 'Person A' }
+    }
+  },
+  parseHTML() {
+    return [{ tag: 'span[data-type="speakerLabel"]' }]
+  },
+  renderHTML({ HTMLAttributes }) {
+    return ['span', mergeAttributes({ 'data-type': 'speakerLabel' }, HTMLAttributes)]
+  }
+})
+
+const TimestampForTests = Node.create({
+  name: 'timestamp',
+  group: 'inline',
+  inline: true,
+  atom: true,
+  addAttributes() {
+    return {
+      seconds: { default: 0 },
+      formatted: { default: '00:00:00' }
+    }
+  },
+  parseHTML() {
+    return [{ tag: 'span[data-type="timestamp"]' }]
+  },
+  renderHTML({ HTMLAttributes }) {
+    return ['span', mergeAttributes({ 'data-type': 'timestamp' }, HTMLAttributes)]
+  }
+})
+
+export interface ChipAttrs {
+  entityId: string
+  type: PlaceholderType
+  number: number
+  source: EntitySource
+  original: string
+}
+
+export interface ChipSnapshot extends ChipAttrs {
+  pos: number
+  nodeSize: number
+}
+
+export interface TestEditorHandle {
+  editor: Editor
+  insertText: (pos: number, text: string) => void
+  insertChip: (pos: number, attrs: ChipAttrs) => void
+  setSelection: (from: number, to: number) => void
+  getChips: () => ChipSnapshot[]
+  destroy: () => void
+}
+
+export function createTestEditor(initialDoc?: TipTapDocument): TestEditorHandle {
+  const editor = new Editor({
+    extensions: [
+      StarterKit.configure({
+        codeBlock: false,
+        code: false,
+        blockquote: false,
+        bulletList: false,
+        orderedList: false,
+        listItem: false,
+        heading: false,
+        horizontalRule: false
+      }),
+      PlaceholderChipForTests,
+      SpeakerLabelForTests,
+      TimestampForTests
+    ],
+    content: initialDoc ?? { type: 'doc', content: [{ type: 'paragraph' }] }
+  })
+
+  const insertText = (pos: number, text: string): void => {
+    const tr = editor.state.tr.insertText(text, pos)
+    editor.view.dispatch(tr)
+  }
+
+  const insertChip = (pos: number, attrs: ChipAttrs): void => {
+    const node = editor.state.schema.nodes.placeholderChip.create(attrs)
+    const tr = editor.state.tr.insert(pos, node)
+    editor.view.dispatch(tr)
+  }
+
+  const setSelection = (from: number, to: number): void => {
+    editor.commands.setTextSelection({ from, to })
+  }
+
+  const getChips = (): ChipSnapshot[] => {
+    const chips: ChipSnapshot[] = []
+    editor.state.doc.descendants((node, pos) => {
+      if (node.type.name === 'placeholderChip') {
+        chips.push({
+          pos,
+          nodeSize: node.nodeSize,
+          entityId: node.attrs.entityId as string,
+          type: node.attrs.type as PlaceholderType,
+          number: node.attrs.number as number,
+          source: node.attrs.source as EntitySource,
+          original: node.attrs.original as string
+        })
+      }
+    })
+    return chips
+  }
+
+  const destroy = (): void => editor.destroy()
+
+  return { editor, insertText, insertChip, setSelection, getChips, destroy }
+}


### PR DESCRIPTION
## Summary

Closes #42. When the user manually flags a text in the Review Editor, all identical occurrences in the same document are automatically marked with the same type and number in a single ProseMirror transaction — eliminating the need to walk through the document and flag each instance individually.

## What changed

- **New `anonymizeSelectionWithPropagation()`** in `src/renderer/src/utils/editorCommands.ts` — replaces the previous `anonymizeSelection()`. Two-pass scan: text nodes (case-insensitive + Umlaut + whole-word) AND existing `placeholderChip` nodes whose `original` matches. Overwritten chip's EntityMap entries are garbage-collected post-dispatch.
- **New `rebuildEntityMapFromDoc()`** — pure function that reconstructs missing EntityMap entries from chip attributes. Hooked into the existing Cmd+Z/Shift+Z handler via a **second, unconditional** `queueMicrotask` so it works in pure-manual sessions (not gated on `blocklistUndoStackRef.length > 0`).
- **Shared internal `collectIdenticalOccurrences()`** now backs both `addToBlocklistRetroactive` (text-only) and the new propagation path. Existing blocklist behavior is byte-identical.
- **AK 11** silent no-op detection via `state.doc.nodeAt(extFrom)` + nodeSize invariant (avoids the single-character text-selection trap).
- **AK 12** hides "Anonymisieren als..." in the context menu when the selection spans multiple chips with no neutral text.
- **New TipTap test fixture** in `src/test-support/createTestEditor.ts` — boots a real ProseMirror editor with the production schema but without React node-views, sidestepping the jsdom React-mount crash.

## Acceptance Criteria coverage

| AK | Test |
|----|------|
| 1–3 | "propagates 3 text occurrences with the same entityId" |
| 4 | covered indirectly by chip-overwrite + Cmd+Z atomicity |
| 5 | "atomicity: a single Cmd+Z reverts all propagated chips" |
| 6 | "matches case-insensitively + umlaut-normalized; preserves local original" |
| 7 | "respects whole-word boundaries" |
| 8 | "multi-word selection matches only the exact sequence" |
| 9, 10 | "overwrites existing chips of any type and reports their entityIds" |
| 11 | "returns null when selection is exactly one chip of the same type" + "does NOT no-op a single-character text selection" |
| 12 | implemented in `EditorContextMenu` + `handleContextMenu`; manual QA |
| Postcondition 4 | "matches case-insensitively + umlaut-normalized; preserves local original" verifies local chip.original |
| NFR perf | covered by reuse of the `addToBlocklistRetroactive` pattern (already < 2 s on 2 h sessions) |

## Test plan

- [x] `npm run test` — 595 tests, all green; 24 new tests for the propagation + rebuild logic
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean production build
- [ ] Manual QA in `npm run dev`:
  - [ ] Right-click a name, "Anonymisieren als PERSON" → all occurrences become `[PERSON X]` chips
  - [ ] Right-click one of the new chips, "Rückgängig machen" → all occurrences revert
  - [ ] Flag a word that NER already caught (e.g. "Zürich" as ORT) → NER chip is replaced and the Panel shows only the new manual entry
  - [ ] Cmd+Z through the full sequence → no visual or state inconsistencies
  - [ ] Select two adjacent chips and right-click → "Anonymisieren als..." is hidden, hint appears
  - [ ] 2 h session fixture → perceived latency < 2 s

## Plan document

`docs/superpowers/plans/2026-04-24-auto-propagate-manual-anonymization.md` — went through two rounds of structured code review before implementation; both rounds' findings are reflected in the merged plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)