### PR TITLE
refactor(ner): backend dispatcher foundation (Phase 1 of multi-anonymization)

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -36,6 +36,10 @@ extraResources:
     to: ml_sidecar/diarize.py
   - from: python_sidecar/ner_service.py
     to: ml_sidecar/ner_service.py
+  - from: python_sidecar/ner_backends
+    to: ml_sidecar/ner_backends
+    filter:
+      - '**/*.py'
   - from: python_sidecar/torchcodec_shim.py
     to: ml_sidecar/torchcodec_shim.py
 npmRebuild: false

--- a/python_sidecar/ner_backends/__init__.py
+++ b/python_sidecar/ner_backends/__init__.py
@@ -1,7 +1,9 @@
 """NER backends — one module per backend implementation.
 
-Each backend exposes a `predict(segments, hf_id, model_dir, progress_cb) -> tuple[list[dict], str]`
-function returning (entities, model_id). Native entity-type strings are passed
-through unchanged; the TypeScript-side `entity-merger.ts` performs canonical
-mapping based on `metadata.backend` in the sidecar output.
+Each backend exposes a `predict(segments, hf_id, model_dir, progress_cb) -> list[dict]`
+function returning detected entities in native (backend-specific) format. The
+TypeScript-side `entity-merger.ts` performs canonical mapping based on the
+`metadata.backend` field that the dispatcher sets in the sidecar output.
+
+See `base.py` for the authoritative `BackendPredictFn` Protocol.
 """

--- a/python_sidecar/ner_backends/__init__.py
+++ b/python_sidecar/ner_backends/__init__.py
@@ -1,0 +1,7 @@
+"""NER backends — one module per backend implementation.
+
+Each backend exposes a `predict(segments, hf_id, model_dir, progress_cb) -> tuple[list[dict], str]`
+function returning (entities, model_id). Native entity-type strings are passed
+through unchanged; the TypeScript-side `entity-merger.ts` performs canonical
+mapping based on `metadata.backend` in the sidecar output.
+"""

--- a/python_sidecar/ner_backends/base.py
+++ b/python_sidecar/ner_backends/base.py
@@ -1,0 +1,34 @@
+"""Abstract base / shared types for NER backends.
+
+Backends are plain functions (no class hierarchy needed) that conform to:
+
+    predict(
+        segments: list[dict],   # transcript segments with .text, .start, .end
+        hf_id: str,             # HuggingFace identifier (e.g. "flair/ner-german-large")
+        model_dir: str,         # local cache root
+        progress_cb: Callable[[int], None],   # progress 0-100 to stderr
+    ) -> list[dict]              # native entities — backend-specific .type strings
+
+Each entity dict has the shape:
+
+    {
+        "text": str,
+        "type": str,            # native type (PER/LOC/MISC for flair, etc.)
+        "segmentIndex": int,
+        "charStart": int,
+        "charEnd": int,
+        "confidence": float,    # 0-1
+    }
+"""
+
+from typing import Callable, Protocol
+
+
+class BackendPredictFn(Protocol):
+    def __call__(
+        self,
+        segments: list[dict],
+        hf_id: str,
+        model_dir: str,
+        progress_cb: Callable[[int], None],
+    ) -> list[dict]: ...

--- a/python_sidecar/ner_backends/flair_backend.py
+++ b/python_sidecar/ner_backends/flair_backend.py
@@ -1,0 +1,63 @@
+"""flair NER backend — uses flair/ner-german-large by default.
+
+Native entity types: PER, LOC, MISC, ORG. (ORG is filtered TS-side per
+Decision #5/#158.)
+"""
+
+import logging
+import os
+import sys
+from typing import Callable
+
+
+def predict(
+    segments: list[dict],
+    hf_id: str,
+    model_dir: str,
+    progress_cb: Callable[[int], None],
+) -> list[dict]:
+    # Heavy imports inside predict() — only loaded when this backend is selected.
+    import flair
+    from flair.data import Sentence
+    from flair.nn import Classifier
+
+    # Redirect flair's logger from stdout to stderr so JSON output stays clean.
+    flair.logger.handlers.clear()
+    flair.logger.addHandler(logging.StreamHandler(sys.stderr))
+
+    # flair caches under FLAIR_CACHE_ROOT; point it at our model directory.
+    os.environ["FLAIR_CACHE_ROOT"] = model_dir
+
+    progress_cb(10)
+
+    tagger = Classifier.load(hf_id)
+
+    progress_cb(25)
+
+    entities: list[dict] = []
+    total = len(segments)
+    for idx, segment in enumerate(segments):
+        text = segment.get("text", "")
+        if not text.strip():
+            continue
+
+        sentence = Sentence(text)
+        tagger.predict(sentence)
+
+        for entity in sentence.get_spans("ner"):
+            entities.append(
+                {
+                    "text": entity.text,
+                    "type": entity.get_label("ner").value,
+                    "segmentIndex": idx,
+                    "charStart": entity.start_position,
+                    "charEnd": entity.end_position,
+                    "confidence": round(entity.get_label("ner").score, 4),
+                }
+            )
+
+        # Progress: 25-95% mapped to segment processing
+        pct = 25 + int((idx + 1) / total * 70)
+        progress_cb(min(pct, 95))
+
+    return entities

--- a/python_sidecar/ner_service.py
+++ b/python_sidecar/ner_service.py
@@ -1,20 +1,30 @@
 #!/usr/bin/env python3
-"""
-Named Entity Recognition service using flair/ner-german-large.
+"""Named Entity Recognition dispatcher.
 
-Processes transcript segments and outputs detected entities in JSON format to stdout.
-Progress is reported to stderr for parsing by the Electron main process.
+Selects a backend (flair / gliner / ai4privacy) and forwards segment-level
+prediction to the corresponding `ner_backends/<backend>_backend.py` module.
+Native entity-type strings are passed through unchanged; canonical mapping
+to Therascript's PlaceholderType happens TypeScript-side in entity-merger.ts.
 
 Usage:
-    python3 ner_service.py --transcript <path> [--model-dir <path>]
+    python3 ner_service.py \
+        --transcript <path> \
+        --backend <flair|gliner|ai4privacy> \
+        --hf-model <huggingface-identifier> \
+        [--model-dir <path>]
 
 Output format (stdout JSON):
     {
       "entities": [
-        {"text": "Dr. Müller", "type": "PER", "segment_index": 0,
-         "char_start": 0, "char_end": 10, "confidence": 0.96}
+        {"text": "Dr. Müller", "type": "PER", "segmentIndex": 0,
+         "charStart": 0, "charEnd": 10, "confidence": 0.96}
       ],
-      "metadata": {"model": "flair/ner-german-large", ...}
+      "metadata": {
+        "backend": "flair",
+        "model": "flair/ner-german-large",
+        "segmentCount": N,
+        "entityCount": N
+      }
     }
 
 Progress format (stderr):
@@ -34,6 +44,13 @@ import json
 import os
 import sys
 
+# Force offline loading in production. Both env vars must be set BEFORE any
+# huggingface_hub / transformers / flair / gliner import; the backend modules
+# import these libraries lazily inside predict(), so setting them here is safe.
+# Mirrors the pattern in diarize.py.
+os.environ.setdefault("HF_HUB_OFFLINE", "1")
+os.environ.setdefault("TRANSFORMERS_OFFLINE", "1")
+
 
 def report_progress(percent: int) -> None:
     """Print progress to stderr for TaskExecutor parsing."""
@@ -41,12 +58,23 @@ def report_progress(percent: int) -> None:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="NER via flair/ner-german-large")
+    parser = argparse.ArgumentParser(description="NER dispatcher (flair/gliner/ai4privacy)")
     parser.add_argument("--transcript", required=True, help="Path to transcript JSON file")
+    parser.add_argument(
+        "--backend",
+        required=True,
+        choices=["flair", "gliner", "ai4privacy"],
+        help="NER backend to dispatch to",
+    )
+    parser.add_argument(
+        "--hf-model",
+        required=True,
+        help="HuggingFace identifier of the model to load",
+    )
     parser.add_argument(
         "--model-dir",
         default=os.path.expanduser("~/.therascript/models/ner"),
-        help="Directory for flair model cache",
+        help="Directory for backend model cache",
     )
     args = parser.parse_args()
 
@@ -71,7 +99,8 @@ def main() -> None:
         result = {
             "entities": [],
             "metadata": {
-                "model": "flair/ner-german-large",
+                "backend": args.backend,
+                "model": args.hf_model,
                 "segmentCount": 0,
                 "entityCount": 0,
             },
@@ -82,83 +111,52 @@ def main() -> None:
 
     report_progress(5)
 
-    # Import flair (heavy import, ~3-5s)
+    # Dispatch to backend
     try:
-        import logging
-
-        import flair
-        from flair.data import Sentence
-        from flair.nn import Classifier
-
-        # Redirect flair's logger from stdout to stderr so JSON output stays clean
-        flair.logger.handlers.clear()
-        flair.logger.addHandler(logging.StreamHandler(sys.stderr))
+        if args.backend == "flair":
+            from ner_backends import flair_backend as backend
+        elif args.backend == "gliner":
+            from ner_backends import gliner_backend as backend  # type: ignore
+        elif args.backend == "ai4privacy":
+            from ner_backends import ai4privacy_backend as backend  # type: ignore
+        else:
+            print(f"Fehler: Unbekanntes Backend '{args.backend}'", file=sys.stderr)
+            sys.exit(1)
     except ImportError as e:
-        print(f"Fehler: Benötigtes Paket nicht installiert: {e}", file=sys.stderr)
+        print(f"Fehler: Backend '{args.backend}' nicht verfügbar: {e}", file=sys.stderr)
         print(
             "Führen Sie scripts/setup-ner.sh aus, um Abhängigkeiten zu installieren.",
             file=sys.stderr,
         )
         sys.exit(2)
 
-    report_progress(10)
-
-    # Load NER model
+    # Load model + run prediction
     try:
-        # flair caches models in ~/.flair/ by default
-        # We set FLAIR_CACHE_ROOT to keep models in our directory
-        os.environ["FLAIR_CACHE_ROOT"] = args.model_dir
-        tagger = Classifier.load("flair/ner-german-large")
-    except Exception as e:
-        print(f"Fehler: NER-Modell konnte nicht geladen werden: {e}", file=sys.stderr)
+        entities = backend.predict(
+            segments=segments,
+            hf_id=args.hf_model,
+            model_dir=args.model_dir,
+            progress_cb=report_progress,
+        )
+    except FileNotFoundError as e:
+        print(f"Fehler: Modell-Datei nicht gefunden ({args.backend}): {e}", file=sys.stderr)
         print(
             "Führen Sie scripts/setup-ner.sh --model aus, um das Modell herunterzuladen.",
             file=sys.stderr,
         )
         sys.exit(2)
-
-    report_progress(25)
-
-    # Process segments
-    all_entities = []
-    total = len(segments)
-
-    try:
-        for idx, segment in enumerate(segments):
-            text = segment.get("text", "")
-            if not text.strip():
-                continue
-
-            sentence = Sentence(text)
-            tagger.predict(sentence)
-
-            for entity in sentence.get_spans("ner"):
-                all_entities.append(
-                    {
-                        "text": entity.text,
-                        "type": entity.get_label("ner").value,
-                        "segmentIndex": idx,
-                        "charStart": entity.start_position,
-                        "charEnd": entity.end_position,
-                        "confidence": round(entity.get_label("ner").score, 4),
-                    }
-                )
-
-            # Report progress: 25-95% range mapped to segment processing
-            pct = 25 + int((idx + 1) / total * 70)
-            report_progress(min(pct, 95))
-
     except Exception as e:
-        print(f"Fehler: NER-Verarbeitung fehlgeschlagen: {e}", file=sys.stderr)
+        print(f"Fehler: NER-Verarbeitung fehlgeschlagen ({args.backend}): {e}", file=sys.stderr)
         sys.exit(3)
 
     # Output result
     result = {
-        "entities": all_entities,
+        "entities": entities,
         "metadata": {
-            "model": "flair/ner-german-large",
-            "segmentCount": total,
-            "entityCount": len(all_entities),
+            "backend": args.backend,
+            "model": args.hf_model,
+            "segmentCount": len(segments),
+            "entityCount": len(entities),
         },
     }
 

--- a/src/main/ml/AnonymizationService.ts
+++ b/src/main/ml/AnonymizationService.ts
@@ -16,6 +16,8 @@ import { buildTipTapDocument } from './tiptap-builder'
 import { countWords } from '../../shared/utils/countWords'
 import { resolvePythonSidecar } from './resolve-python'
 import { writeFileAtomic } from '../utils/file-ops'
+import { getModelById } from '../services/ModelDownloadService'
+import { getSettings } from '../services/SettingsService'
 
 // Progress line format: "[PROGRESS] 42"
 const PROGRESS_REGEX = /\[PROGRESS\]\s*(\d+)/
@@ -57,51 +59,70 @@ export class AnonymizationService implements TaskExecutor {
 
     onProgress(0.05)
 
-    // 2. Run Python NER sidecar (0.05 → 0.50)
-    const nerEntities = await this.runNerSidecar(
+    // 2. Resolve active NER model + backend from settings
+    const activeNerId = getSettings().get('activeModels').ner
+    const nerModel = getModelById(activeNerId)
+    if (!nerModel || nerModel.group !== 'ner' || !nerModel.nerBackend || !nerModel.hfIdentifier) {
+      throw new Error(
+        `Anonymisierung: aktives NER-Modell "${activeNerId}" ist ungültig oder unvollständig konfiguriert (backend/hfIdentifier fehlt).`
+      )
+    }
+
+    // 3. Run Python NER sidecar (0.05 → 0.50)
+    const nerOutput = await this.runNerSidecar(
       transcriptSource,
+      nerModel.nerBackend,
+      nerModel.hfIdentifier,
       (nerProgress) => onProgress(0.05 + nerProgress * 0.45),
       signal
     )
+    const nerEntities = nerOutput.entities
 
     onProgress(0.5)
 
-    // 3. Run regex engine
+    // 4. Run regex engine
     const regexEntities = runRegexEngine(transcript.segments)
 
     onProgress(0.55)
 
-    // 4. Load blocklist from DB
+    // 5. Load blocklist from DB
     const blocklistRepo = new BlocklistRepository(db)
     const blocklistEntries = blocklistRepo.findAll()
 
     onProgress(0.6)
 
-    // 5. Merge entities (NER > Blocklist > Regex)
-    const merged = mergeEntities(nerEntities, regexEntities, blocklistEntries, transcript.segments)
+    // 6. Merge entities (NER > Blocklist > Regex). Backend is read from sidecar metadata so the
+    //    merger uses the correct native→canonical mapper, even if settings changed mid-run.
+    const merged = mergeEntities(
+      nerEntities,
+      regexEntities,
+      blocklistEntries,
+      transcript.segments,
+      nerOutput.metadata.backend
+    )
 
     onProgress(0.7)
 
-    // 6. Resolve coreferences (PERSON entities)
+    // 7. Resolve coreferences (PERSON entities)
     const resolved = resolveCoreferences(merged)
 
     onProgress(0.75)
 
-    // 7. Build EntityMap
+    // 8. Build EntityMap
     const entityMap = buildEntityMap(resolved)
 
     onProgress(0.8)
 
-    // 8. Determine speaker count for TipTap document
+    // 9. Determine speaker count for TipTap document
     const uniqueSpeakers = new Set(transcript.segments.map((s) => s.speaker).filter(Boolean))
     const speakerCount = uniqueSpeakers.size
 
-    // 9. Build TipTap document
+    // 10. Build TipTap document
     const tiptapDoc = buildTipTapDocument(transcript.segments, entityMap, resolved, speakerCount)
 
     onProgress(0.9)
 
-    // 10. Save results
+    // 11. Save results
     const anonymizedPath = sessionService.generateAnonymizedPath(task.sessionId)
     writeFileAtomic(anonymizedPath, JSON.stringify(tiptapDoc, null, 2))
 
@@ -118,9 +139,11 @@ export class AnonymizationService implements TaskExecutor {
 
   private runNerSidecar(
     transcriptPath: string,
+    backend: string,
+    hfModel: string,
     onProgress: (progress: number) => void,
     signal?: AbortSignal
-  ): Promise<NerServiceOutput['entities']> {
+  ): Promise<NerServiceOutput> {
     return new Promise((resolve, reject) => {
       const { bin, args: prefixArgs } = this.getCommand()
 
@@ -130,7 +153,17 @@ export class AnonymizationService implements TaskExecutor {
       }
 
       const modelDir = this.getModelDir()
-      const args = [...prefixArgs, '--transcript', transcriptPath, '--model-dir', modelDir]
+      const args = [
+        ...prefixArgs,
+        '--transcript',
+        transcriptPath,
+        '--backend',
+        backend,
+        '--hf-model',
+        hfModel,
+        '--model-dir',
+        modelDir
+      ]
 
       // QoS: nice -n 10 (NFR-23)
       const proc = spawn('nice', ['-n', '10', bin, ...args], {
@@ -230,7 +263,7 @@ export class AnonymizationService implements TaskExecutor {
         // Parse JSON output
         try {
           const result = JSON.parse(stdout) as NerServiceOutput
-          resolve(result.entities)
+          resolve(result)
         } catch (parseError) {
           reject(
             new Error(

--- a/src/main/ml/__tests__/entity-merger.test.ts
+++ b/src/main/ml/__tests__/entity-merger.test.ts
@@ -1,5 +1,11 @@
-import { describe, it, expect } from 'vitest'
-import { mergeEntities, normalizeUmlaut, isWholeWord } from '../entity-merger'
+import { describe, it, expect, vi } from 'vitest'
+import {
+  mergeEntities,
+  normalizeUmlaut,
+  isWholeWord,
+  mapFlairType,
+  mapNativeType
+} from '../entity-merger'
 import type { TranscriptSegment } from '../../../shared/types'
 import type { NerEntity, RegexEntity, BlocklistEntry } from '../../../shared/types/NerTypes'
 
@@ -194,5 +200,82 @@ describe('mergeEntities', () => {
     expect(result[0].text).toBe('Peter')
     expect(result[1].text).toBe('Bern')
     expect(result[2].text).toBe('Anna')
+  })
+})
+
+describe('mapFlairType', () => {
+  it('maps PER to PERSON', () => {
+    expect(mapFlairType('PER')).toBe('PERSON')
+  })
+
+  it('maps LOC to ORT', () => {
+    expect(mapFlairType('LOC')).toBe('ORT')
+  })
+
+  it('maps MISC to SONSTIGES', () => {
+    expect(mapFlairType('MISC')).toBe('SONSTIGES')
+  })
+
+  it('drops ORG (Decision #5/#158)', () => {
+    expect(mapFlairType('ORG')).toBeNull()
+  })
+
+  it('drops unknown types', () => {
+    expect(mapFlairType('UNKNOWN_TYPE')).toBeNull()
+  })
+})
+
+describe('mapNativeType (backend dispatcher)', () => {
+  it('flair backend delegates to mapFlairType', () => {
+    expect(mapNativeType('flair', 'PER')).toBe('PERSON')
+    expect(mapNativeType('flair', 'LOC')).toBe('ORT')
+    expect(mapNativeType('flair', 'ORG')).toBeNull()
+  })
+
+  it('gliner backend drops everything until mapper is wired (Phase 2)', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    expect(mapNativeType('gliner', 'Person')).toBeNull()
+    expect(warn).toHaveBeenCalled()
+    warn.mockRestore()
+  })
+
+  it('ai4privacy backend drops everything until mapper is wired (Phase 2)', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    expect(mapNativeType('ai4privacy', 'GIVENNAME')).toBeNull()
+    expect(warn).toHaveBeenCalled()
+    warn.mockRestore()
+  })
+})
+
+describe('mergeEntities backend dispatch', () => {
+  it('uses flair mapping by default when no backend is passed', () => {
+    const segments = [seg('Peter wohnt in Bern')]
+    const nerEntities: NerEntity[] = [
+      { text: 'Peter', type: 'PER', segmentIndex: 0, charStart: 0, charEnd: 5, confidence: 0.9 }
+    ]
+    const result = mergeEntities(nerEntities, [], [], segments)
+    expect(result).toHaveLength(1)
+    expect(result[0].type).toBe('PERSON')
+  })
+
+  it('explicit flair backend gives identical result to default', () => {
+    const segments = [seg('Peter wohnt in Bern')]
+    const nerEntities: NerEntity[] = [
+      { text: 'Peter', type: 'PER', segmentIndex: 0, charStart: 0, charEnd: 5, confidence: 0.9 }
+    ]
+    const result = mergeEntities(nerEntities, [], [], segments, 'flair')
+    expect(result).toHaveLength(1)
+    expect(result[0].type).toBe('PERSON')
+  })
+
+  it('gliner backend drops all entities until Phase 2 wires its mapper', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const segments = [seg('Peter wohnt in Bern')]
+    const nerEntities: NerEntity[] = [
+      { text: 'Peter', type: 'Person', segmentIndex: 0, charStart: 0, charEnd: 5, confidence: 0.9 }
+    ]
+    const result = mergeEntities(nerEntities, [], [], segments, 'gliner')
+    expect(result).toHaveLength(0)
+    warn.mockRestore()
   })
 })

--- a/src/main/ml/entity-merger.ts
+++ b/src/main/ml/entity-merger.ts
@@ -36,9 +36,10 @@ export function mapFlairType(nativeType: string): PlaceholderType | null {
  * Backend-aware mapping from native NER entity type to canonical PlaceholderType.
  * Returns `null` for types that should be filtered out (e.g. ORG, non-PII).
  *
- * Phase 1 only supports the flair backend; gliner/ai4privacy mappers are added
- * in subsequent phases per the design spec
- * (`docs/superpowers/specs/2026-04-24-multi-anonymization-models-design.md`).
+ * `gliner` and `ai4privacy` are accepted as discriminator values but have no
+ * canonical mapper yet — entities from those backends are dropped with a
+ * `console.warn` rather than being mis-mapped through flair semantics
+ * (different label vocabularies make a fall-through unsafe).
  */
 export function mapNativeType(
   backend: NerBackend,
@@ -49,11 +50,8 @@ export function mapNativeType(
       return mapFlairType(nativeType)
     case 'gliner':
     case 'ai4privacy':
-      // Backend modules exist but TS-side mapper is not yet wired (Phase 2/3).
-      // Falling through to flair is unsafe (different label vocabulary), so the
-      // safer behavior is to drop everything until the mapper is added.
       console.warn(
-        `[entity-merger] mapNativeType called for backend "${backend}" before its mapper is wired — dropping entity "${nativeType}"`
+        `[entity-merger] mapNativeType called for backend "${backend}" but no mapper is implemented — dropping entity "${nativeType}"`
       )
       return null
   }
@@ -77,8 +75,8 @@ function overlapsWithExisting(
  * - Whole-word boundary check applied to all
  * - Overlapping entities are skipped (first-come wins by priority)
  *
- * `nerBackend` discriminates how to translate native types to canonical types.
- * Defaults to 'flair' for backward-compat with existing callers.
+ * `nerBackend` discriminates how native NER types translate to canonical types.
+ * Defaults to 'flair'.
  */
 export function mergeEntities(
   nerEntities: NerEntity[],

--- a/src/main/ml/entity-merger.ts
+++ b/src/main/ml/entity-merger.ts
@@ -3,7 +3,8 @@ import type {
   NerEntity,
   RegexEntity,
   MergedEntity,
-  BlocklistEntry
+  BlocklistEntry,
+  NerBackend
 } from '../../shared/types/NerTypes'
 import { mapRegexTypeToPlaceholder } from './regex-patterns'
 import {
@@ -15,9 +16,9 @@ import {
 // Re-export shared utilities for existing consumers
 export { normalizeUmlaut, isWholeWord }
 
-/** Map flair NER type to Therascript placeholder type */
-function mapNerType(nerType: string): PlaceholderType | null {
-  switch (nerType) {
+/** Map flair native type → canonical PlaceholderType. ORG ignored per Decision #5/#158. */
+export function mapFlairType(nativeType: string): PlaceholderType | null {
+  switch (nativeType) {
     case 'PER':
       return 'PERSON'
     case 'LOC':
@@ -25,9 +26,35 @@ function mapNerType(nerType: string): PlaceholderType | null {
     case 'MISC':
       return 'SONSTIGES'
     case 'ORG':
-      // ORG entities are IGNORED per Decision #5/#158
       return null
     default:
+      return null
+  }
+}
+
+/**
+ * Backend-aware mapping from native NER entity type to canonical PlaceholderType.
+ * Returns `null` for types that should be filtered out (e.g. ORG, non-PII).
+ *
+ * Phase 1 only supports the flair backend; gliner/ai4privacy mappers are added
+ * in subsequent phases per the design spec
+ * (`docs/superpowers/specs/2026-04-24-multi-anonymization-models-design.md`).
+ */
+export function mapNativeType(
+  backend: NerBackend,
+  nativeType: string
+): PlaceholderType | null {
+  switch (backend) {
+    case 'flair':
+      return mapFlairType(nativeType)
+    case 'gliner':
+    case 'ai4privacy':
+      // Backend modules exist but TS-side mapper is not yet wired (Phase 2/3).
+      // Falling through to flair is unsafe (different label vocabulary), so the
+      // safer behavior is to drop everything until the mapper is added.
+      console.warn(
+        `[entity-merger] mapNativeType called for backend "${backend}" before its mapper is wired — dropping entity "${nativeType}"`
+      )
       return null
   }
 }
@@ -49,18 +76,22 @@ function overlapsWithExisting(
  * - ORG entities from NER are ignored (Decision #5/#158)
  * - Whole-word boundary check applied to all
  * - Overlapping entities are skipped (first-come wins by priority)
+ *
+ * `nerBackend` discriminates how to translate native types to canonical types.
+ * Defaults to 'flair' for backward-compat with existing callers.
  */
 export function mergeEntities(
   nerEntities: NerEntity[],
   regexEntities: RegexEntity[],
   blocklistEntries: BlocklistEntry[],
-  segments: TranscriptSegment[]
+  segments: TranscriptSegment[],
+  nerBackend: NerBackend = 'flair'
 ): MergedEntity[] {
   const merged: MergedEntity[] = []
 
   // 1. NER entities (highest priority)
   for (const entity of nerEntities) {
-    const placeholderType = mapNerType(entity.type)
+    const placeholderType = mapNativeType(nerBackend, entity.type)
     if (!placeholderType) continue // Skip ORG and unknown types
 
     const segText = segments[entity.segmentIndex]?.text

--- a/src/main/services/ModelDownloadService.ts
+++ b/src/main/services/ModelDownloadService.ts
@@ -5,6 +5,7 @@ import { getDataDir } from '../db/connection'
 import { getSettings } from './SettingsService'
 import { downloadFile, verifyFileSha256, extractTarGz } from './DownloadService'
 import type { ModelGroup } from '../../shared/validation/model-catalog-schemas'
+import type { NerBackend } from '../../shared/types/NerTypes'
 
 const R2_CDN = 'https://pub-f6971d643e3a464ba6977c0816c43e50.r2.dev'
 
@@ -31,6 +32,8 @@ export interface ModelDefinition {
   speedScore?: number
   // Nur für Diarization relevant — pyannote-Pipelines laden via from_pretrained(hfIdentifier).
   hfIdentifier?: string
+  // Nur für NER-Gruppe gesetzt — discriminator, an den Python-Dispatcher (ner_service.py --backend) durchgereicht.
+  nerBackend?: NerBackend
 }
 
 export interface ModelDownloadProgress {
@@ -126,7 +129,9 @@ const MODEL_DEFINITIONS: ModelDefinition[] = [
     sha256: 'a34f6315659a34991930dae5d7a2bc2f3ee24ff6eb70dcd4d41e3aca7a5253e6',
     archive: true,
     group: 'ner',
-    isRequired: true
+    isRequired: true,
+    hfIdentifier: 'flair/ner-german-large',
+    nerBackend: 'flair'
   }
 ]
 

--- a/src/main/services/ModelDownloadService.ts
+++ b/src/main/services/ModelDownloadService.ts
@@ -30,9 +30,12 @@ export interface ModelDefinition {
   languages?: string[]
   accuracyScore?: number
   speedScore?: number
-  // Nur für Diarization relevant — pyannote-Pipelines laden via from_pretrained(hfIdentifier).
+  // HuggingFace-Identifier — durchgereicht an Python-Sidecars für from_pretrained()
+  // (pyannote, transformers) bzw. Classifier.load() (flair). Für Whisper-/Vision-OCR-
+  // Modelle ohne HF-Pipeline undefiniert.
   hfIdentifier?: string
-  // Nur für NER-Gruppe gesetzt — discriminator, an den Python-Dispatcher (ner_service.py --backend) durchgereicht.
+  // NER-Backend-Discriminator — wählt das Python-Modul in ner_backends/, an
+  // ner_service.py --backend durchgereicht. Nur für group: 'ner' relevant.
   nerBackend?: NerBackend
 }
 

--- a/src/shared/types/NerTypes.ts
+++ b/src/shared/types/NerTypes.ts
@@ -1,9 +1,17 @@
 import type { EntitySource, PlaceholderType } from './EntityMap'
 
-/** Entity detected by flair NER (from Python sidecar output) */
+/**
+ * Identifier of the active NER backend implementation. Each backend produces
+ * its own native entity-type strings; the TS-side `entity-merger.ts` dispatches
+ * on this discriminator to choose the right canonical mapping.
+ */
+export type NerBackend = 'flair' | 'gliner' | 'ai4privacy'
+
+/** Entity detected by NER (from Python sidecar output). The native `type` string
+ * is backend-specific; see `entity-merger.ts` for the per-backend mapping. */
 export interface NerEntity {
   text: string
-  type: string // flair type: PER, LOC, ORG, MISC
+  type: string
   segmentIndex: number
   charStart: number
   charEnd: number
@@ -35,6 +43,9 @@ export interface MergedEntity {
 export interface NerServiceOutput {
   entities: NerEntity[]
   metadata: {
+    /** Backend identifier — drives canonical-type mapping in `entity-merger.ts`. */
+    backend: NerBackend
+    /** HuggingFace identifier of the loaded model (e.g. `flair/ner-german-large`). */
     model: string
     segmentCount: number
     entityCount: number


### PR DESCRIPTION
## Summary

Foundation refactor for the multi-anonymization-models feature — see the [design spec](docs/superpowers/specs/2026-04-24-multi-anonymization-models-design.md) on develop.

This PR is **Phase 1 of 3**, behaviour-preserving for the existing flair pipeline. It introduces the dispatcher abstraction so Phase 2 (ai4privacy) and Phase 3 (GLiNER) can land cleanly without touching the merger or sidecar plumbing again.

## What changed

- **Python sidecar** — [ner_service.py](python_sidecar/ner_service.py) becomes a thin dispatcher. flair logic moved to [ner_backends/flair_backend.py](python_sidecar/ner_backends/flair_backend.py). New required CLI flags `--backend` and `--hf-model`. `HF_HUB_OFFLINE` / `TRANSFORMERS_OFFLINE` set in the dispatcher before any backend import (mirror of the diarize.py pattern).
- **Type system** — new `NerBackend = 'flair' | 'gliner' | 'ai4privacy'` discriminator. `NerServiceOutput.metadata` gains required `backend` field.
- **ModelDefinition** — new optional `nerBackend` field; flair entry now carries `hfIdentifier` + `nerBackend` so the active model fully describes how to invoke the sidecar.
- **entity-merger.ts** — `mapNerType` renamed to `mapFlairType` (exported); new `mapNativeType(backend, type)` dispatcher. `mergeEntities` accepts an optional `nerBackend` (defaults to `'flair'` for backward compat). gliner/ai4privacy mappers are stubs that drop entities + warn until Phase 2/3 wires them.
- **AnonymizationService.ts** — reads `activeModels.ner` from settings, passes `--backend` + `--hf-model` to the sidecar, threads `metadata.backend` from the sidecar response into the merger so a stale settings change mid-run doesn't produce a wrong canonical mapping.
- **electron-builder.yml** — `ner_backends/` now bundled into `ml_sidecar/`.

## Validation

- `npm run typecheck` — passes
- `npm test` — 616 tests pass (605 existing + 11 new for backend dispatch)
- `python3 -m py_compile` on all new/changed Python files — passes
- `ner_service.py --help` smoke test — passes

## Test plan

- [ ] Manually run an existing recording through the flair anonymization pipeline; verify identical output to before (same placeholders, same chip types).
- [ ] Verify the sidecar still starts cleanly in the dev venv (`scripts/setup-ner.sh`).
- [ ] Verify the production sidecar bundle includes `ner_backends/` after `npm run package` (if testing a packaged build).

## Not included (follow-up phases)

- **Phase 2**: ai4privacy backend module + ModelDefinition + Pre-Ship-Eval gate
- **Phase 3**: GLiNER backend + UI section in `ModelsSettings.tsx` + R2 packaging for the new models
- Default switch to ai4privacy (gated by Pre-Ship eval per spec)

🤖 Generated with [Claude Code](https://claude.com/claude-code)