### PR TITLE
feat(ner): add ai4privacy OpenPII backend (Phase 2 of multi-anonymization)

### DIFF
--- a/python_sidecar/ner_backends/ai4privacy_backend.py
+++ b/python_sidecar/ner_backends/ai4privacy_backend.py
@@ -1,0 +1,77 @@
+"""ai4privacy NER backend — uses ai4privacy/llama-...-openpii (ModernBERT-based).
+
+Despite the "llama-" prefix, the model is a ModernBERT-base token-classifier
+(~100M params, ~400 MB on disk). Native entity types (21 classes):
+GIVENNAME, SURNAME, TITLE, CITY, STREET, BUILDINGNUM, ZIPCODE, EMAIL,
+TELEPHONENUM, DATE, TIME, AGE, SEX, GENDER, CREDITCARDNUMBER, SOCIALNUM,
+IDCARDNUM, PASSPORTNUM, DRIVERLICENSENUM, TAXNUM, O.
+
+The TypeScript-side `mapAi4PrivacyType` maps these to canonical PlaceholderType
+values (see entity-merger.ts).
+"""
+
+from typing import Callable
+
+
+def predict(
+    segments: list[dict],
+    hf_id: str,
+    model_dir: str,
+    progress_cb: Callable[[int], None],
+) -> list[dict]:
+    # Heavy imports inside predict() — only loaded when this backend is selected.
+    from transformers import AutoModelForTokenClassification, AutoTokenizer, pipeline
+
+    progress_cb(10)
+
+    tokenizer = AutoTokenizer.from_pretrained(
+        hf_id,
+        cache_dir=model_dir,
+        local_files_only=True,
+    )
+    model = AutoModelForTokenClassification.from_pretrained(
+        hf_id,
+        cache_dir=model_dir,
+        local_files_only=True,
+    )
+
+    progress_cb(20)
+
+    # aggregation_strategy="simple" merges B-/I- subword tokens back into spans.
+    ner = pipeline(
+        "ner",
+        model=model,
+        tokenizer=tokenizer,
+        aggregation_strategy="simple",
+    )
+
+    progress_cb(25)
+
+    entities: list[dict] = []
+    total = len(segments)
+    for idx, segment in enumerate(segments):
+        text = segment.get("text", "")
+        if not text.strip():
+            continue
+
+        spans = ner(text)
+
+        # transformers pipeline returns dicts with keys: entity_group, score, word, start, end
+        for span in spans:
+            entity_group = span.get("entity_group") or span.get("entity", "")
+            entities.append(
+                {
+                    "text": span.get("word", text[int(span["start"]) : int(span["end"])]),
+                    "type": entity_group,
+                    "segmentIndex": idx,
+                    "charStart": int(span["start"]),
+                    "charEnd": int(span["end"]),
+                    "confidence": round(float(span["score"]), 4),
+                }
+            )
+
+        # Progress: 25-95% mapped to segment processing
+        pct = 25 + int((idx + 1) / total * 70)
+        progress_cb(min(pct, 95))
+
+    return entities

--- a/python_sidecar/requirements-ner.txt
+++ b/python_sidecar/requirements-ner.txt
@@ -1,1 +1,6 @@
 flair>=0.13.0
+# Explicit transformers requirement — needed for ai4privacy backend
+# (AutoModelForTokenClassification + ModernBERT support requires >=4.48).
+# flair already pulls in transformers transitively, but CLAUDE.md mandates
+# that all runtime deps be listed in this file as the sole source.
+transformers>=4.48.0

--- a/scripts/package-models.sh
+++ b/scripts/package-models.sh
@@ -75,12 +75,28 @@ fi
 # Pyannote-Suite — monolithisches Paket mit allen vier benötigten Sub-Modellen
 package_pyannote_suite || exit 1
 
-# flair NER model (archive contents extracted INTO ner/)
-if [ -d "$MODELS_DIR/ner" ]; then
-  tar -czf "$OUTPUT_DIR/flair-ner-german-large.tar.gz" -C "$MODELS_DIR/ner" .
+# NER-Tarballs werden mit expliziten Includes gepackt, damit beide Modelle
+# (flair, ai4privacy) friedlich unter $MODELS_DIR/ner/ koexistieren können
+# ohne dass eine Tarball-Erstellung Inhalte des jeweils anderen mitschleppt.
+
+# flair NER model (extrahiert nach ner/models/ner-german-large)
+FLAIR_SUBDIR="models/ner-german-large"
+if [ -d "$MODELS_DIR/ner/$FLAIR_SUBDIR" ]; then
+  tar -czf "$OUTPUT_DIR/flair-ner-german-large.tar.gz" \
+    -C "$MODELS_DIR/ner" "$FLAIR_SUBDIR"
   echo "  -> flair-ner-german-large.tar.gz"
 else
-  echo "  SKIP: flair-Modell nicht gefunden: $MODELS_DIR/ner"
+  echo "  SKIP: flair-Modell nicht gefunden: $MODELS_DIR/ner/$FLAIR_SUBDIR"
+fi
+
+# ai4privacy NER model (HF-Cache-Layout, extrahiert nach ner/models--ai4privacy--…)
+AI4PRIVACY_SUBDIR="models--ai4privacy--llama-ai4privacy-multilingual-categorical-anonymiser-openpii"
+if [ -d "$MODELS_DIR/ner/$AI4PRIVACY_SUBDIR" ]; then
+  tar -czf "$OUTPUT_DIR/ai4privacy-openpii-modernbert.tar.gz" \
+    -C "$MODELS_DIR/ner" "$AI4PRIVACY_SUBDIR"
+  echo "  -> ai4privacy-openpii-modernbert.tar.gz"
+else
+  echo "  SKIP: ai4privacy-Modell nicht gefunden: $MODELS_DIR/ner/$AI4PRIVACY_SUBDIR"
 fi
 
 echo ""

--- a/scripts/publish-manifest.sh
+++ b/scripts/publish-manifest.sh
@@ -75,6 +75,7 @@ declare -a MODELS=(
   "whisper-large-v3-turbo-swiss|whisper-ggml-large-v3-turbo-swiss-q5_0.bin|Whisper Large V3 Turbo (Swiss-German)|asr/ggml-large-v3-turbo-swiss-q5_0.bin|false|asr/ggml-large-v3-turbo-swiss-q5_0.bin"
   "pyannote-suite|pyannote-suite.tar.gz|Sprechererkennung (pyannote)|diarization|true|diarization/models--pyannote--speaker-diarization-community-1"
   "flair-ner-german-large|flair-ner-german-large.tar.gz|Anonymisierung (flair-ner-german-large)|ner|true|ner/models/ner-german-large"
+  "ai4privacy-openpii-modernbert|ai4privacy-openpii-modernbert.tar.gz|Anonymisierung — ai4privacy OpenPII (ModernBERT)|ner|true|ner/models--ai4privacy--llama-ai4privacy-multilingual-categorical-anonymiser-openpii"
 )
 
 # CDN base URL

--- a/src/main/ml/__tests__/entity-merger.test.ts
+++ b/src/main/ml/__tests__/entity-merger.test.ts
@@ -4,6 +4,7 @@ import {
   normalizeUmlaut,
   isWholeWord,
   mapFlairType,
+  mapAi4PrivacyType,
   mapNativeType
 } from '../entity-merger'
 import type { TranscriptSegment } from '../../../shared/types'
@@ -225,6 +226,101 @@ describe('mapFlairType', () => {
   })
 })
 
+describe('mapAi4PrivacyType', () => {
+  it.each([
+    ['GIVENNAME', 'PERSON'],
+    ['SURNAME', 'PERSON'],
+    ['TITLE', 'PERSON']
+  ])('maps person-related %s to PERSON', (native, canonical) => {
+    expect(mapAi4PrivacyType(native)).toBe(canonical)
+  })
+
+  it.each([
+    ['CITY', 'ORT'],
+    ['STREET', 'ORT'],
+    ['BUILDINGNUM', 'ORT'],
+    ['ZIPCODE', 'ORT']
+  ])('maps location-related %s to ORT', (native, canonical) => {
+    expect(mapAi4PrivacyType(native)).toBe(canonical)
+  })
+
+  it.each([
+    ['DATE', 'DATUM'],
+    ['TIME', 'DATUM']
+  ])('maps temporal %s to DATUM', (native, canonical) => {
+    expect(mapAi4PrivacyType(native)).toBe(canonical)
+  })
+
+  it.each([
+    ['EMAIL', 'KONTAKT'],
+    ['TELEPHONENUM', 'KONTAKT'],
+    ['CREDITCARDNUMBER', 'KONTAKT']
+  ])('maps contact-related %s to KONTAKT', (native, canonical) => {
+    expect(mapAi4PrivacyType(native)).toBe(canonical)
+  })
+
+  it.each([
+    'AGE',
+    'SEX',
+    'GENDER',
+    'SOCIALNUM',
+    'IDCARDNUM',
+    'PASSPORTNUM',
+    'DRIVERLICENSENUM',
+    'TAXNUM'
+  ])('maps misc PII %s to SONSTIGES', (native) => {
+    expect(mapAi4PrivacyType(native)).toBe('SONSTIGES')
+  })
+
+  it('drops the O (non-entity) class', () => {
+    expect(mapAi4PrivacyType('O')).toBeNull()
+  })
+
+  it('routes unknown labels to SONSTIGES with a console.warn (schema-drift guard)', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    expect(mapAi4PrivacyType('FUTURE_LABEL_XYZ')).toBe('SONSTIGES')
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('FUTURE_LABEL_XYZ')
+    )
+    warn.mockRestore()
+  })
+
+  it('covers the full 21-label model schema (lock against silent drift)', () => {
+    // Authoritative label set — any change here must be matched by the model card.
+    const labels = [
+      'O',
+      'GIVENNAME',
+      'SURNAME',
+      'TITLE',
+      'CITY',
+      'STREET',
+      'BUILDINGNUM',
+      'ZIPCODE',
+      'DATE',
+      'TIME',
+      'AGE',
+      'SEX',
+      'GENDER',
+      'EMAIL',
+      'TELEPHONENUM',
+      'CREDITCARDNUMBER',
+      'SOCIALNUM',
+      'IDCARDNUM',
+      'PASSPORTNUM',
+      'DRIVERLICENSENUM',
+      'TAXNUM'
+    ]
+    expect(labels).toHaveLength(21)
+    // Every documented label must map without triggering the unknown-label warn.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    for (const label of labels) {
+      mapAi4PrivacyType(label)
+    }
+    expect(warn).not.toHaveBeenCalled()
+    warn.mockRestore()
+  })
+})
+
 describe('mapNativeType (backend dispatcher)', () => {
   it('flair backend delegates to mapFlairType', () => {
     expect(mapNativeType('flair', 'PER')).toBe('PERSON')
@@ -232,16 +328,16 @@ describe('mapNativeType (backend dispatcher)', () => {
     expect(mapNativeType('flair', 'ORG')).toBeNull()
   })
 
-  it('gliner backend drops everything until mapper is wired (Phase 2)', () => {
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
-    expect(mapNativeType('gliner', 'Person')).toBeNull()
-    expect(warn).toHaveBeenCalled()
-    warn.mockRestore()
+  it('ai4privacy backend delegates to mapAi4PrivacyType', () => {
+    expect(mapNativeType('ai4privacy', 'GIVENNAME')).toBe('PERSON')
+    expect(mapNativeType('ai4privacy', 'CITY')).toBe('ORT')
+    expect(mapNativeType('ai4privacy', 'EMAIL')).toBe('KONTAKT')
+    expect(mapNativeType('ai4privacy', 'O')).toBeNull()
   })
 
-  it('ai4privacy backend drops everything until mapper is wired (Phase 2)', () => {
+  it('gliner backend drops everything until mapper is wired', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
-    expect(mapNativeType('ai4privacy', 'GIVENNAME')).toBeNull()
+    expect(mapNativeType('gliner', 'Person')).toBeNull()
     expect(warn).toHaveBeenCalled()
     warn.mockRestore()
   })
@@ -268,7 +364,7 @@ describe('mergeEntities backend dispatch', () => {
     expect(result[0].type).toBe('PERSON')
   })
 
-  it('gliner backend drops all entities until Phase 2 wires its mapper', () => {
+  it('gliner backend drops all entities until its mapper is implemented', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const segments = [seg('Peter wohnt in Bern')]
     const nerEntities: NerEntity[] = [
@@ -277,5 +373,19 @@ describe('mergeEntities backend dispatch', () => {
     const result = mergeEntities(nerEntities, [], [], segments, 'gliner')
     expect(result).toHaveLength(0)
     warn.mockRestore()
+  })
+
+  it('ai4privacy backend maps native PII types into the canonical pipeline', () => {
+    const segments = [seg('Peter Müller wohnt in Bern')]
+    const nerEntities: NerEntity[] = [
+      { text: 'Peter', type: 'GIVENNAME', segmentIndex: 0, charStart: 0, charEnd: 5, confidence: 0.95 },
+      { text: 'Müller', type: 'SURNAME', segmentIndex: 0, charStart: 6, charEnd: 12, confidence: 0.94 },
+      { text: 'Bern', type: 'CITY', segmentIndex: 0, charStart: 22, charEnd: 26, confidence: 0.91 }
+    ]
+    const result = mergeEntities(nerEntities, [], [], segments, 'ai4privacy')
+    expect(result).toHaveLength(3)
+    expect(result.find((e) => e.text === 'Peter')?.type).toBe('PERSON')
+    expect(result.find((e) => e.text === 'Müller')?.type).toBe('PERSON')
+    expect(result.find((e) => e.text === 'Bern')?.type).toBe('ORT')
   })
 })

--- a/src/main/ml/entity-merger.ts
+++ b/src/main/ml/entity-merger.ts
@@ -33,13 +33,62 @@ export function mapFlairType(nativeType: string): PlaceholderType | null {
 }
 
 /**
+ * Map ai4privacy native type → canonical PlaceholderType.
+ *
+ * The model emits 21 classes (verified against the HuggingFace model card for
+ * `ai4privacy/llama-ai4privacy-multilingual-categorical-anonymiser-openpii`).
+ * Native EMAIL/TELEPHONENUM/DATE/ZIPCODE flow through to canonical types and
+ * are reconciled with the regex pipeline by `mergeEntities` (NER > Regex
+ * priority — when both detect the same span, NER wins; when only one does,
+ * its detection is kept). Unknown labels are routed to SONSTIGES with a
+ * `console.warn` so model-update schema drifts surface immediately rather
+ * than silently leaking PII.
+ */
+export function mapAi4PrivacyType(nativeType: string): PlaceholderType | null {
+  switch (nativeType) {
+    case 'O':
+      return null
+    case 'GIVENNAME':
+    case 'SURNAME':
+    case 'TITLE':
+      return 'PERSON'
+    case 'CITY':
+    case 'STREET':
+    case 'BUILDINGNUM':
+    case 'ZIPCODE':
+      return 'ORT'
+    case 'DATE':
+    case 'TIME':
+      return 'DATUM'
+    case 'EMAIL':
+    case 'TELEPHONENUM':
+    case 'CREDITCARDNUMBER':
+      return 'KONTAKT'
+    case 'AGE':
+    case 'SEX':
+    case 'GENDER':
+    case 'SOCIALNUM':
+    case 'IDCARDNUM':
+    case 'PASSPORTNUM':
+    case 'DRIVERLICENSENUM':
+    case 'TAXNUM':
+      return 'SONSTIGES'
+    default:
+      console.warn(
+        `[entity-merger] mapAi4PrivacyType received unknown native type "${nativeType}" — routing to SONSTIGES (model schema may have changed)`
+      )
+      return 'SONSTIGES'
+  }
+}
+
+/**
  * Backend-aware mapping from native NER entity type to canonical PlaceholderType.
  * Returns `null` for types that should be filtered out (e.g. ORG, non-PII).
  *
- * `gliner` and `ai4privacy` are accepted as discriminator values but have no
- * canonical mapper yet — entities from those backends are dropped with a
- * `console.warn` rather than being mis-mapped through flair semantics
- * (different label vocabularies make a fall-through unsafe).
+ * `gliner` is accepted as a discriminator value but has no canonical mapper yet
+ * — entities are dropped with a `console.warn` rather than mis-mapped through
+ * flair/ai4privacy semantics (different label vocabularies make a fall-through
+ * unsafe).
  */
 export function mapNativeType(
   backend: NerBackend,
@@ -48,10 +97,11 @@ export function mapNativeType(
   switch (backend) {
     case 'flair':
       return mapFlairType(nativeType)
-    case 'gliner':
     case 'ai4privacy':
+      return mapAi4PrivacyType(nativeType)
+    case 'gliner':
       console.warn(
-        `[entity-merger] mapNativeType called for backend "${backend}" but no mapper is implemented — dropping entity "${nativeType}"`
+        `[entity-merger] mapNativeType called for backend "gliner" but no mapper is implemented — dropping entity "${nativeType}"`
       )
       return null
   }

--- a/src/main/services/ModelDownloadService.ts
+++ b/src/main/services/ModelDownloadService.ts
@@ -132,8 +132,6 @@ const MODEL_DEFINITIONS: ModelDefinition[] = [
     sha256: 'a34f6315659a34991930dae5d7a2bc2f3ee24ff6eb70dcd4d41e3aca7a5253e6',
     archive: true,
     group: 'ner',
-    // Bleibt First-Launch-Pflichtmodell solange kein UI-Picker für aktives NER-Modell existiert.
-    // Ein zukünftiger Default-Switch auf ai4privacy (gated durch Pre-Ship-Eval) hebt das auf.
     isRequired: true,
     hfIdentifier: 'flair/ner-german-large',
     nerBackend: 'flair',

--- a/src/main/services/ModelDownloadService.ts
+++ b/src/main/services/ModelDownloadService.ts
@@ -124,7 +124,7 @@ const MODEL_DEFINITIONS: ModelDefinition[] = [
   },
   {
     id: 'flair-ner-german-large',
-    label: 'Anonymisierung (flair-ner-german-large)',
+    label: 'Anonymisierung — flair-ner-german-large',
     url: `${R2_CDN}/flair-ner-german-large.tar.gz`,
     relativePath: 'ner',
     checkPath: 'ner/models/ner-german-large',
@@ -132,9 +132,35 @@ const MODEL_DEFINITIONS: ModelDefinition[] = [
     sha256: 'a34f6315659a34991930dae5d7a2bc2f3ee24ff6eb70dcd4d41e3aca7a5253e6',
     archive: true,
     group: 'ner',
+    // Bleibt First-Launch-Pflichtmodell solange kein UI-Picker für aktives NER-Modell existiert.
+    // Ein zukünftiger Default-Switch auf ai4privacy (gated durch Pre-Ship-Eval) hebt das auf.
     isRequired: true,
     hfIdentifier: 'flair/ner-german-large',
-    nerBackend: 'flair'
+    nerBackend: 'flair',
+    description:
+      'XLM-RoBERTa-large (~550M Parameter, ~2.2 GB). Höchste Genauigkeit für Deutsch (F1 92% auf CoNLL-03 DE). Empfohlen wenn Anonymisierungsqualität wichtiger als Geschwindigkeit ist.',
+    languages: ['de'],
+    accuracyScore: 0.92,
+    speedScore: 0.4
+  },
+  {
+    id: 'ai4privacy-openpii-modernbert',
+    label: 'Anonymisierung — ai4privacy OpenPII (ModernBERT)',
+    url: `${R2_CDN}/ai4privacy-openpii-modernbert.tar.gz`,
+    relativePath: 'ner',
+    checkPath: 'ner/models--ai4privacy--llama-ai4privacy-multilingual-categorical-anonymiser-openpii',
+    sizeBytes: 400_000_000,
+    sha256: 'PENDING_AI4PRIVACY_OPENPII_MODERNBERT',
+    archive: true,
+    group: 'ner',
+    isRequired: false,
+    hfIdentifier: 'ai4privacy/llama-ai4privacy-multilingual-categorical-anonymiser-openpii',
+    nerBackend: 'ai4privacy',
+    description:
+      'ModernBERT-base (~100M Parameter, ~400 MB). Multilingual (DE/EN/FR/IT/ES/NL/HI/TE), 21 PII-Klassen, MIT-Lizenz. Schneller und kleiner als flair, F1 91.5% global. Empfohlen für schlanke Installation.',
+    languages: ['multi'],
+    accuracyScore: 0.85,
+    speedScore: 0.85
   }
 ]
 


### PR DESCRIPTION
## Summary

Second NER backend per the [design spec](docs/superpowers/specs/2026-04-24-multi-anonymization-models-design.md) — opt-in only. flair remains the first-launch default; users can install + activate ai4privacy from Settings (UI lands in Phase 3 alongside GLiNER).

This is **Phase 2 of 3**, building on Phase 1's dispatcher foundation (#47).

## What changed

- **Python backend** — [`python_sidecar/ner_backends/ai4privacy_backend.py`](python_sidecar/ner_backends/ai4privacy_backend.py) uses `transformers.AutoModelForTokenClassification` + `pipeline(\"ner\", aggregation_strategy=\"simple\")` so subword tokens are merged back into spans before being emitted. Loads with `local_files_only=True` for offline operation.
- **Canonical mapper** — [`mapAi4PrivacyType`](src/main/ml/entity-merger.ts) covers the model's full **21-class schema** (verified against the HuggingFace card):
  - `GIVENNAME` / `SURNAME` / `TITLE` → `PERSON`
  - `CITY` / `STREET` / `BUILDINGNUM` / `ZIPCODE` → `ORT`
  - `DATE` / `TIME` → `DATUM`
  - `EMAIL` / `TELEPHONENUM` / `CREDITCARDNUMBER` → `KONTAKT`
  - `AGE` / `SEX` / `GENDER` / `SOCIALNUM` / `IDCARDNUM` / `PASSPORTNUM` / `DRIVERLICENSENUM` / `TAXNUM` → `SONSTIGES`
  - `O` is dropped
  - **Unknown labels** route to `SONSTIGES` with a `console.warn` so model-update schema drifts surface immediately rather than silently leaking PII.
- **Dispatch wired** — `mapNativeType('ai4privacy', …)` now routes to the real mapper (no longer the warn-and-drop stub). gliner stays stubbed for Phase 3.
- **ModelDefinition** — new [`ai4privacy-openpii-modernbert`](src/main/services/ModelDownloadService.ts) entry with `sha256: 'PENDING_AI4PRIVACY_OPENPII_MODERNBERT'` placeholder. Real SHA + R2 upload land in a separate ops commit per the standard packaging flow.
- **requirements-ner.txt** — `transformers>=4.48.0` listed explicitly per the CLAUDE.md *\"sole dependency source\"* rule (ModernBERT support requires ≥4.48; flair already pulls transformers transitively, but the rule mandates explicit listing).

## Validation

- `npm run typecheck` — passes
- `npm test` — **640 tests pass** (616 from Phase 1 + 24 new for ai4privacy, including a 21-label schema lock that fails if the documented label set drifts)
- `python3 -m py_compile` on the new backend — passes
- `ner_service.py --help` smoke test — passes

## Test plan

- [ ] After R2 upload + SHA sync (separate ops commit), download the ai4privacy model via Settings and run anonymization on a real recording
- [ ] Verify chip output: PERSON/ORT/DATUM/KONTAKT chips appear correctly mapped from the new backend
- [ ] Verify the existing flair pipeline still works unchanged (ai4privacy is opt-in)
- [ ] Manual log inspection: confirm `console.warn` fires once if the model emits an unexpected label

## Not included (deferred)

- **Flair-default-flip** to ai4privacy → gated by the Pre-Ship-Eval (≥95% PERSON-recall on real test transcripts) per the spec
- **UI in ModelsSettings** → Phase 3 alongside GLiNER, will reuse the existing `ModelCard` component
- **R2 packaging + SHA-256 sync** → separate ops commit (CLAUDE.md gotcha — must be done manually after `package-models.sh`)
- **GLiNER backend** → Phase 3
- **Pre-Ship-Eval-Script** → Phase 3 (gates the default-flip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)