### PR TITLE
feat(ner): GLiNER backend + Settings UI + Pre-Ship-Eval (Phase 3)

### DIFF
--- a/python_sidecar/ner_backends/gliner_backend.py
+++ b/python_sidecar/ner_backends/gliner_backend.py
@@ -1,0 +1,80 @@
+"""GLiNER NER backend — zero-shot multilingual entity recognition.
+
+Uses urchade/gliner_multi-v2.1 by default (~209M params, ~1.16 GB on disk).
+Zero-shot: native entity types are the labels we hand the model at inference
+time. The label list below is intentionally narrow (5 labels) to mirror the
+canonical PlaceholderType values that the TypeScript merger emits — EMAIL/
+PHONE/DATE are deliberately excluded because the regex pipeline covers those
+deterministically with Swiss-format calibration.
+
+The TypeScript-side `mapGlinerType` maps these labels to canonical
+PlaceholderType values (see entity-merger.ts).
+"""
+
+from typing import Callable
+
+# Zero-shot label set — must match the keys in the TS-side mapGlinerType
+# switch. Keep these labels in sync with that mapping.
+GLINER_LABELS_DE = [
+    "Person",
+    "Ort",
+    "Organisation",
+    "Krankheit",
+    "Medikament",
+]
+
+# Confidence threshold for emitted entities — GLiNER's `predict_entities`
+# accepts a threshold parameter; below this score the prediction is dropped.
+# 0.5 is the library default; we set it explicitly so behavior is independent
+# of upstream defaults changing.
+DEFAULT_THRESHOLD = 0.5
+
+
+def predict(
+    segments: list[dict],
+    hf_id: str,
+    model_dir: str,
+    progress_cb: Callable[[int], None],
+) -> list[dict]:
+    # Heavy imports inside predict() — only loaded when this backend is selected.
+    from gliner import GLiNER
+
+    progress_cb(10)
+
+    # GLiNER.from_pretrained respects HF_HUB_OFFLINE / TRANSFORMERS_OFFLINE
+    # (set by the dispatcher) plus its own local_files_only kwarg.
+    model = GLiNER.from_pretrained(
+        hf_id,
+        cache_dir=model_dir,
+        local_files_only=True,
+    )
+
+    progress_cb(25)
+
+    entities: list[dict] = []
+    total = len(segments)
+    for idx, segment in enumerate(segments):
+        text = segment.get("text", "")
+        if not text.strip():
+            continue
+
+        spans = model.predict_entities(text, GLINER_LABELS_DE, threshold=DEFAULT_THRESHOLD)
+
+        # GLiNER returns dicts with: start, end, text, label, score
+        for span in spans:
+            entities.append(
+                {
+                    "text": span.get("text", text[int(span["start"]) : int(span["end"])]),
+                    "type": span["label"],
+                    "segmentIndex": idx,
+                    "charStart": int(span["start"]),
+                    "charEnd": int(span["end"]),
+                    "confidence": round(float(span["score"]), 4),
+                }
+            )
+
+        # Progress: 25-95% mapped to segment processing
+        pct = 25 + int((idx + 1) / total * 70)
+        progress_cb(min(pct, 95))
+
+    return entities

--- a/python_sidecar/requirements-ner.txt
+++ b/python_sidecar/requirements-ner.txt
@@ -4,3 +4,5 @@ flair>=0.13.0
 # flair already pulls in transformers transitively, but CLAUDE.md mandates
 # that all runtime deps be listed in this file as the sole source.
 transformers>=4.48.0
+# Zero-shot NER for the GLiNER backend.
+gliner>=0.2.0

--- a/scripts/eval-ner-backends.py
+++ b/scripts/eval-ner-backends.py
@@ -92,8 +92,9 @@ HF_IDENTIFIERS = {
     "gliner": "urchade/gliner_multi-v2.1",
 }
 
-# Acceptance thresholds per (backend, type) — F1 minimum. Tightest threshold
-# is PERSON recall, because a missed PERSON span is a PII leak.
+# Acceptance thresholds per (backend, "<entity>_<metric>") with metric ∈
+# {precision, recall, f1}. Tightest threshold is PERSON recall, because a
+# missed PERSON span is a PII leak.
 THRESHOLDS = {
     "ai4privacy": {"PERSON_recall": 0.95},
     "gliner": {"PERSON_recall": 0.90},
@@ -102,12 +103,17 @@ THRESHOLDS = {
 
 
 def map_native(backend: str, native_type: str) -> Optional[str]:
-    """Mirror of TS-side mapNativeType. Unknown labels for ai4privacy go
-    to SONSTIGES (matches the schema-drift policy)."""
+    """Mirror of TS-side mapNativeType (entity-merger.ts).
+
+    flair drops unknown labels (its native schema is fixed). ai4privacy and
+    gliner route unknown labels to SONSTIGES (the same schema-drift fallback
+    that the TS-side mappers apply with a console.warn — production code
+    surfaces drift rather than silently leaks PII).
+    """
     mapping = CANONICAL_MAPS[backend]
     if native_type in mapping:
         return mapping[native_type]
-    if backend == "ai4privacy":
+    if backend in ("ai4privacy", "gliner"):
         return "SONSTIGES"
     return None
 

--- a/scripts/eval-ner-backends.py
+++ b/scripts/eval-ner-backends.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+"""Pre-Ship-Eval gate for NER backends.
+
+Runs each available backend against a directory of gold-labeled test transcripts
+and reports Precision/Recall/F1 per (backend, entity-type). Intended use: gate
+the default-backend switch on quality (e.g. ai4privacy must reach >= 95% PERSON
+recall on real Swiss therapy transcripts before it becomes the new default).
+
+Usage:
+    python3 scripts/eval-ner-backends.py \
+        --fixtures tests/fixtures/ner-eval/ \
+        --backends flair ai4privacy gliner \
+        --output eval-report.json
+
+Fixture format (tests/fixtures/ner-eval/<name>.json):
+    {
+      "segments": [{"text": "...", "start": 0, "end": 5, "speaker": "Person A"}],
+      "gold_entities": [
+        {"text": "Peter", "type": "PERSON", "segmentIndex": 0,
+         "charStart": 0, "charEnd": 5}
+      ]
+    }
+
+`type` in gold_entities uses the canonical 7 PlaceholderType values. The
+script invokes each backend through ner_service.py (so production code paths
+are exercised), then maps the native types to canonical via the same logic
+that `entity-merger.ts` would apply (mirrored in this script — see
+CANONICAL_MAPS below).
+
+Exit codes:
+    0 = all configured backends meet their thresholds
+    1 = invalid arguments or fixture directory missing
+    2 = at least one backend failed its threshold
+
+This script is intentionally script-only — it is NOT a vitest test. It is
+gated by the availability of real test fixtures, which contain anonymized
+patient data and live outside the repo.
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+
+# Mirror of entity-merger.ts mappings — must stay in lock-step.
+CANONICAL_MAPS: dict[str, dict[str, Optional[str]]] = {
+    "flair": {
+        "PER": "PERSON",
+        "LOC": "ORT",
+        "MISC": "SONSTIGES",
+        "ORG": None,
+    },
+    "ai4privacy": {
+        "O": None,
+        "GIVENNAME": "PERSON",
+        "SURNAME": "PERSON",
+        "TITLE": "PERSON",
+        "CITY": "ORT",
+        "STREET": "ORT",
+        "BUILDINGNUM": "ORT",
+        "ZIPCODE": "ORT",
+        "DATE": "DATUM",
+        "TIME": "DATUM",
+        "EMAIL": "KONTAKT",
+        "TELEPHONENUM": "KONTAKT",
+        "CREDITCARDNUMBER": "KONTAKT",
+        "AGE": "SONSTIGES",
+        "SEX": "SONSTIGES",
+        "GENDER": "SONSTIGES",
+        "SOCIALNUM": "SONSTIGES",
+        "IDCARDNUM": "SONSTIGES",
+        "PASSPORTNUM": "SONSTIGES",
+        "DRIVERLICENSENUM": "SONSTIGES",
+        "TAXNUM": "SONSTIGES",
+    },
+    "gliner": {
+        "Person": "PERSON",
+        "Ort": "ORT",
+        "Organisation": "ORGANISATION",
+        "Krankheit": "MEDIZINISCH",
+        "Medikament": "MEDIZINISCH",
+    },
+}
+
+# HuggingFace identifiers per backend (mirror of MODEL_DEFINITIONS).
+HF_IDENTIFIERS = {
+    "flair": "flair/ner-german-large",
+    "ai4privacy": "ai4privacy/llama-ai4privacy-multilingual-categorical-anonymiser-openpii",
+    "gliner": "urchade/gliner_multi-v2.1",
+}
+
+# Acceptance thresholds per (backend, type) — F1 minimum. Tightest threshold
+# is PERSON recall, because a missed PERSON span is a PII leak.
+THRESHOLDS = {
+    "ai4privacy": {"PERSON_recall": 0.95},
+    "gliner": {"PERSON_recall": 0.90},
+    "flair": {"PERSON_recall": 0.92},  # baseline reference
+}
+
+
+def map_native(backend: str, native_type: str) -> Optional[str]:
+    """Mirror of TS-side mapNativeType. Unknown labels for ai4privacy go
+    to SONSTIGES (matches the schema-drift policy)."""
+    mapping = CANONICAL_MAPS[backend]
+    if native_type in mapping:
+        return mapping[native_type]
+    if backend == "ai4privacy":
+        return "SONSTIGES"
+    return None
+
+
+def run_backend(
+    backend: str,
+    transcript_path: Path,
+    sidecar_python: Path,
+    sidecar_script: Path,
+    model_dir: Path,
+) -> list[dict]:
+    """Invoke ner_service.py for one fixture and return the predicted
+    entities (in native types)."""
+    cmd = [
+        str(sidecar_python),
+        str(sidecar_script),
+        "--transcript", str(transcript_path),
+        "--backend", backend,
+        "--hf-model", HF_IDENTIFIERS[backend],
+        "--model-dir", str(model_dir),
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=300)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"Backend {backend} failed (exit {result.returncode}):\n{result.stderr[-1000:]}"
+        )
+    output = json.loads(result.stdout)
+    return output.get("entities", [])
+
+
+def overlaps(a: dict, b: dict) -> bool:
+    """Return True if two entities overlap by segment + char range."""
+    if a.get("segmentIndex") != b.get("segmentIndex"):
+        return False
+    return a["charStart"] < b["charEnd"] and a["charEnd"] > b["charStart"]
+
+
+def score_predictions(
+    backend: str,
+    predictions: list[dict],
+    gold: list[dict],
+) -> dict[str, dict[str, float]]:
+    """Compute precision/recall/F1 per canonical entity type.
+
+    A predicted span is a true positive iff there is a gold span with the
+    same (canonical type, overlapping char range, same segment).
+    """
+    # Map predictions to canonical types; drop those that map to None.
+    canonical_preds = []
+    for pred in predictions:
+        canonical = map_native(backend, pred.get("type", ""))
+        if canonical is None:
+            continue
+        canonical_preds.append({**pred, "type": canonical})
+
+    # Per-type counters.
+    types = set(p["type"] for p in canonical_preds) | set(g["type"] for g in gold)
+    scores: dict[str, dict[str, float]] = {}
+
+    for entity_type in types:
+        tp = 0
+        fp = 0
+        fn = 0
+        type_preds = [p for p in canonical_preds if p["type"] == entity_type]
+        type_gold = [g for g in gold if g["type"] == entity_type]
+        matched_gold = set()
+
+        for pred in type_preds:
+            match_idx = next(
+                (i for i, g in enumerate(type_gold) if i not in matched_gold and overlaps(pred, g)),
+                None,
+            )
+            if match_idx is not None:
+                tp += 1
+                matched_gold.add(match_idx)
+            else:
+                fp += 1
+        fn = len(type_gold) - len(matched_gold)
+
+        precision = tp / (tp + fp) if (tp + fp) > 0 else 0.0
+        recall = tp / (tp + fn) if (tp + fn) > 0 else 0.0
+        f1 = (2 * precision * recall) / (precision + recall) if (precision + recall) > 0 else 0.0
+
+        scores[entity_type] = {
+            "precision": round(precision, 4),
+            "recall": round(recall, 4),
+            "f1": round(f1, 4),
+            "support": len(type_gold),
+        }
+
+    return scores
+
+
+def evaluate_backend(
+    backend: str,
+    fixtures: list[Path],
+    sidecar_python: Path,
+    sidecar_script: Path,
+    model_dir: Path,
+) -> dict:
+    """Aggregate scores across fixtures for one backend."""
+    total_predictions: list[dict] = []
+    total_gold: list[dict] = []
+    fixture_count = 0
+    failures: list[str] = []
+
+    for fixture in fixtures:
+        with open(fixture, "r", encoding="utf-8") as f:
+            data = json.load(f)
+
+        try:
+            preds = run_backend(backend, fixture, sidecar_python, sidecar_script, model_dir)
+        except Exception as e:
+            failures.append(f"{fixture.name}: {e}")
+            continue
+
+        # Tag with fixture-relative segment offsets so cross-fixture aggregation works.
+        for p in preds:
+            p["segmentIndex"] = (fixture_count * 1000) + p.get("segmentIndex", 0)
+        for g in data.get("gold_entities", []):
+            g["segmentIndex"] = (fixture_count * 1000) + g.get("segmentIndex", 0)
+
+        total_predictions.extend(preds)
+        total_gold.extend(data.get("gold_entities", []))
+        fixture_count += 1
+
+    return {
+        "fixture_count": fixture_count,
+        "failures": failures,
+        "scores": score_predictions(backend, total_predictions, total_gold),
+    }
+
+
+def check_thresholds(backend: str, report: dict) -> list[str]:
+    """Return list of threshold violations for one backend's report."""
+    violations: list[str] = []
+    requirements = THRESHOLDS.get(backend, {})
+    for key, minimum in requirements.items():
+        if "_" not in key:
+            continue
+        entity_type, metric = key.rsplit("_", 1)
+        scores = report["scores"].get(entity_type)
+        if scores is None:
+            violations.append(f"{backend}: no {entity_type} entities found in fixtures")
+            continue
+        actual = scores[metric]
+        if actual < minimum:
+            violations.append(
+                f"{backend}: {entity_type} {metric}={actual:.3f} < {minimum:.3f} (threshold)"
+            )
+    return violations
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Pre-Ship-Eval for NER backends")
+    parser.add_argument("--fixtures", required=True, type=Path)
+    parser.add_argument(
+        "--backends",
+        nargs="+",
+        default=["flair", "ai4privacy", "gliner"],
+        choices=["flair", "ai4privacy", "gliner"],
+    )
+    parser.add_argument("--output", type=Path, default=None)
+    parser.add_argument(
+        "--sidecar-python",
+        type=Path,
+        default=Path("python_sidecar/venv/bin/python3"),
+    )
+    parser.add_argument(
+        "--sidecar-script",
+        type=Path,
+        default=Path("python_sidecar/ner_service.py"),
+    )
+    parser.add_argument(
+        "--model-dir",
+        type=Path,
+        default=Path(os.path.expanduser("~/.therascript/models/ner")),
+    )
+    args = parser.parse_args()
+
+    if not args.fixtures.is_dir():
+        print(f"Error: fixtures directory not found: {args.fixtures}", file=sys.stderr)
+        return 1
+
+    fixtures = sorted(args.fixtures.glob("*.json"))
+    if not fixtures:
+        print(f"Error: no .json fixtures found in {args.fixtures}", file=sys.stderr)
+        return 1
+
+    print(f"Found {len(fixtures)} fixture(s) in {args.fixtures}")
+
+    full_report: dict = {"backends": {}, "violations": []}
+
+    for backend in args.backends:
+        print(f"\n=== {backend} ===")
+        report = evaluate_backend(
+            backend, fixtures, args.sidecar_python, args.sidecar_script, args.model_dir
+        )
+        full_report["backends"][backend] = report
+
+        if report["failures"]:
+            print(f"  FAILURES: {len(report['failures'])} fixture(s) failed")
+            for f in report["failures"]:
+                print(f"    - {f}")
+
+        for entity_type, metrics in sorted(report["scores"].items()):
+            print(
+                f"  {entity_type:14s} P={metrics['precision']:.3f}  "
+                f"R={metrics['recall']:.3f}  F1={metrics['f1']:.3f}  "
+                f"(n={metrics['support']})"
+            )
+
+        violations = check_thresholds(backend, report)
+        full_report["violations"].extend(violations)
+
+    print()
+    if full_report["violations"]:
+        print("=== THRESHOLD VIOLATIONS ===")
+        for v in full_report["violations"]:
+            print(f"  ✗ {v}")
+    else:
+        print("All backends pass their thresholds.")
+
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as f:
+            json.dump(full_report, f, indent=2)
+        print(f"\nReport written to {args.output}")
+
+    return 2 if full_report["violations"] else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/package-models.sh
+++ b/scripts/package-models.sh
@@ -99,6 +99,16 @@ else
   echo "  SKIP: ai4privacy-Modell nicht gefunden: $MODELS_DIR/ner/$AI4PRIVACY_SUBDIR"
 fi
 
+# GLiNER NER model (HF-Cache-Layout, extrahiert nach ner/models--urchade--…)
+GLINER_SUBDIR="models--urchade--gliner_multi-v2.1"
+if [ -d "$MODELS_DIR/ner/$GLINER_SUBDIR" ]; then
+  tar -czf "$OUTPUT_DIR/gliner-multi-v2.1.tar.gz" \
+    -C "$MODELS_DIR/ner" "$GLINER_SUBDIR"
+  echo "  -> gliner-multi-v2.1.tar.gz"
+else
+  echo "  SKIP: GLiNER-Modell nicht gefunden: $MODELS_DIR/ner/$GLINER_SUBDIR"
+fi
+
 echo ""
 echo "=== Sizes ==="
 ls -lh "$OUTPUT_DIR/"

--- a/scripts/publish-manifest.sh
+++ b/scripts/publish-manifest.sh
@@ -76,6 +76,7 @@ declare -a MODELS=(
   "pyannote-suite|pyannote-suite.tar.gz|Sprechererkennung (pyannote)|diarization|true|diarization/models--pyannote--speaker-diarization-community-1"
   "flair-ner-german-large|flair-ner-german-large.tar.gz|Anonymisierung (flair-ner-german-large)|ner|true|ner/models/ner-german-large"
   "ai4privacy-openpii-modernbert|ai4privacy-openpii-modernbert.tar.gz|Anonymisierung — ai4privacy OpenPII (ModernBERT)|ner|true|ner/models--ai4privacy--llama-ai4privacy-multilingual-categorical-anonymiser-openpii"
+  "gliner-multi-v2.1|gliner-multi-v2.1.tar.gz|Anonymisierung — GLiNER Multi v2.1|ner|true|ner/models--urchade--gliner_multi-v2.1"
 )
 
 # CDN base URL

--- a/src/main/ml/__tests__/entity-merger.test.ts
+++ b/src/main/ml/__tests__/entity-merger.test.ts
@@ -5,6 +5,7 @@ import {
   isWholeWord,
   mapFlairType,
   mapAi4PrivacyType,
+  mapGlinerType,
   mapNativeType
 } from '../entity-merger'
 import type { TranscriptSegment } from '../../../shared/types'
@@ -335,10 +336,50 @@ describe('mapNativeType (backend dispatcher)', () => {
     expect(mapNativeType('ai4privacy', 'O')).toBeNull()
   })
 
-  it('gliner backend drops everything until mapper is wired', () => {
+  it('gliner backend delegates to mapGlinerType', () => {
+    expect(mapNativeType('gliner', 'Person')).toBe('PERSON')
+    expect(mapNativeType('gliner', 'Ort')).toBe('ORT')
+    expect(mapNativeType('gliner', 'Organisation')).toBe('ORGANISATION')
+    expect(mapNativeType('gliner', 'Krankheit')).toBe('MEDIZINISCH')
+  })
+})
+
+describe('mapGlinerType', () => {
+  it('maps Person to PERSON', () => {
+    expect(mapGlinerType('Person')).toBe('PERSON')
+  })
+
+  it('maps Ort to ORT', () => {
+    expect(mapGlinerType('Ort')).toBe('ORT')
+  })
+
+  it('maps Organisation to ORGANISATION', () => {
+    expect(mapGlinerType('Organisation')).toBe('ORGANISATION')
+  })
+
+  it.each([
+    ['Krankheit', 'MEDIZINISCH'],
+    ['Medikament', 'MEDIZINISCH']
+  ])('maps medical %s to MEDIZINISCH', (native, canonical) => {
+    expect(mapGlinerType(native)).toBe(canonical)
+  })
+
+  it('routes unknown labels to SONSTIGES with a console.warn (drift guard)', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
-    expect(mapNativeType('gliner', 'Person')).toBeNull()
-    expect(warn).toHaveBeenCalled()
+    expect(mapGlinerType('FUTURE_LABEL')).toBe('SONSTIGES')
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('FUTURE_LABEL'))
+    warn.mockRestore()
+  })
+
+  it('covers the documented GLINER_LABELS_DE label set (lock against drift)', () => {
+    // Must match python_sidecar/ner_backends/gliner_backend.py:GLINER_LABELS_DE
+    const labels = ['Person', 'Ort', 'Organisation', 'Krankheit', 'Medikament']
+    expect(labels).toHaveLength(5)
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    for (const label of labels) {
+      mapGlinerType(label)
+    }
+    expect(warn).not.toHaveBeenCalled()
     warn.mockRestore()
   })
 })
@@ -364,15 +405,43 @@ describe('mergeEntities backend dispatch', () => {
     expect(result[0].type).toBe('PERSON')
   })
 
-  it('gliner backend drops all entities until its mapper is implemented', () => {
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
-    const segments = [seg('Peter wohnt in Bern')]
+  it('gliner backend maps zero-shot labels into the canonical pipeline', () => {
+    const text = 'Peter Müller arbeitet bei Helsana und nimmt Aspirin'
+    const segments = [seg(text)]
+    const personStart = text.indexOf('Peter Müller')
+    const orgStart = text.indexOf('Helsana')
+    const medStart = text.indexOf('Aspirin')
     const nerEntities: NerEntity[] = [
-      { text: 'Peter', type: 'Person', segmentIndex: 0, charStart: 0, charEnd: 5, confidence: 0.9 }
+      {
+        text: 'Peter Müller',
+        type: 'Person',
+        segmentIndex: 0,
+        charStart: personStart,
+        charEnd: personStart + 'Peter Müller'.length,
+        confidence: 0.9
+      },
+      {
+        text: 'Helsana',
+        type: 'Organisation',
+        segmentIndex: 0,
+        charStart: orgStart,
+        charEnd: orgStart + 'Helsana'.length,
+        confidence: 0.85
+      },
+      {
+        text: 'Aspirin',
+        type: 'Medikament',
+        segmentIndex: 0,
+        charStart: medStart,
+        charEnd: medStart + 'Aspirin'.length,
+        confidence: 0.8
+      }
     ]
     const result = mergeEntities(nerEntities, [], [], segments, 'gliner')
-    expect(result).toHaveLength(0)
-    warn.mockRestore()
+    expect(result).toHaveLength(3)
+    expect(result.find((e) => e.text === 'Peter Müller')?.type).toBe('PERSON')
+    expect(result.find((e) => e.text === 'Helsana')?.type).toBe('ORGANISATION')
+    expect(result.find((e) => e.text === 'Aspirin')?.type).toBe('MEDIZINISCH')
   })
 
   it('ai4privacy backend maps native PII types into the canonical pipeline', () => {

--- a/src/main/ml/entity-merger.ts
+++ b/src/main/ml/entity-merger.ts
@@ -88,9 +88,10 @@ export function mapAi4PrivacyType(nativeType: string): PlaceholderType | null {
  * time. The Python sidecar's `GLINER_LABELS_DE` constant must stay in lock-step
  * with the cases below. Unknown labels route to SONSTIGES with a `console.warn`
  * so a sidecar-side label-list change without a TS-side mapping update surfaces
- * loudly rather than silently leaking PII.
+ * loudly rather than silently leaking PII. The return type is non-null because
+ * the catch-all always emits SONSTIGES.
  */
-export function mapGlinerType(nativeType: string): PlaceholderType | null {
+export function mapGlinerType(nativeType: string): PlaceholderType {
   switch (nativeType) {
     case 'Person':
       return 'PERSON'

--- a/src/main/ml/entity-merger.ts
+++ b/src/main/ml/entity-merger.ts
@@ -82,13 +82,36 @@ export function mapAi4PrivacyType(nativeType: string): PlaceholderType | null {
 }
 
 /**
- * Backend-aware mapping from native NER entity type to canonical PlaceholderType.
- * Returns `null` for types that should be filtered out (e.g. ORG, non-PII).
+ * Map GLiNER native label → canonical PlaceholderType.
  *
- * `gliner` is accepted as a discriminator value but has no canonical mapper yet
- * — entities are dropped with a `console.warn` rather than mis-mapped through
- * flair/ai4privacy semantics (different label vocabularies make a fall-through
- * unsafe).
+ * GLiNER is zero-shot: the labels emitted are exactly those passed at inference
+ * time. The Python sidecar's `GLINER_LABELS_DE` constant must stay in lock-step
+ * with the cases below. Unknown labels route to SONSTIGES with a `console.warn`
+ * so a sidecar-side label-list change without a TS-side mapping update surfaces
+ * loudly rather than silently leaking PII.
+ */
+export function mapGlinerType(nativeType: string): PlaceholderType | null {
+  switch (nativeType) {
+    case 'Person':
+      return 'PERSON'
+    case 'Ort':
+      return 'ORT'
+    case 'Organisation':
+      return 'ORGANISATION'
+    case 'Krankheit':
+    case 'Medikament':
+      return 'MEDIZINISCH'
+    default:
+      console.warn(
+        `[entity-merger] mapGlinerType received unknown native label "${nativeType}" — routing to SONSTIGES (label set may have drifted from GLINER_LABELS_DE)`
+      )
+      return 'SONSTIGES'
+  }
+}
+
+/**
+ * Backend-aware mapping from native NER entity type to canonical PlaceholderType.
+ * Returns `null` for types that should be filtered out (e.g. ORG from flair, non-PII).
  */
 export function mapNativeType(
   backend: NerBackend,
@@ -100,10 +123,7 @@ export function mapNativeType(
     case 'ai4privacy':
       return mapAi4PrivacyType(nativeType)
     case 'gliner':
-      console.warn(
-        `[entity-merger] mapNativeType called for backend "gliner" but no mapper is implemented — dropping entity "${nativeType}"`
-      )
-      return null
+      return mapGlinerType(nativeType)
   }
 }
 

--- a/src/main/services/ModelDownloadService.ts
+++ b/src/main/services/ModelDownloadService.ts
@@ -566,8 +566,8 @@ export async function downloadSingleModel(id: string): Promise<void> {
 /**
  * Löscht ein einzelnes Modell von Disk. Verboten für:
  *   - unbekannte IDs
- *   - Pflicht-Modelle (isRequired, z.B. flair NER)
- *   - das aktuell aktive Modell einer group-required Gruppe (ASR, Diarization)
+ *   - Pflicht-Modelle (isRequired)
+ *   - das aktuell aktive Modell einer auswählbaren Gruppe (ASR, NER)
  */
 export async function deleteModel(id: string): Promise<void> {
   const def = getModelById(id)

--- a/src/main/services/ModelDownloadService.ts
+++ b/src/main/services/ModelDownloadService.ts
@@ -159,6 +159,25 @@ const MODEL_DEFINITIONS: ModelDefinition[] = [
     languages: ['multi'],
     accuracyScore: 0.85,
     speedScore: 0.85
+  },
+  {
+    id: 'gliner-multi-v2.1',
+    label: 'Anonymisierung — GLiNER Multi v2.1',
+    url: `${R2_CDN}/gliner-multi-v2.1.tar.gz`,
+    relativePath: 'ner',
+    checkPath: 'ner/models--urchade--gliner_multi-v2.1',
+    sizeBytes: 1_200_000_000,
+    sha256: 'PENDING_GLINER_MULTI_V2_1',
+    archive: true,
+    group: 'ner',
+    isRequired: false,
+    hfIdentifier: 'urchade/gliner_multi-v2.1',
+    nerBackend: 'gliner',
+    description:
+      'GLiNER multilingual (~209M Parameter, ~1.16 GB), Apache-2.0. Zero-Shot — emittiert auch ORGANISATION und MEDIZINISCH (Versicherungen, Kliniken, Diagnosen, Medikamente). Mehr Chips als flair/ai4privacy zu Kosten von Genauigkeit auf reinem PER/LOC.',
+    languages: ['multi'],
+    accuracyScore: 0.8,
+    speedScore: 0.7
   }
 ]
 
@@ -439,19 +458,24 @@ export function abortModelDownload(): void {
 }
 
 /**
- * Lädt ein einziges ASR-Modell herunter (nicht für Pflicht-Modelle gedacht —
- * die laufen via startModelDownload auf First-Launch).
+ * Lädt ein einziges Modell herunter (nicht für First-Launch-Bulk-Downloads —
+ * die laufen via startModelDownload mit modelsDownloaded-Settings-Flag).
  *
  * Sendet denselben `modelDownload:status`-Channel wie startModelDownload,
  * damit die bestehende UI-Progress-Anzeige wiederverwendbar bleibt.
+ *
+ * Erlaubt für ASR und NER (User-wählbare Gruppen). Diarization läuft als
+ * monolithische Suite und wird nicht einzeln nachgeladen.
  */
 export async function downloadSingleModel(id: string): Promise<void> {
   const def = getModelById(id)
   if (!def) {
     throw new Error(`Download: unbekanntes Modell "${id}"`)
   }
-  if (def.group !== 'asr') {
-    throw new Error(`Download: nur ASR-Modelle sind einzeln ladbar (id=${id})`)
+  if (def.group !== 'asr' && def.group !== 'ner') {
+    throw new Error(
+      `Download: Modell-Gruppe "${def.group ?? 'unbekannt'}" wird nicht einzeln nachgeladen (id=${id})`
+    )
   }
   if (abortSignal && !abortSignal.aborted) {
     throw new Error('Download: bereits aktiv — zuerst abbrechen')
@@ -559,6 +583,11 @@ export async function deleteModel(id: string): Promise<void> {
   if (def.group === 'asr' && active.transcription === id) {
     throw new Error(
       `Löschen: "${def.label}" ist aktuell als ASR-Modell aktiv. Zuerst anderes Modell aktivieren.`
+    )
+  }
+  if (def.group === 'ner' && active.ner === id) {
+    throw new Error(
+      `Löschen: "${def.label}" ist aktuell als Anonymisierungs-Modell aktiv. Zuerst anderes Modell aktivieren.`
     )
   }
 

--- a/src/main/services/__tests__/ModelDownloadService.test.ts
+++ b/src/main/services/__tests__/ModelDownloadService.test.ts
@@ -99,15 +99,9 @@ describe('downloadSingleModel', () => {
     )
   })
 
-  it('throws when model is not in asr group (pyannote-suite)', async () => {
+  it('throws when model belongs to a non-singly-loadable group (diarization)', async () => {
     await expect(downloadSingleModel('pyannote-suite')).rejects.toThrow(
-      /nur ASR-Modelle/i
-    )
-  })
-
-  it('throws when model is not in asr group (flair)', async () => {
-    await expect(downloadSingleModel('flair-ner-german-large')).rejects.toThrow(
-      /nur ASR-Modelle/i
+      /wird nicht einzeln nachgeladen/i
     )
   })
 })

--- a/src/renderer/src/components/settings/ModelsSettings.tsx
+++ b/src/renderer/src/components/settings/ModelsSettings.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import type { ModelCatalogEntry } from '../../../../shared/validation/model-catalog-schemas'
+import type { ModelCatalogEntry, ModelGroup } from '../../../../shared/validation/model-catalog-schemas'
 import type { ModelDownloadStatus } from '../../../../shared/types/IpcApi'
 import { useToast } from '../../hooks/useToast'
 import { ConfirmDialog } from '../ConfirmDialog'
@@ -7,16 +7,56 @@ import { formatBytes } from '../../utils/formatBytes'
 import ModelCard from './ModelCard'
 import DiarizationPipelineSection from './DiarizationPipelineSection'
 
+interface SectionConfig {
+  group: ModelGroup
+  title: string
+  description: string
+  activeUsageLabel: string
+  activatedToast: (label: string) => string
+}
+
+const SECTIONS: SectionConfig[] = [
+  {
+    group: 'asr',
+    title: 'Transkriptions-Modelle',
+    description:
+      'Wähle das Modell, das für die Transkription deiner Sitzungen verwendet werden soll. Ein Modellwechsel wirkt sich nur auf neue Transkriptionen aus.',
+    activeUsageLabel: 'Wird für Transkription verwendet',
+    activatedToast: (label) =>
+      `"${label}" aktiviert. Neue Transkriptionen verwenden ab jetzt dieses Modell — bereits verarbeitete Sitzungen bleiben unverändert.`
+  },
+  {
+    group: 'ner',
+    title: 'Anonymisierungs-Modelle',
+    description:
+      'Wähle das Modell für die Erkennung personenbezogener Daten (Namen, Orte, Diagnosen). Die Modelle unterscheiden sich in Größe, Geschwindigkeit und welche Entity-Typen sie erkennen. Ein Wechsel wirkt sich nur auf neue Anonymisierungen aus.',
+    activeUsageLabel: 'Wird für Anonymisierung verwendet',
+    activatedToast: (label) =>
+      `"${label}" aktiviert. Neue Anonymisierungen verwenden ab jetzt dieses Modell — bereits verarbeitete Sitzungen bleiben unverändert.`
+  }
+]
+
 export default function ModelsSettings(): React.JSX.Element {
   const toast = useToast()
-  const [asrModels, setAsrModels] = useState<ModelCatalogEntry[]>([])
+  const [modelsByGroup, setModelsByGroup] = useState<Record<ModelGroup, ModelCatalogEntry[]>>({
+    asr: [],
+    diarization: [],
+    ner: []
+  })
   const [downloadingId, setDownloadingId] = useState<string | null>(null)
   const [progress, setProgress] = useState<number | undefined>(undefined)
   const [deleteCandidate, setDeleteCandidate] = useState<ModelCatalogEntry | null>(null)
 
   const reload = async (): Promise<void> => {
-    const asr = await window.api.modelCatalog.list('asr')
-    setAsrModels(asr)
+    const groups: ModelGroup[] = SECTIONS.map((s) => s.group)
+    const lists = await Promise.all(groups.map((g) => window.api.modelCatalog.list(g)))
+    setModelsByGroup((prev) => {
+      const next = { ...prev }
+      groups.forEach((g, i) => {
+        next[g] = lists[i]
+      })
+      return next
+    })
   }
 
   useEffect(() => {
@@ -40,8 +80,8 @@ export default function ModelsSettings(): React.JSX.Element {
   const handleDownload = async (id: string): Promise<void> => {
     setDownloadingId(id)
     try {
-      const updated = await window.api.modelCatalog.download(id)
-      setAsrModels(updated)
+      await window.api.modelCatalog.download(id)
+      await reload()
       toast.success('Modell erfolgreich heruntergeladen.')
     } catch (err) {
       toast.error(err instanceof Error ? err.message : String(err))
@@ -58,41 +98,39 @@ export default function ModelsSettings(): React.JSX.Element {
   const handleDeleteConfirmed = async (model: ModelCatalogEntry): Promise<void> => {
     setDeleteCandidate(null)
     try {
-      const updated = await window.api.modelCatalog.delete(model.id)
-      setAsrModels(updated)
-      toast.success(
-        `"${model.label}" gelöscht — ${formatBytes(model.sizeBytes)} freigegeben.`
-      )
+      await window.api.modelCatalog.delete(model.id)
+      await reload()
+      toast.success(`"${model.label}" gelöscht — ${formatBytes(model.sizeBytes)} freigegeben.`)
     } catch (err) {
       toast.error(err instanceof Error ? err.message : String(err))
     }
   }
 
-  const handleActivate = async (model: ModelCatalogEntry): Promise<void> => {
+  const handleActivate = async (
+    model: ModelCatalogEntry,
+    section: SectionConfig
+  ): Promise<void> => {
     try {
-      const updated = await window.api.modelCatalog.setActive(model.group, model.id)
-      setAsrModels(updated)
-      toast.success(
-        `"${model.label}" aktiviert. Neue Transkriptionen verwenden ab jetzt dieses Modell — bereits verarbeitete Sitzungen bleiben unverändert.`
-      )
+      await window.api.modelCatalog.setActive(model.group, model.id)
+      await reload()
+      toast.success(section.activatedToast(model.label))
     } catch (err) {
       toast.error(err instanceof Error ? err.message : String(err))
     }
   }
 
-  const installed = asrModels.filter((m) => m.isInstalled)
-  const available = asrModels.filter((m) => !m.isInstalled)
   const anyBusy = downloadingId !== null
 
-  return (
-    <div className="space-y-8 p-6">
-      <section className="space-y-3">
+  const renderSection = (section: SectionConfig): React.JSX.Element => {
+    const models = modelsByGroup[section.group]
+    const installed = models.filter((m) => m.isInstalled)
+    const available = models.filter((m) => !m.isInstalled)
+
+    return (
+      <section key={section.group} className="space-y-3">
         <div>
-          <h2 className="mb-1 text-lg font-semibold">Transkriptions-Modelle</h2>
-          <p className="text-sm text-text-secondary">
-            Wähle das Modell, das für die Transkription deiner Sitzungen verwendet
-            werden soll. Ein Modellwechsel wirkt sich nur auf neue Transkriptionen aus.
-          </p>
+          <h2 className="mb-1 text-lg font-semibold">{section.title}</h2>
+          <p className="text-sm text-text-secondary">{section.description}</p>
         </div>
 
         {installed.length > 0 && (
@@ -103,14 +141,15 @@ export default function ModelsSettings(): React.JSX.Element {
                 <ModelCard
                   key={m.id}
                   model={m}
-                  activeUsageLabel="Wird für Transkription verwendet"
+                  activeUsageLabel={section.activeUsageLabel}
                   downloading={downloadingId === m.id}
                   progress={downloadingId === m.id ? progress : undefined}
                   anyBusy={anyBusy}
+                  deletable={!m.isRequired}
                   onDownload={() => handleDownload(m.id)}
                   onCancelDownload={handleCancelDownload}
                   onDelete={() => setDeleteCandidate(m)}
-                  onActivate={() => handleActivate(m)}
+                  onActivate={() => handleActivate(m, section)}
                 />
               ))}
             </div>
@@ -127,34 +166,31 @@ export default function ModelsSettings(): React.JSX.Element {
                 <ModelCard
                   key={m.id}
                   model={m}
-                  activeUsageLabel="Wird für Transkription verwendet"
+                  activeUsageLabel={section.activeUsageLabel}
                   downloading={downloadingId === m.id}
                   progress={downloadingId === m.id ? progress : undefined}
                   anyBusy={anyBusy}
+                  deletable={!m.isRequired}
                   onDownload={() => handleDownload(m.id)}
                   onCancelDownload={handleCancelDownload}
                   onDelete={() => setDeleteCandidate(m)}
-                  onActivate={() => handleActivate(m)}
+                  onActivate={() => handleActivate(m, section)}
                 />
               ))}
             </div>
           </div>
         )}
       </section>
+    )
+  }
+
+  return (
+    <div className="space-y-8 p-6">
+      {renderSection(SECTIONS[0])}
 
       <DiarizationPipelineSection />
 
-      <section>
-        <h3 className="mb-2 text-sm font-medium text-text-tertiary">Pflicht-Modelle</h3>
-        <p className="mb-2 text-xs text-text-tertiary">
-          Diese Modelle sind für die Anonymisierung zwingend erforderlich und werden
-          automatisch aktuell gehalten.
-        </p>
-        <ul className="space-y-1 rounded-md border border-border bg-surface-1 p-3 text-xs text-text-tertiary">
-          <li>Sprechererkennung (pyannote-suite)</li>
-          <li>Anonymisierung (flair-ner-german-large)</li>
-        </ul>
-      </section>
+      {renderSection(SECTIONS[1])}
 
       {deleteCandidate && (
         <ConfirmDialog


### PR DESCRIPTION
## Summary

Closes the [multi-anonymization-models design](docs/superpowers/specs/2026-04-24-multi-anonymization-models-design.md) by shipping the third NER backend, the user-facing model picker, and the eval-gate tooling.

This is **Phase 3 of 3**, building on Phase 1 (#47, dispatcher foundation) and Phase 2 (#48, ai4privacy backend).

## What changed

- **GLiNER Python backend** — [`python_sidecar/ner_backends/gliner_backend.py`](python_sidecar/ner_backends/gliner_backend.py) uses `urchade/gliner_multi-v2.1` (zero-shot multilingual, ~209M params, 1.16 GB). Hardcoded label list (Person/Ort/Organisation/Krankheit/Medikament) keeps EMAIL/PHONE/DATE out of the model output — those stay regex-driven for CH-format determinism. Loads with `local_files_only=True` for offline operation.
- **GLiNER canonical mapper** — [`mapGlinerType`](src/main/ml/entity-merger.ts) covers the five zero-shot labels. Unknown labels route to SONSTIGES with `console.warn`, mirroring the schema-drift policy from ai4privacy. Wired into `mapNativeType` (replacing the Phase 1 warn-and-drop stub).
- **GLiNER ModelDefinition** — new [`gliner-multi-v2.1`](src/main/services/ModelDownloadService.ts) entry, `sha256: 'PENDING_GLINER_MULTI_V2_1'`, `sizeBytes: 1_200_000_000`. Marked optional.
- **Download/Delete generalization** — `downloadSingleModel` now accepts `ner` group (was ASR-only). `deleteModel` blocks deletion of the active NER model (mirror of the existing ASR check). Diarization stays single-suite-only.
- **Settings UI** — [`ModelsSettings.tsx`](src/renderer/src/components/settings/ModelsSettings.tsx) refactored from single-section (Transkription) to multi-section. New \"Anonymisierungs-Modelle\" section ships flair + ai4privacy + GLiNER cards. Reuses the existing `ModelCard` component, threads `deletable={!isRequired}` so flair (required) can be activated but not deleted.
- **Pre-Ship-Eval** — [`scripts/eval-ner-backends.py`](scripts/eval-ner-backends.py) is the gate that the default-flip from flair to ai4privacy depends on. Mirrors the TS canonical mappings, runs each backend through production `ner_service.py`, computes precision/recall/F1 per (backend, type), exits non-zero if any threshold is violated. Default thresholds require ai4privacy ≥ 95% PERSON recall before becoming default. Gated on real fixtures in `tests/fixtures/ner-eval/` (out-of-repo data, anonymized therapy transcripts).
- **Packaging** — `package-models.sh` and `publish-manifest.sh` extended with the new `gliner-multi-v2.1.tar.gz` entry.

## Validation

- `npm run typecheck` — passes
- `npm test` — **646 tests pass** (640 from Phase 2 + 6 new for GLiNER, including a 5-label schema lock).
- `python3 -m py_compile` on the new backend + eval script — passes.
- `ner_service.py --help` smoke test — passes.

## Test plan

- [ ] Manual UI test: open Settings → Modelle, verify three sections (Transkription, Sprechererkennung, Anonymisierung). Each shows installed/available cards. Required models (flair, pyannote-suite) hide the delete button.
- [ ] Install ai4privacy via UI, switch active to ai4privacy, run anonymization on a recording, verify chips render correctly.
- [ ] Switch active back to flair, verify behavior unchanged.
- [ ] Once R2 packaging + SHA sync done: install GLiNER, verify ORGANISATION + MEDIZINISCH chips appear (e.g. on a recording mentioning insurance / medication).
- [ ] When real fixtures exist: run `python3 scripts/eval-ner-backends.py --fixtures tests/fixtures/ner-eval/` to validate the eval-gate thresholds.

## Not included (deferred)

- **R2 packaging + SHA-256 sync** for ai4privacy + GLiNER — separate ops commit.
- **Default-flip** to ai4privacy — gated by Pre-Ship-Eval passing on real fixtures.
- **Real test fixtures** — anonymized therapy transcripts must be created out-of-repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)