### PR TITLE
feat: local LLM summarization (Gemma 3 4B via llama.cpp)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,8 @@ scripts/setup-pyannote.sh --all-models   # Download both
 scripts/setup-ner.sh              # Install flair into existing Python venv
 scripts/setup-ner.sh --model      # Also download NER model (~1.1 GB)
 scripts/setup-vision-ocr.sh       # Build Swift Vision OCR CLI helper → resources/bin/
+scripts/setup-llama.sh             # Install llama.cpp via Homebrew → resources/bin/ + resources/lib/
+scripts/setup-llama.sh --model     # Also download Gemma 3 4B Instruct Q4_K_M (~2.5 GB, gated — needs huggingface-cli login)
 npm run sidecar:build              # Build standalone Python sidecar via uv → python_sidecar/standalone/
 npm run sidecar:package            # Package models for R2 upload
 npm run sidecar:upload             # Upload model packages to Cloudflare R2
@@ -57,11 +59,13 @@ scripts/publish-manifest.sh       # Generate manifest.json from r2-upload/ + upl
 1. whisper.cpp subprocess — ASR via auswählbares Modell aus Katalog (Default: Whisper Large V3 Turbo Q5_0 multilingual; optional: Swiss-German-Fine-Tune). Active model stored in electron-store (`activeModels.transcription`), verwaltet via Settings → Modelle. ✓ implemented
 2. Python sidecar — pyannote.audio diarization via auswählbares Modell aus Katalog (Default: `speaker-diarization-3.1`; optional: `speaker-diarization-community-1` für bessere Deutsch-Performance). Active model stored in electron-store (`activeModels.diarization`), verwaltet via Settings → Modelle. HF_HUB_OFFLINE=1 erzwingt lokale Cache-Nutzung. ✓ implemented
 3. Python sidecar — flair NER (flair/ner-german-large) + Regex + Blocklist → TipTap document ✓ implemented
+4. llama.cpp subprocess — optionale Zusammenfassung über auswählbares Modell aus Katalog (Default: Gemma 3 4B Instruct Q4_K_M GGUF). Registriert als letzter Schritt beider Pipeline-Chains (Audio + PDF). Wenn Modell nicht installiert → Executor skippt den Step geräuschlos, Summary bleibt NULL. Active model in electron-store (`activeModels.summarization`), verwaltet via Settings → Modelle. ✓ implemented
 
-**ML pipeline — PDF** (extraction → ocr → anonymization):
+**ML pipeline — PDF** (extraction → ocr → anonymization → summarization):
 1. pdfjs-dist — Text extraction per page (with `standardFontDataUrl` configured) ✓ implemented
 2. Swift CLI helper — Apple Vision OCR for scanned pages (skipped if all text) ✓ implemented
 3. Python sidecar — flair NER + Regex + Blocklist → TipTap document (shared with audio) ✓ implemented
+4. llama.cpp subprocess — optional summarization (shared with audio). ✓ implemented
 
 **ML models:** Stored in `~/.therascript/models/<type>/` (e.g. `models/asr/`, `models/diarization/`, `models/ner/`). Directories created at startup by `initDatabase()`.
 
@@ -103,6 +107,8 @@ scripts/publish-manifest.sh       # Generate manifest.json from r2-upload/ + upl
 - **electron-vite externals:** `electron-store` (main) and `@electron-toolkit/preload` (preload) are excluded from `externalizeDeps` in `electron.vite.config.ts` — they must be bundled, not externalized.
 - **Model hash sync:** After `npm run sidecar:deploy` or `scripts/publish-manifest.sh`, the SHA-256 hashes in `ModelDownloadService.ts` `MODEL_DEFINITIONS` must be manually updated to match `manifest.json`. The packaging scripts print hashes to stdout but don't auto-update the source. Stale hashes cause first-launch download failures.
 - **Standalone Python sidecar:** Built via `uv` with python-build-standalone (~1 GB). All `.dylib`/`.so` files are ad-hoc codesigned during build. If the sidecar fails to run, try `scripts/build-sidecar.sh --clean` for a fresh build. The `torchcodec_shim.py` provides a soundfile-based fallback for torchcodec (required by pyannote.audio 4.0.4+), loaded automatically via `sitecustomize.py`. **Important:** `requirements.txt` + `requirements-ner.txt` are the sole dependency source — any Python package needed at runtime (including transitive deps like `soundfile`) must be listed explicitly, unlike the old PyInstaller build which had hidden imports.
+- **Gemma 4 E4B GGUF source:** No official Google GGUF for Gemma 4 E4B existed when the summarization feature shipped. Default catalog entry uses bartowski's Gemma 3 4B Instruct Q4_K_M as fallback. The repo is HuggingFace-gated — `huggingface-cli login` is required before `scripts/setup-llama.sh --model`. If/when a Gemma 4 E4B GGUF lands upstream, swap the URL/filename in `MODEL_DEFINITIONS` and re-run `scripts/publish-manifest.sh` to mirror into R2.
+- **llama-cli stall threshold:** `LlamaSummarizer.summarize()` provides no fine-grained progress callbacks (single subprocess call returning final stdout). The TaskQueue's `ProcessWatchdog` defaults to 120s for unrecognized task types — for a 4B model this is generous on M-series hardware (typical inference ~5-30s) but tight if the user's box is loaded. If summarization tasks start failing with "Verarbeitung reagiert nicht mehr", add a `summarization: 600_000` entry to `STALL_THRESHOLDS` in `ProcessWatchdog.ts`.
 
 ## Code Conventions
 

--- a/docs/product/features/summarization.md
+++ b/docs/product/features/summarization.md
@@ -1,0 +1,95 @@
+# Lokale Zusammenfassung (Gemma 3 4B Instruct)
+
+## Zweck
+
+Erzeugt am Ende der Pipeline für jede Sitzung (Audio oder PDF) lokal:
+
+- Einen prägnanten **Titel** (Nominalphrase, 3–8 Wörter) — überschreibt das bisher
+  generische `Sitzung 14.02.2026 14:30`-Pattern.
+- Eine **2-Satz-Zusammenfassung** der zentralen Themen.
+
+Beide werden im Review-Editor als h1 + Panel angezeigt und sind inline editierbar.
+
+## Modell
+
+- **Default**: `bartowski/gemma-3-4b-it-GGUF` Q4_K_M (~2.5 GB), Metal-beschleunigt
+  via `llama.cpp`.
+- **Optional** — nicht Teil des First-Launch-Downloads. Installation über
+  Settings → Modelle → "Zusammenfassung (optional)".
+- Geplante Migration auf Gemma 4 E4B Instruct, sobald upstream eine GGUF-Konvertierung
+  verfügbar ist (siehe CLAUDE.md "Gemma 4 E4B GGUF source").
+
+## Architektur
+
+Summarization läuft als **letzter Schritt der TaskQueue-Pipeline**:
+
+```
+Audio: transcription → diarization → alignment → anonymization → summarization
+PDF:   extraction → ocr → anonymization → summarization
+```
+
+Komponenten:
+
+- `LlamaSummarizer` (`src/main/ml/LlamaSummarizer.ts`) — wrappt `llama-cli` als
+  Subprozess, baut den Prompt (`summarization-prompt.ts`), parst den Output in
+  `{ title, text }`. Path-traversal-Guard für die Modell-Datei.
+- `SummarizationExecutor` (`src/main/ml/SummarizationExecutor.ts`) —
+  TaskExecutor-Implementation. Skippt geräuschlos, wenn das Modell nicht installiert
+  ist (`isModelInstalled` false) oder der anonymisierte Text leer/fehlend ist.
+- `summary-handlers.ts` — IPC-Channels `summary:get`, `summary:updateTitle`,
+  `summary:updateText` für die User-Bearbeitung.
+
+Persistenz: Spalten `title` (existing, überschrieben), `summary`,
+`summary_model_id`, `summarized_at` auf `sessions` (Migration 007).
+
+## Prompt
+
+Strukturierter Zwei-Block-Output (TITEL + ZUSAMMENFASSUNG) auf Deutsch, mit
+expliziter Format-Specification. Der Parser toleriert Lower/Uppercase und
+multi-line ZUSAMMENFASSUNG. Input wird auf 120k Zeichen gekürzt — für typische
+Therapie-Sessions weit unter dem Limit.
+
+Sampling: `--temp 0.3 --top-p 0.9 -n 260` — niedrige Temperatur für deterministische,
+faktentreue Ausgabe. `--chat-template gemma`.
+
+## Failure Modes
+
+| Situation                              | Verhalten                                       |
+| -------------------------------------- | ----------------------------------------------- |
+| Modell nicht installiert               | Task erfolgreich, Summary bleibt NULL, Log-Info |
+| Anonymisierter Text leer / kein File   | Task erfolgreich, Log-Info                      |
+| llama-cli crashed / timeout            | Task failed, Session in Error-State             |
+| Output unparsbar (TITEL/ZUSAMM. fehlt) | Task failed (siehe oben)                        |
+
+UI behandelt fehlende Summary still: Kein Banner, kein CTA, kein Hinweis. h1
+fällt auf "Sitzung ohne Titel" zurück (oder den ursprünglichen Auto-Titel),
+SummaryPanel rendert `null`.
+
+## RAM + Disk Cost
+
+- Inference: ~3 GB Working Set (4B Q4_K_M + KV-Cache für ~3k Tokens). Läuft
+  sequenziell nach Anonymisierung — kein RAM-Konflikt.
+- Disk: 2.5 GB für das Modell + ~5 MB für `llama-cli` + dylibs.
+
+## Privacy
+
+- Ausschließlich lokal. Keine Netzwerk-Calls, kein Telemetrie.
+- Anonymisierter Text wird verarbeitet — Roh-Transkripte erreichen das Modell
+  nie. Platzhalter wie `[PERSON 1]` werden im Prompt verbatim erhalten.
+
+## UI-Einstiege
+
+- Settings → Modelle → "Zusammenfassung (optional)" — Download/Aktivierung.
+- Review-Editor → h1 (Titel) + Zusammenfassung-Panel — automatisch sichtbar
+  wenn Summary persistiert.
+- Session-Liste → Titel als primäres Label (Fallback auf Datum bei leerem Titel).
+
+## Bekannte Einschränkungen
+
+- Keine Regenerate-Schaltfläche. Wer Re-Run will, muss aktuell die Session
+  retrying-en (Settings → Sitzung erneut verarbeiten). Kann später als IPC
+  `summary:regenerate` nachgezogen werden.
+- Kein In-Progress-State im UI — Sitzung erscheint erst im Review nachdem die
+  ganze Pipeline (inklusive LLM) durch ist. Während der LLM-Stage läuft die
+  Status-Anzeige weiter auf "Anonymisierung" (kein eigener `summarizing`
+  SessionStatus).

--- a/docs/superpowers/plans/2026-04-24-local-llm-summarization.md
+++ b/docs/superpowers/plans/2026-04-24-local-llm-summarization.md
@@ -1,0 +1,1932 @@
+# Lokales LLM für Zusammenfassungen (Gemma 4 E4B) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a local, lightweight LLM to Therascript that generates a 2-sentence German summary of a session transcript or imported PDF, fully on-device.
+
+**Architecture:** llama.cpp runs as a subprocess (analog to the existing whisper.cpp pattern), wrapped by a new `LlamaSummarizer` service and invoked through a new `SummarizationExecutor` that plugs into the existing `TaskQueue`. The model is Gemma 4 E4B Instruct in GGUF Q4_K_M quantization (~2.5 GB), Metal-accelerated. Each invocation produces **two outputs in a single pass**: a short session **title** (Nominalphrase, 3–8 Wörter) and a 2-sentence **summary**. Both are persisted on the `sessions` table and are user-editable inline in the Review Editor. The **model is optional** (not required at first launch, downloadable from Settings → Modelle).
+
+**Design decision — summarization is a pipeline tail step on the existing TaskQueue.** The `'summarization'` `TaskType` is appended to both audio and PDF pipeline chains as the last step after `anonymization`. This gives sequential-model safety for free (the TaskQueue runs one executor at a time, honoring the 8 GB RAM budget) and handles the real-world case where the user opens Session B in the Review Editor while Session A is still in the pipeline — summarizations queue up correctly without any extra coordination.
+
+**Executor behavior when model is missing:** If the active summarization model file is not present on disk, the executor logs an info message and completes successfully with no output (task succeeds, `sessions.summary` stays `NULL`). This makes the feature truly opt-in — users who never download the model pay zero cost beyond a trivial queue tick per session.
+
+**UI flow (minimal):** The Review Editor has **no user-facing trigger** for generation or regeneration — no button, no banner, no CTA. Summary and title run exclusively as the pipeline tail step. The Review-Editor state model of the app already guarantees a session only appears in "Review" *after* the pipeline completes, so there is no in-progress UI state. When a session is opened:
+
+- If a summary exists (`sessions.summary IS NOT NULL`), render the `<SummaryPanel>` with the summary text; use `sessions.title` as the editable h1 in the header.
+- If no summary exists (model was not installed, executor skipped, generation failed, or session is older than the feature), render nothing extra — the h1 falls back to the existing date-based label, and no summary panel is mounted. No hint, no promotional CTA.
+
+Both fields are **inline-editable** (Notion-pattern `contenteditable`): click to edit, `Enter`/blur saves via `summary:updateTitle` / `summary:updateText`. If the user clears the title to empty, it reverts to the date fallback in the view layer.
+
+**No provenance icons.** No ✨, no 🔒. The affordance for editability is a subtle hover highlight, consistent with editable text elsewhere in the app.
+
+**Tech Stack:** llama.cpp (Homebrew in dev, ad-hoc signed binary + dylibs in `resources/bin` + `resources/lib/` for production), GGUF format via llama-cli, TypeScript main-process service, React/Tailwind in renderer, better-sqlite3 for persistence, existing R2 manifest flow for model distribution.
+
+---
+
+## Pre-flight: Constraints & Assumptions
+
+Read before starting any task:
+
+- **RAM budget is 8 GB.** Summarization runs as the tail step of each pipeline via the existing `TaskQueue`, which guarantees strictly sequential executor runs. Never invoke `LlamaSummarizer` outside of `SummarizationExecutor` (no direct IPC spawn path) — that is the only way to keep the sequential guarantee.
+- **CSP is `connect-src 'none'` in production.** No network calls from renderer. All model loading happens in main process via local file paths.
+- **Gemma 4 E4B Instruct Q4_K_M GGUF (~2.5 GB)** is the target. Community conversions live under `bartowski/google_gemma-4-e4b-it-GGUF` on HuggingFace. Verify availability in Task 1 before proceeding — if no GGUF exists yet, fall back to Gemma 3 4B Instruct Q4_K_M (`bartowski/gemma-3-4b-it-GGUF`) and document the fallback in CLAUDE.md.
+- **Model hash sync is manual.** Per CLAUDE.md gotcha: after `scripts/publish-manifest.sh` the SHA-256 in `ModelDownloadService.ts` `MODEL_DEFINITIONS` must be hand-updated. The packaging script prints hashes to stdout but does not auto-patch.
+- **Summarization IS a TaskQueue task.** Add `'summarization'` to the `TaskType` union and append it to both audio and PDF pipeline chains. `SummarizationExecutor.execute()` returns `Promise<void>` and persists the result via `SessionService.saveGeneratedSummary(id, title, text, modelId)` — results flow to the UI through the existing `task:completed` event stream + `summary:get`, never as a direct IPC return value.
+- **Model-missing is a skip, not a failure.** If `modelDownloadService.isModelInstalled(activeSummarizationModelId)` returns `false`, the executor completes successfully with no output. Do not mark the task as `failed`. Do not surface a modal error. Summary feature is strictly opt-in.
+- **Anonymized text extraction happens server-side.** `SessionService` will gain a `getAnonymizedPlainText(sessionId)` helper that loads the stored TipTap JSON and walks it into plain text — the renderer passes only `sessionId`, never raw text across IPC.
+- **Test discipline:** Write tests for logic (service classes, schema validation, IPC input validation, DB migrations, prompt builder). Skip tests for trivial wiring (preload bridge, React button click → IPC call). Tests use vitest + jsdom, live next to the code in `__tests__/` or `*.test.ts` files.
+- **Conventions:** No semicolons, single quotes, no trailing commas, 100 char lines. Unused vars prefixed `_`. Never write `#` comments inside Bash tool calls.
+
+---
+
+## File Structure
+
+Files created (new):
+- `scripts/setup-llama.sh` — install llama.cpp binary + dylibs to `resources/bin/` + `resources/lib/`; optional `--model` flag downloads Gemma 4 E4B GGUF to `~/.therascript/models/summarization/`.
+- `src/main/ml/LlamaSummarizer.ts` — plain service: spawns `llama-cli`, returns the parsed summary string. Not a `TaskExecutor`; used by the executor below.
+- `src/main/ml/__tests__/LlamaSummarizer.test.ts` — unit tests (args builder, output parser, path-traversal guard).
+- `src/main/ml/SummarizationExecutor.ts` — `TaskExecutor` implementation. Skips when model missing; otherwise calls `LlamaSummarizer` and persists via `SessionService.saveGeneratedSummary`.
+- `src/main/ml/__tests__/SummarizationExecutor.test.ts` — skip-when-missing + save-on-success tests.
+- `src/main/ml/summarization-prompt.ts` — builds the Gemma 4 chat-template prompt for German 2-sentence summary.
+- `src/main/ml/__tests__/summarization-prompt.test.ts` — prompt builder tests.
+- `src/main/ipc/summary-handlers.ts` — IPC handlers `summary:get` (reads title + summary), `summary:updateTitle`, `summary:updateText`. No regenerate, no clear, no synchronous generate.
+- `src/main/ipc/__tests__/summary-handlers.test.ts` — handler input-validation tests.
+- `src/main/db/migrations/002-add-summary-to-sessions.sql` — add `title`, `summary`, `summary_model_id`, `summarized_at` columns to `sessions` (adjust the leading number to match the next free migration index; migrations are `.sql` files tracked via `schema_version`, not TypeScript).
+- `src/main/ml/tiptap-plain-text.ts` — pure function extracting plain text from a TipTap JSON document (unwrap speaker labels, placeholder chips, timestamps).
+- `src/main/ml/__tests__/tiptap-plain-text.test.ts` — extraction tests.
+- `src/renderer/src/components/review/SummaryPanel.tsx` — "Zusammenfassung" panel in Review Editor: button + generated text + regenerate + error state.
+- `src/renderer/src/components/review/__tests__/SummaryPanel.test.tsx` — renders states: empty / loading / success / error / model-missing.
+- `src/shared/validation/summary-schemas.ts` — Zod schemas for `summary:get` / `summary:updateTitle` / `summary:updateText`.
+
+Files modified:
+- `src/shared/validation/model-catalog-schemas.ts` — extend `ModelGroupSchema` to include `'summarization'`.
+- `src/main/services/ModelDownloadService.ts` — add Gemma 4 E4B entry to `MODEL_DEFINITIONS`.
+- `src/main/services/SettingsService.ts` — add `activeModels.summarization` field + default + `GROUP_TO_SETTINGS_KEY` mapping. Note: existing shape is `{ transcription, diarization, diarizationPipeline, ner, ocr }` — extend with `summarization`.
+- `src/main/services/SessionService.ts` — add `getAnonymizedPlainText(id)`, `getSummary(id)` returning `{ title, text, modelId, summarizedAt }`, `saveGeneratedSummary(id, title, text, modelId)`, `updateTitle(id, title)`, `updateSummaryText(id, text)`.
+- `src/shared/types/IpcApi.ts` — add `SummaryApi` interface to `IpcApi`.
+- `src/preload/index.ts` — expose `summary` API via contextBridge.
+- `src/main/index.ts` — wire up `LlamaSummarizer` executor + `registerSummaryHandlers()`.
+- `src/renderer/src/views/ReviewEditor.tsx` — mount `<SummaryPanel>` above or below the anonymization view.
+- `src/renderer/src/components/settings/ModelsSettingsSection.tsx` (or equivalent) — add new `"summarization"` group to the models settings UI.
+- `src/renderer/src/components/FirstLaunchScreen.tsx` — no change (summary model is optional, not required at first launch). Document this.
+- `scripts/publish-manifest.sh` — add Gemma 4 E4B entry to `MODELS` array.
+- `scripts/build-sidecar.sh` — no change (llama.cpp is a standalone binary, not Python).
+- `electron-builder.yml` — ensure `resources/bin/llama-cli` and `resources/lib/libllama*.dylib`, `libggml*.dylib` are packaged.
+- `CLAUDE.md` — document the new model type, setup script, manual hash sync, GGUF fallback.
+- `docs/product/features/summarization.md` — new feature doc (architecture, prompt, model, limits).
+
+---
+
+## Task 1: Verify GGUF availability and lock the model choice
+
+**Files:**
+- Read-only investigation; final notes written to the plan status comments or a scratch doc.
+
+- [ ] **Step 1: Check bartowski's Gemma 4 E4B GGUF repo**
+
+Run: `curl -sI https://huggingface.co/bartowski/google_gemma-4-e4b-it-GGUF/resolve/main/google_gemma-4-e4b-it-Q4_K_M.gguf | head -5`
+
+Expected: HTTP/2 200 (or 302 redirect to CDN) and a `content-length` header around `2500000000` (±500 MB).
+
+If 404: check the repo root `https://huggingface.co/bartowski/google_gemma-4-e4b-it-GGUF` in a browser for the correct filename (versions sometimes use `-unsloth-` or date suffixes). Note the resolved filename.
+
+- [ ] **Step 2: If no Gemma 4 E4B GGUF exists, confirm Gemma 3 4B fallback**
+
+Run: `curl -sI https://huggingface.co/bartowski/gemma-3-4b-it-GGUF/resolve/main/gemma-3-4b-it-Q4_K_M.gguf | head -5`
+
+Expected: HTTP/2 200.
+
+- [ ] **Step 3: Document the final choice inline in the plan**
+
+Edit this plan: replace all `<GGUF_URL>`, `<GGUF_FILENAME>`, `<GGUF_SIZE_BYTES>` placeholders below with the concrete values from Step 1 or Step 2. No code written yet.
+
+- [ ] **Step 4: Commit the plan update**
+
+```bash
+git add docs/superpowers/plans/2026-04-24-local-llm-summarization.md
+git commit -m "plan: lock GGUF source for summarization LLM"
+```
+
+---
+
+## Task 2: Setup script for llama.cpp + Gemma 4 E4B model
+
+**Files:**
+- Create: `scripts/setup-llama.sh`
+
+- [ ] **Step 1: Write the setup script skeleton**
+
+Mirror the structure of `scripts/setup-whisper.sh`. Contents:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+BIN_DIR="$REPO_ROOT/resources/bin"
+LIB_DIR="$REPO_ROOT/resources/lib"
+
+mkdir -p "$BIN_DIR" "$LIB_DIR"
+
+echo "==> Installing llama.cpp via Homebrew"
+if ! command -v brew >/dev/null 2>&1; then
+  echo "Homebrew is required. Install from https://brew.sh" >&2
+  exit 1
+fi
+brew install llama.cpp
+
+BREW_PREFIX="$(brew --prefix llama.cpp)"
+echo "==> Copying llama-cli binary"
+cp "$BREW_PREFIX/bin/llama-cli" "$BIN_DIR/llama-cli"
+
+echo "==> Copying runtime dylibs"
+cp "$BREW_PREFIX/lib/"libllama*.dylib "$LIB_DIR/" 2>/dev/null || true
+cp "$BREW_PREFIX/lib/"libggml*.dylib "$LIB_DIR/" 2>/dev/null || true
+
+echo "==> Re-signing binary with ad-hoc signature"
+codesign --force --sign - "$BIN_DIR/llama-cli"
+for dylib in "$LIB_DIR/"libllama*.dylib "$LIB_DIR/"libggml*.dylib; do
+  [ -f "$dylib" ] && codesign --force --sign - "$dylib"
+done
+
+echo "==> Verifying binary"
+"$BIN_DIR/llama-cli" --version
+
+if [[ "${1:-}" == "--model" ]]; then
+  MODEL_DIR="$HOME/.therascript/models/summarization"
+  mkdir -p "$MODEL_DIR"
+  MODEL_FILE="$MODEL_DIR/<GGUF_FILENAME>"
+  if [ ! -f "$MODEL_FILE" ]; then
+    echo "==> Downloading Gemma 4 E4B (~2.5 GB)"
+    curl -L --fail -o "$MODEL_FILE" "<GGUF_URL>"
+  else
+    echo "Model already present: $MODEL_FILE"
+  fi
+  echo "==> SHA-256:"
+  shasum -a 256 "$MODEL_FILE"
+fi
+
+echo "==> Done"
+```
+
+- [ ] **Step 2: Make executable and run for dev**
+
+```bash
+chmod +x scripts/setup-llama.sh
+./scripts/setup-llama.sh --model
+```
+
+Expected: `resources/bin/llama-cli --version` succeeds, model file present in `~/.therascript/models/summarization/<GGUF_FILENAME>`, SHA-256 printed.
+
+- [ ] **Step 3: Record the SHA-256**
+
+Copy the SHA-256 output to a scratch note. You will paste it into `MODEL_DEFINITIONS` in Task 6.
+
+- [ ] **Step 4: Smoke-test inference manually**
+
+```bash
+./resources/bin/llama-cli \
+  -m ~/.therascript/models/summarization/<GGUF_FILENAME> \
+  -p "Fasse in zwei Sätzen zusammen: Das Wetter war gut und wir gingen spazieren." \
+  --chat-template gemma \
+  -n 80 \
+  --temp 0.3 \
+  --no-display-prompt
+```
+
+Expected: A short German summary prints within a few seconds. If it hangs or outputs gibberish, check `--chat-template` support (`llama-cli --help | grep chat-template`) — Gemma 4 may use a different template name. Note the working template name for Task 4.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/setup-llama.sh
+git commit -m "feat(build): add llama.cpp + Gemma 4 E4B setup script"
+```
+
+---
+
+## Task 3: Extend model catalog schema to include `'summarization'` group
+
+**Files:**
+- Modify: `src/shared/validation/model-catalog-schemas.ts`
+- Test: `src/shared/validation/__tests__/model-catalog-schemas.test.ts` (create if missing)
+
+- [ ] **Step 1: Write failing test**
+
+Add to the test file:
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { ModelGroupSchema } from '../model-catalog-schemas'
+
+describe('ModelGroupSchema', () => {
+  it('accepts "summarization" as a valid group', () => {
+    expect(ModelGroupSchema.parse('summarization')).toBe('summarization')
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `vitest run src/shared/validation/__tests__/model-catalog-schemas.test.ts`
+
+Expected: FAIL — `"summarization"` not in enum.
+
+- [ ] **Step 3: Extend the enum**
+
+In `src/shared/validation/model-catalog-schemas.ts`:
+
+```ts
+export const ModelGroupSchema = z.enum(['asr', 'diarization', 'ner', 'summarization'])
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `vitest run src/shared/validation/__tests__/model-catalog-schemas.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Typecheck the repo**
+
+Run: `npm run typecheck`
+
+Expected: Errors where `ModelGroup` is pattern-matched exhaustively — the compiler will point you at `GROUP_TO_SETTINGS_KEY` in `SettingsService.ts` and any switch statements that miss `'summarization'`. Do not fix them here — Task 4 covers SettingsService; any other hits should get a `case 'summarization':` branch wired to sensible no-op behavior, consistent with the surrounding code.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/shared/validation/model-catalog-schemas.ts src/shared/validation/__tests__/model-catalog-schemas.test.ts
+git commit -m "feat(catalog): add summarization model group"
+```
+
+---
+
+## Task 4: Add `activeModels.summarization` to SettingsService
+
+**Files:**
+- Modify: `src/main/services/SettingsService.ts`
+- Test: `src/main/services/__tests__/SettingsService.test.ts` (create if missing)
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { SettingsService } from '../SettingsService'
+
+describe('SettingsService defaults', () => {
+  it('includes summarization in activeModels defaults', () => {
+    const svc = new SettingsService()
+    expect(svc.getSettings().activeModels.summarization).toBe('gemma-4-e4b-summarization')
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `vitest run src/main/services/__tests__/SettingsService.test.ts`
+
+Expected: FAIL — property missing or undefined.
+
+- [ ] **Step 3: Update the AppSettings shape and defaults**
+
+In `src/main/services/SettingsService.ts`, extend the existing `AppSettings.activeModels` type (current shape is `{ transcription, diarization, diarizationPipeline, ner, ocr }`) by adding `summarization: string`. Do NOT remove or rename the existing fields.
+
+Then extend `defaults.activeModels` with one new line:
+
+```ts
+summarization: 'gemma-4-e4b-summarization',
+```
+
+(Preserve the existing default values for the other fields — read them from the current file, do not replace the whole block.)
+
+Extend `GROUP_TO_SETTINGS_KEY` by adding one entry; keep existing mappings as-is:
+
+```ts
+summarization: 'summarization',
+```
+
+TypeScript will enforce exhaustiveness over `ModelGroup` — once Task 3 adds `'summarization'` to the enum, the compiler will flag this map as incomplete until this line is added.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `vitest run src/main/services/__tests__/SettingsService.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/services/SettingsService.ts src/main/services/__tests__/SettingsService.test.ts
+git commit -m "feat(settings): add active summarization model"
+```
+
+---
+
+## Task 5: Add `'summarization'` to TaskType and both pipeline chains
+
+**Files:**
+- Modify: `src/shared/types/Task.ts` (or wherever `TaskType` lives)
+- Modify: `src/main/services/TaskQueueService.ts` — extend audio + PDF pipeline chains
+
+- [ ] **Step 1: Find the current TaskType definition and pipeline chains**
+
+Run: `grep -rn "TaskType\|'anonymization'" src/shared/types src/main/services --include="*.ts"`
+
+Expected: locate the union (current values are `'transcription' | 'diarization' | 'alignment' | 'extraction' | 'ocr' | 'anonymization'`) and the pipeline chain arrays for audio + PDF.
+
+- [ ] **Step 2: Extend TaskType**
+
+Append `| 'summarization'` to the union. Do not reorder existing members.
+
+- [ ] **Step 3: Append to pipeline chains**
+
+In `TaskQueueService`, locate the chain arrays and append `'summarization'` as the last element:
+
+```ts
+// audio pipeline (example — match actual existing chain)
+const AUDIO_PIPELINE: TaskType[] = ['transcription', 'diarization', 'alignment', 'anonymization', 'summarization']
+// PDF pipeline (example — match actual existing chain)
+const PDF_PIPELINE: TaskType[] = ['extraction', 'ocr', 'anonymization', 'summarization']
+```
+
+Preserve the existing order of the other steps. The summarization step must be **last** — it depends on the anonymized document being persisted.
+
+- [ ] **Step 4: Typecheck**
+
+Run: `npm run typecheck`
+
+Expected: TypeScript errors in switches that pattern-match `TaskType`. For each, add a `case 'summarization':` branch. For now, stub with a throw (`throw new Error('Summarization executor not yet registered')`) — the real executor wires up in Task 11. This commit leaves the type in place but not functional yet; that is intentional and keeps the commit small.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/shared/types/Task.ts src/main/services/TaskQueueService.ts <any-other-switch-files>
+git commit -m "feat(task): add summarization as pipeline tail step"
+```
+
+---
+
+## Task 6: Add Gemma 4 E4B to MODEL_DEFINITIONS
+
+**Files:**
+- Modify: `src/main/services/ModelDownloadService.ts`
+
+- [ ] **Step 1: Add the model entry**
+
+In the `MODEL_DEFINITIONS` array, append:
+
+```ts
+{
+  id: 'gemma-4-e4b-summarization',
+  label: 'Gemma 4 E4B (Summarization)',
+  url: `${R2_CDN}/<GGUF_FILENAME>`,
+  relativePath: 'summarization/<GGUF_FILENAME>',
+  checkPath: 'summarization/<GGUF_FILENAME>',
+  sizeBytes: <GGUF_SIZE_BYTES>,
+  sha256: '<SHA_FROM_TASK_2>',
+  group: 'summarization',
+  isRequired: false,
+  description: 'Lokales 4B-Parameter-Modell für 2-Satz-Zusammenfassungen deutscher Texte.',
+  languages: ['de', 'en'],
+},
+```
+
+`isRequired: false` is the critical flag — FirstLaunchScreen will skip it.
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npm run typecheck`
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/main/services/ModelDownloadService.ts
+git commit -m "feat(models): register Gemma 4 E4B summarization model"
+```
+
+---
+
+## Task 7: Add summary columns to sessions table (SQL migration)
+
+**Files:**
+- Create: `src/main/db/migrations/00N-add-summary-to-sessions.sql` — determine `N` from Step 1 (next free index after existing migrations).
+
+- [ ] **Step 1: Find the next migration index**
+
+Run: `ls src/main/db/migrations/`
+
+Expected: numbered `.sql` files like `001-initial-schema.sql`. Migrations are tracked by `schema_version` in `src/main/db/connection.ts` and run automatically on startup — no registry file to edit. Pick the next free number (e.g. `002` if `001` is the last existing migration).
+
+- [ ] **Step 2: Verify summary column does not already exist**
+
+Run: `grep -n "summary" src/main/db/migrations/*.sql || echo "not present"`
+
+Expected: `not present` (or no hits on the `sessions` table).
+
+- [ ] **Step 3: Write the migration**
+
+Create `src/main/db/migrations/002-add-summary-to-sessions.sql` (adjust number per Step 1):
+
+```sql
+ALTER TABLE sessions ADD COLUMN title TEXT;
+ALTER TABLE sessions ADD COLUMN summary TEXT;
+ALTER TABLE sessions ADD COLUMN summary_model_id TEXT;
+ALTER TABLE sessions ADD COLUMN summarized_at TEXT;
+```
+
+Four columns: `title` is the LLM-generated or user-edited session headline (view layer falls back to formatted date if `NULL` / empty); `summary_model_id` lets us invalidate generation provenance when the active model changes; `summarized_at` is an ISO-8601 timestamp for debugging. No `edited_by_user` flags — user edits simply overwrite the values and, for the `summary`, clear `summary_model_id` to `NULL` (so we know a subsequent model upgrade shouldn't assume the text is still machine-authoritative).
+
+- [ ] **Step 4: Start the app to run the migration**
+
+Run: `npm run dev`
+
+Expected: main-process log shows migration executed, no SQL errors. Stop after first window paint.
+
+- [ ] **Step 5: Verify schema**
+
+```bash
+sqlite3 ~/.therascript/therascript.db ".schema sessions" | grep -E "title|summary|summarized"
+```
+
+Expected: the four new columns appear.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/main/db/migrations/002-add-summary-to-sessions.sql
+git commit -m "feat(db): add summary columns to sessions"
+```
+
+---
+
+## Task 7b: SessionService summary methods + TipTap plain-text extractor (TDD)
+
+**Files:**
+- Create: `src/main/ml/tiptap-plain-text.ts`
+- Test: `src/main/ml/__tests__/tiptap-plain-text.test.ts`
+- Modify: `src/main/services/SessionService.ts`
+- Test: `src/main/services/__tests__/SessionService.test.ts` (create if missing)
+
+- [ ] **Step 1: Write failing test for TipTap extractor**
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { tiptapToPlainText } from '../tiptap-plain-text'
+
+describe('tiptapToPlainText', () => {
+  it('joins text nodes across paragraphs with newlines', () => {
+    const doc = {
+      type: 'doc',
+      content: [
+        { type: 'paragraph', content: [{ type: 'text', text: 'Satz A.' }] },
+        { type: 'paragraph', content: [{ type: 'text', text: 'Satz B.' }] },
+      ],
+    }
+    expect(tiptapToPlainText(doc)).toBe('Satz A.\nSatz B.')
+  })
+
+  it('renders placeholderChip nodes using their label attribute', () => {
+    const doc = {
+      type: 'doc',
+      content: [
+        { type: 'paragraph', content: [
+          { type: 'text', text: 'Der Patient ' },
+          { type: 'placeholderChip', attrs: { label: '[PERSON 1]' } },
+          { type: 'text', text: ' war müde.' },
+        ] },
+      ],
+    }
+    expect(tiptapToPlainText(doc)).toBe('Der Patient [PERSON 1] war müde.')
+  })
+
+  it('drops speakerLabel and timestamp nodes (noise for LLM)', () => {
+    const doc = {
+      type: 'doc',
+      content: [
+        { type: 'paragraph', content: [
+          { type: 'speakerLabel', attrs: { speaker: 'SPEAKER_00' } },
+          { type: 'timestamp', attrs: { seconds: 12.3 } },
+          { type: 'text', text: 'Hallo.' },
+        ] },
+      ],
+    }
+    expect(tiptapToPlainText(doc)).toBe('Hallo.')
+  })
+
+  it('returns empty string for malformed input', () => {
+    expect(tiptapToPlainText(null as any)).toBe('')
+    expect(tiptapToPlainText({} as any)).toBe('')
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify FAIL**
+
+Run: `vitest run src/main/ml/__tests__/tiptap-plain-text.test.ts`
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the extractor**
+
+```ts
+interface TipTapNode {
+  type?: string
+  text?: string
+  attrs?: Record<string, unknown>
+  content?: TipTapNode[]
+}
+
+export function tiptapToPlainText(doc: TipTapNode | null | undefined): string {
+  if (!doc || typeof doc !== 'object') return ''
+  const parts: string[] = []
+
+  const walk = (node: TipTapNode, into: string[]): void => {
+    if (!node) return
+    switch (node.type) {
+      case 'text':
+        into.push(node.text ?? '')
+        return
+      case 'placeholderChip':
+        into.push(String(node.attrs?.label ?? ''))
+        return
+      case 'speakerLabel':
+      case 'timestamp':
+        return
+      case 'paragraph': {
+        const buf: string[] = []
+        for (const child of node.content ?? []) walk(child, buf)
+        into.push(buf.join(''))
+        return
+      }
+      default:
+        for (const child of node.content ?? []) walk(child, into)
+    }
+  }
+
+  const buf: string[] = []
+  walk(doc, buf)
+  return buf.filter(s => s.length > 0).join('\n')
+}
+```
+
+- [ ] **Step 4: Run extractor test**
+
+Run: `vitest run src/main/ml/__tests__/tiptap-plain-text.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Locate where the anonymized TipTap doc is stored**
+
+Run: `grep -rn "anonymizedPath\|anonymized_path" src/main --include="*.ts"`
+
+Note how the anonymized TipTap JSON is persisted (likely a file referenced by `sessions.anonymized_path`). The `SessionService.getAnonymizedPlainText` implementation will read that file and run it through `tiptapToPlainText`.
+
+- [ ] **Step 6: Add SessionService methods**
+
+In `src/main/services/SessionService.ts`, append five methods (adapt signatures to match existing conventions — e.g. if other methods take numeric IDs, use numeric; if they throw on not-found, throw; if they return null, return null):
+
+```ts
+getAnonymizedPlainText(sessionId: string): string {
+  const session = this.getById(sessionId) // or whatever the existing getter is called
+  if (!session?.anonymizedPath) throw new Error(`Session ${sessionId} has no anonymized document`)
+  const raw = readFileSync(session.anonymizedPath, 'utf-8')
+  const doc = JSON.parse(raw)
+  return tiptapToPlainText(doc)
+}
+
+getSummary(sessionId: string): { title: string | null; text: string; modelId: string | null; summarizedAt: string | null } | null {
+  const row = this.db.prepare('SELECT title, summary, summary_model_id, summarized_at FROM sessions WHERE id = ?').get(sessionId) as any
+  // Return a record if EITHER title or summary is present. Otherwise the renderer
+  // would lose a user-edited title when the summary happens to be empty.
+  // SummaryPanel handles the empty-text case by rendering null; the header still shows the title.
+  if (!row || (!row.summary && !row.title)) return null
+  return {
+    title: row.title ?? null,
+    text: row.summary ?? '',
+    modelId: row.summary_model_id,
+    summarizedAt: row.summarized_at,
+  }
+}
+
+saveGeneratedSummary(sessionId: string, title: string, text: string, modelId: string): void {
+  this.db.prepare('UPDATE sessions SET title = ?, summary = ?, summary_model_id = ?, summarized_at = ? WHERE id = ?')
+    .run(title, text, modelId, new Date().toISOString(), sessionId)
+}
+
+updateTitle(sessionId: string, title: string): void {
+  const normalized = title.trim()
+  this.db.prepare('UPDATE sessions SET title = ? WHERE id = ?')
+    .run(normalized.length > 0 ? normalized : null, sessionId)
+}
+
+updateSummaryText(sessionId: string, text: string): void {
+  const normalized = text.trim()
+  // User-edited summary is no longer LLM-authoritative — clear the model id.
+  this.db.prepare('UPDATE sessions SET summary = ?, summary_model_id = NULL WHERE id = ?')
+    .run(normalized.length > 0 ? normalized : null, sessionId)
+}
+```
+
+Adjust imports: `import { readFileSync } from 'node:fs'` and the `tiptapToPlainText` import. Match the actual DB-access pattern of the class (the snippet above assumes a `this.db` better-sqlite3 handle — if the codebase uses a repository layer, route through it).
+
+- [ ] **Step 7: Write a SessionService test for saveGeneratedSummary/getSummary round-trip**
+
+Use an in-memory sqlite DB seeded with the `sessions` schema + the Task 7 migration. Insert a dummy session, call `saveGeneratedSummary(id, title, text, modelId)`, then `getSummary`, assert `title`, `text`, and `modelId` match. Add a second test that inserts a session, calls `updateTitle` only (leaves summary null), and verifies `getSummary` returns the record with the title preserved and `text === ''`.
+
+- [ ] **Step 8: Run tests**
+
+Run: `vitest run src/main/services/__tests__/SessionService.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/main/ml/tiptap-plain-text.ts src/main/ml/__tests__/tiptap-plain-text.test.ts src/main/services/SessionService.ts src/main/services/__tests__/SessionService.test.ts
+git commit -m "feat(session): summary persistence + TipTap plain-text extractor"
+```
+
+---
+
+## Task 8: Write the summarization prompt builder (TDD)
+
+**Files:**
+- Create: `src/main/ml/summarization-prompt.ts`
+- Test: `src/main/ml/__tests__/summarization-prompt.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { buildSummarizationPrompt } from '../summarization-prompt'
+
+describe('buildSummarizationPrompt', () => {
+  it('requests structured TITEL + ZUSAMMENFASSUNG output in German', () => {
+    const prompt = buildSummarizationPrompt('Der Patient berichtet von Schlafstörungen.')
+    expect(prompt).toContain('TITEL:')
+    expect(prompt).toContain('ZUSAMMENFASSUNG:')
+    expect(prompt).toContain('zwei')
+    expect(prompt).toContain('Schlafstörungen')
+  })
+
+  it('truncates input exceeding 120k characters to fit model context', () => {
+    const long = 'a'.repeat(200_000)
+    const prompt = buildSummarizationPrompt(long)
+    expect(prompt.length).toBeLessThan(150_000)
+  })
+
+  it('preserves placeholder chips inside the anonymized text verbatim', () => {
+    const prompt = buildSummarizationPrompt('Der Patient [PERSON 1] war müde.')
+    expect(prompt).toContain('[PERSON 1]')
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify FAIL**
+
+Run: `vitest run src/main/ml/__tests__/summarization-prompt.test.ts`
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the builder**
+
+```ts
+const MAX_INPUT_CHARS = 120_000
+
+const INSTRUCTION = `Du bist ein professioneller Assistent für die Kurz-Beschreibung von Therapiesitzungen und medizinischen Dokumenten. Analysiere den folgenden Text und erzeuge zwei Ausgaben:
+
+1. Einen prägnanten deutschen Titel (Nominalphrase, 3–8 Wörter, max. 80 Zeichen). Keine vollständige Satz, keine Anführungszeichen, keine Einleitung.
+2. Eine Zusammenfassung in genau zwei prägnanten deutschen Sätzen. Nenne die zentralen Themen und Schlüsselpunkte.
+
+Formatiere die Antwort exakt so (zwei Zeilen, keine weiteren Inhalte):
+
+TITEL: <dein Titel>
+ZUSAMMENFASSUNG: <deine zwei Sätze>
+
+Keine Einleitung, keine Aufzählungen, keine Meta-Kommentare, keine Markdown-Formatierung.`
+
+export function buildSummarizationPrompt(text: string): string {
+  const trimmed = text.length > MAX_INPUT_CHARS
+    ? text.slice(0, MAX_INPUT_CHARS) + '\n[... gekürzt ...]'
+    : text
+  return `${INSTRUCTION}\n\nText:\n---\n${trimmed}\n---`
+}
+```
+
+Note: the chat template itself (`<start_of_turn>user`, etc.) is applied by `llama-cli --chat-template gemma` — we pass a plain prompt.
+
+- [ ] **Step 4: Run tests**
+
+Run: `vitest run src/main/ml/__tests__/summarization-prompt.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/ml/summarization-prompt.ts src/main/ml/__tests__/summarization-prompt.test.ts
+git commit -m "feat(ml): summarization prompt builder"
+```
+
+---
+
+## Task 9: Implement `LlamaSummarizer` service (TDD)
+
+**Files:**
+- Create: `src/main/ml/LlamaSummarizer.ts`
+- Test: `src/main/ml/__tests__/LlamaSummarizer.test.ts`
+
+This is a **plain service class** that wraps the llama-cli subprocess. It is called by `SummarizationExecutor` (Task 9b). Public surface: `summarize(text, signal): Promise<{ title: string; text: string }>`. No in-flight mutex is needed — the `TaskQueue` guarantees serial executor runs.
+
+- [ ] **Step 1: Write failing tests for the pure helpers**
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { buildLlamaArgs, parseLlamaOutput, validateModelPath } from '../LlamaSummarizer'
+
+describe('buildLlamaArgs', () => {
+  it('includes required flags with given model + prompt path', () => {
+    const args = buildLlamaArgs({
+      modelPath: '/models/gemma.gguf',
+      promptFilePath: '/tmp/prompt.txt',
+      maxTokens: 200,
+    })
+    expect(args).toContain('-m')
+    expect(args).toContain('/models/gemma.gguf')
+    expect(args).toContain('-f')
+    expect(args).toContain('/tmp/prompt.txt')
+    expect(args).toContain('--chat-template')
+    expect(args).toContain('gemma')
+    expect(args).toContain('-n')
+    expect(args).toContain('200')
+    expect(args).toContain('--no-display-prompt')
+  })
+})
+
+describe('parseLlamaOutput', () => {
+  it('extracts TITEL and ZUSAMMENFASSUNG fields into a structured result', () => {
+    const raw = 'TITEL: Schlafstörungen und Arbeitsstress\nZUSAMMENFASSUNG: Der Patient berichtet von Einschlafproblemen. Vereinbart wird ein Schlaftagebuch.\n[end of text]'
+    expect(parseLlamaOutput(raw)).toEqual({
+      title: 'Schlafstörungen und Arbeitsstress',
+      text: 'Der Patient berichtet von Einschlafproblemen. Vereinbart wird ein Schlaftagebuch.',
+    })
+  })
+
+  it('strips any trailing [end of text] marker and trims whitespace', () => {
+    const raw = 'TITEL: Thema\nZUSAMMENFASSUNG: Satz eins. Satz zwei.\n\nllama_print_timings: ...'
+    expect(parseLlamaOutput(raw)).toEqual({ title: 'Thema', text: 'Satz eins. Satz zwei.' })
+  })
+
+  it('tolerates lowercase variants and leading/trailing whitespace around keys', () => {
+    const raw = '  titel: Thema  \n  zusammenfassung:  Satz eins. Satz zwei.  '
+    expect(parseLlamaOutput(raw)).toEqual({ title: 'Thema', text: 'Satz eins. Satz zwei.' })
+  })
+
+  it('captures the full summary when the LLM splits it across multiple lines', () => {
+    const raw = 'TITEL: Thema\nZUSAMMENFASSUNG: Satz eins.\nSatz zwei.'
+    expect(parseLlamaOutput(raw)).toEqual({ title: 'Thema', text: 'Satz eins. Satz zwei.' })
+  })
+
+  it('throws a readable error when the output is missing either field', () => {
+    expect(() => parseLlamaOutput('something else entirely')).toThrow(/TITEL|ZUSAMMENFASSUNG/)
+  })
+})
+
+describe('validateModelPath', () => {
+  it('accepts paths under the allowed models directory', () => {
+    expect(() => validateModelPath('/root/models/summarization/gemma.gguf', '/root/models')).not.toThrow()
+  })
+
+  it('rejects paths that escape the allowed directory', () => {
+    expect(() => validateModelPath('/root/models/../etc/passwd', '/root/models')).toThrow()
+    expect(() => validateModelPath('/etc/passwd', '/root/models')).toThrow()
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify FAIL**
+
+Run: `vitest run src/main/ml/__tests__/LlamaSummarizer.test.ts`
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the module**
+
+```ts
+import { spawn } from 'node:child_process'
+import { writeFile, unlink } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve as resolvePath, relative } from 'node:path'
+import { randomUUID } from 'node:crypto'
+import { buildSummarizationPrompt } from './summarization-prompt'
+
+export interface LlamaArgsInput {
+  modelPath: string
+  promptFilePath: string
+  maxTokens: number
+}
+
+export function buildLlamaArgs(input: LlamaArgsInput): string[] {
+  return [
+    '-m', input.modelPath,
+    '-f', input.promptFilePath,
+    '--chat-template', 'gemma',
+    '-n', String(input.maxTokens),
+    '--temp', '0.3',
+    '--top-p', '0.9',
+    '--no-display-prompt',
+    '-ngl', '999',
+  ]
+}
+
+export interface SummarizeResult {
+  title: string
+  text: string
+}
+
+export function parseLlamaOutput(raw: string): SummarizeResult {
+  const cleaned = raw
+    .replace(/\[end of text\]\s*$/i, '')
+    .replace(/llama_print_timings[\s\S]*$/i, '')
+    .trim()
+
+  // Extract TITEL from its single line.
+  const titleMatch = cleaned.match(/^\s*titel\s*:\s*(.+?)\s*$/im)
+
+  // Extract ZUSAMMENFASSUNG as everything after the label to end-of-string.
+  // Do NOT use the /m flag here — a two-sentence summary may span multiple lines.
+  const sumLabelIdx = cleaned.search(/(^|\n)\s*zusammenfassung\s*:/i)
+  let summary = ''
+  if (sumLabelIdx >= 0) {
+    const sliced = cleaned.slice(sumLabelIdx).replace(/^\s*\n?/, '').replace(/^\s*zusammenfassung\s*:\s*/i, '')
+    // Collapse internal newlines to single spaces; trim edges.
+    summary = sliced.replace(/\s*\n\s*/g, ' ').trim()
+  }
+
+  if (!titleMatch || summary.length === 0) {
+    throw new Error(`Unerwartetes LLM-Output: TITEL oder ZUSAMMENFASSUNG fehlt. Rohtext: ${cleaned.slice(0, 200)}`)
+  }
+
+  return {
+    title: titleMatch[1].trim(),
+    text: summary,
+  }
+}
+
+export function validateModelPath(modelPath: string, allowedDir: string): void {
+  const resolved = resolvePath(modelPath)
+  const allowedResolved = resolvePath(allowedDir)
+  const rel = relative(allowedResolved, resolved)
+  if (rel.startsWith('..') || resolvePath(allowedResolved, rel) !== resolved) {
+    throw new Error(`Model path escapes allowed directory: ${modelPath}`)
+  }
+}
+
+export interface LlamaSummarizerDeps {
+  getModelPath: () => string
+  getBinaryPath: () => string
+  getAllowedModelsDir: () => string
+}
+
+export class LlamaSummarizer {
+  constructor(private readonly deps: LlamaSummarizerDeps) {}
+
+  async summarize(text: string, signal: AbortSignal): Promise<SummarizeResult> {
+    const modelPath = this.deps.getModelPath()
+    validateModelPath(modelPath, this.deps.getAllowedModelsDir())
+
+    const prompt = buildSummarizationPrompt(text)
+    const promptFile = join(tmpdir(), `therascript-summary-${randomUUID()}.txt`)
+    await writeFile(promptFile, prompt, 'utf-8')
+
+    try {
+      const args = buildLlamaArgs({ modelPath, promptFilePath: promptFile, maxTokens: 260 })
+      const raw = await this.spawn(args, signal)
+      return parseLlamaOutput(raw)
+    } finally {
+      await unlink(promptFile).catch(() => {})
+    }
+  }
+
+  private spawn(args: string[], signal: AbortSignal): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const child = spawn(this.deps.getBinaryPath(), args, { stdio: ['ignore', 'pipe', 'pipe'] })
+      let stdout = ''
+      let stderr = ''
+
+      const abort = () => { child.kill('SIGTERM'); reject(new Error('Summarization aborted')) }
+      signal.addEventListener('abort', abort, { once: true })
+
+      child.stdout.on('data', chunk => { stdout += chunk.toString() })
+      child.stderr.on('data', chunk => { stderr += chunk.toString() })
+      child.on('error', reject)
+      child.on('close', code => {
+        signal.removeEventListener('abort', abort)
+        if (code === 0) resolve(stdout)
+        else reject(new Error(`llama-cli exited with code ${code}: ${stderr.slice(-500)}`))
+      })
+    })
+  }
+}
+```
+
+For `getBinaryPath`, mirror whatever `WhisperService.ts` uses to resolve its `whisper-cli` binary — likely a helper that returns `app.isPackaged ? join(process.resourcesPath, 'bin', 'llama-cli') : join(__dirname, '../../../resources/bin/llama-cli')`. Reuse the helper (or factor one out if `WhisperService` inlines the logic).
+
+- [ ] **Step 4: Run tests**
+
+Run: `vitest run src/main/ml/__tests__/LlamaSummarizer.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/ml/LlamaSummarizer.ts src/main/ml/__tests__/LlamaSummarizer.test.ts
+git commit -m "feat(ml): LlamaSummarizer service with path-traversal guard"
+```
+
+---
+
+## Task 9b: Implement `SummarizationExecutor` (TDD)
+
+**Files:**
+- Create: `src/main/ml/SummarizationExecutor.ts`
+- Test: `src/main/ml/__tests__/SummarizationExecutor.test.ts`
+
+This is the `TaskExecutor` registered with the `TaskQueue`. It handles the "skip when model missing" behavior and persists the result (title + summary text) via `SessionService.saveGeneratedSummary`.
+
+- [ ] **Step 1: Write failing tests**
+
+```ts
+import { describe, it, expect, vi } from 'vitest'
+import { SummarizationExecutor } from '../SummarizationExecutor'
+
+const makeDeps = (over: any = {}) => ({
+  llamaSummarizer: {
+    summarize: vi.fn().mockResolvedValue({ title: 'Kurztitel', text: 'Eine Zusammenfassung.' }),
+    ...over.llamaSummarizer,
+  },
+  sessionService: {
+    getAnonymizedPlainText: vi.fn().mockReturnValue('Der Patient war müde.'),
+    saveGeneratedSummary: vi.fn(),
+    ...over.sessionService,
+  },
+  isModelInstalled: over.isModelInstalled ?? (() => true),
+  getActiveModelId: over.getActiveModelId ?? (() => 'gemma-4-e4b-summarization'),
+  logger: { info: vi.fn(), error: vi.fn() },
+})
+
+const task = { id: 't1', type: 'summarization' as const, sessionId: 'abc' } as any
+const onProgress = () => {}
+const signal = new AbortController().signal
+
+describe('SummarizationExecutor', () => {
+  it('skips cleanly when model is not installed (task succeeds, no spawn, no save)', async () => {
+    const deps = makeDeps({ isModelInstalled: () => false })
+    const exec = new SummarizationExecutor(deps)
+    await expect(exec.execute(task, onProgress, signal)).resolves.toBeUndefined()
+    expect(deps.llamaSummarizer.summarize).not.toHaveBeenCalled()
+    expect(deps.sessionService.saveGeneratedSummary).not.toHaveBeenCalled()
+    expect(deps.logger.info).toHaveBeenCalledWith(expect.stringMatching(/skip.*model/i))
+  })
+
+  it('summarizes anonymized text and persists title + text with active model id', async () => {
+    const deps = makeDeps()
+    const exec = new SummarizationExecutor(deps)
+    await exec.execute(task, onProgress, signal)
+    expect(deps.llamaSummarizer.summarize).toHaveBeenCalledWith('Der Patient war müde.', signal)
+    expect(deps.sessionService.saveGeneratedSummary).toHaveBeenCalledWith(
+      'abc', 'Kurztitel', 'Eine Zusammenfassung.', 'gemma-4-e4b-summarization',
+    )
+  })
+
+  it('propagates summarizer errors as task failure (no save)', async () => {
+    const deps = makeDeps({ llamaSummarizer: { summarize: vi.fn().mockRejectedValue(new Error('spawn failed')) } })
+    const exec = new SummarizationExecutor(deps)
+    await expect(exec.execute(task, onProgress, signal)).rejects.toThrow('spawn failed')
+    expect(deps.sessionService.saveGeneratedSummary).not.toHaveBeenCalled()
+  })
+
+  it('skips cleanly when anonymized text is empty (nothing to summarize)', async () => {
+    const deps = makeDeps({ sessionService: { getAnonymizedPlainText: vi.fn().mockReturnValue('') } })
+    const exec = new SummarizationExecutor(deps)
+    await expect(exec.execute(task, onProgress, signal)).resolves.toBeUndefined()
+    expect(deps.llamaSummarizer.summarize).not.toHaveBeenCalled()
+    expect(deps.sessionService.saveGeneratedSummary).not.toHaveBeenCalled()
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify FAIL**
+
+Run: `vitest run src/main/ml/__tests__/SummarizationExecutor.test.ts`
+
+Expected: FAIL.
+
+- [ ] **Step 3: Implement the executor**
+
+```ts
+import type { Task, TaskExecutor } from '../../shared/types/Task'
+
+export interface SummarizationExecutorDeps {
+  llamaSummarizer: { summarize(text: string, signal: AbortSignal): Promise<{ title: string; text: string }> }
+  sessionService: {
+    getAnonymizedPlainText(sessionId: string): string
+    saveGeneratedSummary(sessionId: string, title: string, text: string, modelId: string): void
+  }
+  isModelInstalled: () => boolean
+  getActiveModelId: () => string
+  logger: { info(msg: string): void; error(msg: string): void }
+}
+
+export class SummarizationExecutor implements TaskExecutor {
+  readonly taskType = 'summarization' as const
+
+  constructor(private readonly deps: SummarizationExecutorDeps) {}
+
+  async execute(task: Task, _onProgress: (p: number) => void, signal: AbortSignal): Promise<void> {
+    if (!this.deps.isModelInstalled()) {
+      this.deps.logger.info(`Summarization skipped for session ${task.sessionId}: model not installed`)
+      return
+    }
+
+    const text = this.deps.sessionService.getAnonymizedPlainText(task.sessionId)
+    if (!text || text.trim().length === 0) {
+      this.deps.logger.info(`Summarization skipped for session ${task.sessionId}: empty anonymized text`)
+      return
+    }
+
+    const result = await this.deps.llamaSummarizer.summarize(text, signal)
+    this.deps.sessionService.saveGeneratedSummary(task.sessionId, result.title, result.text, this.deps.getActiveModelId())
+  }
+}
+```
+
+Adapt the `TaskExecutor` interface shape (method name, progress-callback type) to whatever the existing codebase defines. The progress signature here is `(p: number) => void` (a 0–1 float) per the earlier review finding; match the actual signature. Summarization has no meaningful fine-grained progress, so it's not reported — task state transitions (pending → running → completed) are enough for UI.
+
+- [ ] **Step 4: Run tests**
+
+Run: `vitest run src/main/ml/__tests__/SummarizationExecutor.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/ml/SummarizationExecutor.ts src/main/ml/__tests__/SummarizationExecutor.test.ts
+git commit -m "feat(ml): SummarizationExecutor with skip-on-missing-model"
+```
+
+---
+
+## Task 10: Add IPC schemas + handlers (TDD on validation)
+
+**Files:**
+- Create: `src/shared/validation/summary-schemas.ts`
+- Create: `src/main/ipc/summary-handlers.ts`
+- Test: `src/main/ipc/__tests__/summary-handlers.test.ts`
+
+- [ ] **Step 1: Write Zod schemas**
+
+```ts
+import { z } from 'zod'
+
+const MAX_TITLE_CHARS = 120
+const MAX_SUMMARY_CHARS = 2_000
+
+export const SummaryGetInputSchema = z.object({
+  sessionId: z.string().min(1),
+})
+
+export const SummaryUpdateTitleInputSchema = z.object({
+  sessionId: z.string().min(1),
+  title: z.string().max(MAX_TITLE_CHARS),
+})
+
+export const SummaryUpdateTextInputSchema = z.object({
+  sessionId: z.string().min(1),
+  text: z.string().max(MAX_SUMMARY_CHARS),
+})
+
+export type SummaryGetInput = z.infer<typeof SummaryGetInputSchema>
+export type SummaryUpdateTitleInput = z.infer<typeof SummaryUpdateTitleInputSchema>
+export type SummaryUpdateTextInput = z.infer<typeof SummaryUpdateTextInputSchema>
+```
+
+No `generate`, `regenerate`, or `clear` channels. Initial generation happens automatically as the pipeline tail step (Task 5). There is no UI affordance to re-trigger; users can only edit the persisted text. Length caps guard against a compromised renderer flooding the DB with oversized blobs.
+
+- [ ] **Step 2: Write failing handler tests**
+
+```ts
+import { describe, it, expect, vi } from 'vitest'
+import { handleSummaryGet, handleSummaryUpdateTitle, handleSummaryUpdateText } from '../summary-handlers'
+
+const makeDeps = (over: any = {}) => ({
+  sessionService: {
+    getSummary: vi.fn().mockReturnValue(null),
+    updateTitle: vi.fn(),
+    updateSummaryText: vi.fn(),
+    ...over.sessionService,
+  },
+})
+
+describe('summary:get', () => {
+  it('rejects empty sessionId', () => {
+    expect(() => handleSummaryGet({ sessionId: '' }, makeDeps())).toThrow()
+  })
+
+  it('returns the cached SummaryRecord when present', () => {
+    const record = {
+      title: 'Kurztitel', text: 'Cached.', modelId: 'gemma-4-e4b-summarization', summarizedAt: '2026-04-24T10:00:00Z',
+    }
+    const deps = makeDeps({ sessionService: { getSummary: vi.fn().mockReturnValue(record) } })
+    expect(handleSummaryGet({ sessionId: 'abc' }, deps)).toBe(record)
+  })
+
+  it('returns null when no summary', () => {
+    expect(handleSummaryGet({ sessionId: 'abc' }, makeDeps())).toBeNull()
+  })
+})
+
+describe('summary:updateTitle', () => {
+  it('rejects empty sessionId', () => {
+    expect(() => handleSummaryUpdateTitle({ sessionId: '', title: 'x' }, makeDeps())).toThrow()
+  })
+
+  it('rejects title exceeding 120 chars', () => {
+    const long = 'x'.repeat(121)
+    expect(() => handleSummaryUpdateTitle({ sessionId: 'abc', title: long }, makeDeps())).toThrow()
+  })
+
+  it('delegates to SessionService.updateTitle', () => {
+    const deps = makeDeps()
+    handleSummaryUpdateTitle({ sessionId: 'abc', title: 'Neuer Titel' }, deps)
+    expect(deps.sessionService.updateTitle).toHaveBeenCalledWith('abc', 'Neuer Titel')
+  })
+
+  it('accepts empty title (resets to date-fallback in view layer)', () => {
+    const deps = makeDeps()
+    handleSummaryUpdateTitle({ sessionId: 'abc', title: '' }, deps)
+    expect(deps.sessionService.updateTitle).toHaveBeenCalledWith('abc', '')
+  })
+})
+
+describe('summary:updateText', () => {
+  it('delegates to SessionService.updateSummaryText', () => {
+    const deps = makeDeps()
+    handleSummaryUpdateText({ sessionId: 'abc', text: 'Editierte Zusammenfassung.' }, deps)
+    expect(deps.sessionService.updateSummaryText).toHaveBeenCalledWith('abc', 'Editierte Zusammenfassung.')
+  })
+
+  it('rejects text exceeding 2000 chars', () => {
+    const long = 'x'.repeat(2_001)
+    expect(() => handleSummaryUpdateText({ sessionId: 'abc', text: long }, makeDeps())).toThrow()
+  })
+})
+```
+
+- [ ] **Step 3: Run to verify FAIL**
+
+Run: `vitest run src/main/ipc/__tests__/summary-handlers.test.ts`
+
+Expected: FAIL.
+
+- [ ] **Step 4: Implement the handler module**
+
+```ts
+import { ipcMain } from 'electron'
+import {
+  SummaryGetInputSchema,
+  SummaryUpdateTitleInputSchema,
+  SummaryUpdateTextInputSchema,
+} from '../../shared/validation/summary-schemas'
+
+export interface SummaryRecord {
+  title: string | null
+  text: string
+  modelId: string | null
+  summarizedAt: string | null
+}
+
+export interface SummaryHandlerDeps {
+  sessionService: {
+    getSummary(id: string): SummaryRecord | null
+    updateTitle(id: string, title: string): void
+    updateSummaryText(id: string, text: string): void
+  }
+}
+
+export function handleSummaryGet(input: unknown, deps: SummaryHandlerDeps): SummaryRecord | null {
+  const parsed = SummaryGetInputSchema.parse(input)
+  return deps.sessionService.getSummary(parsed.sessionId)
+}
+
+export function handleSummaryUpdateTitle(input: unknown, deps: SummaryHandlerDeps): void {
+  const parsed = SummaryUpdateTitleInputSchema.parse(input)
+  deps.sessionService.updateTitle(parsed.sessionId, parsed.title)
+}
+
+export function handleSummaryUpdateText(input: unknown, deps: SummaryHandlerDeps): void {
+  const parsed = SummaryUpdateTextInputSchema.parse(input)
+  deps.sessionService.updateSummaryText(parsed.sessionId, parsed.text)
+}
+
+export function registerSummaryHandlers(deps: SummaryHandlerDeps): void {
+  ipcMain.handle('summary:get', (_evt, input) => handleSummaryGet(input, deps))
+  ipcMain.handle('summary:updateTitle', (_evt, input) => handleSummaryUpdateTitle(input, deps))
+  ipcMain.handle('summary:updateText', (_evt, input) => handleSummaryUpdateText(input, deps))
+}
+```
+
+No `taskQueue` dependency — the handler is purely a read + two edit endpoints. All SessionService methods referenced here are added in Task 7b.
+
+- [ ] **Step 5: Run tests**
+
+Run: `vitest run src/main/ipc/__tests__/summary-handlers.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/shared/validation/summary-schemas.ts src/main/ipc/summary-handlers.ts src/main/ipc/__tests__/summary-handlers.test.ts
+git commit -m "feat(ipc): summary get + update handlers"
+```
+
+---
+
+## Task 11: Wire `LlamaSummarizer` + summary handlers into `main/index.ts`
+
+**Files:**
+- Modify: `src/main/index.ts`
+- Modify: `src/main/services/ModelDownloadService.ts` (only if `getActiveModelPath` doesn't already exist)
+
+- [ ] **Step 1: Ensure `getActiveModelPath(group)` exists on `ModelDownloadService`**
+
+Run: `grep -n "getActiveModelPath\|getActiveModelId" src/main/services/ModelDownloadService.ts`
+
+If `getActiveModelId(group)` exists but `getActiveModelPath` does not, add:
+
+```ts
+getActiveModelPath(group: ModelGroup): string {
+  const activeId = this.getActiveModelId(group)
+  const def = MODEL_DEFINITIONS.find(d => d.id === activeId)
+  if (!def) throw new Error(`No model definition for active ${group} id: ${activeId}`)
+  return join(this.getModelsDir(), def.relativePath)
+}
+```
+
+(Use whatever the actual models-dir accessor is called — `getModelsDir()`, `modelsDir`, etc.)
+
+- [ ] **Step 2: Wire the service + executor + handlers at startup**
+
+Find the block that instantiates services and registers task executors (grep `new WhisperService\|registerExecutor`). Add after `sessionService`, `modelDownloadService`, and `taskQueue` are available:
+
+```ts
+import { LlamaSummarizer } from './ml/LlamaSummarizer'
+import { SummarizationExecutor } from './ml/SummarizationExecutor'
+import { registerSummaryHandlers } from './ipc/summary-handlers'
+import { join } from 'node:path'
+import { logger } from './logger' // or wherever the project's logger lives
+
+const llamaSummarizer = new LlamaSummarizer({
+  getModelPath: () => modelDownloadService.getActiveModelPath('summarization'),
+  getBinaryPath: () => resolveLlamaBinary(),
+  getAllowedModelsDir: () => join(modelDownloadService.getModelsDir(), 'summarization'),
+})
+
+const summarizationExecutor = new SummarizationExecutor({
+  llamaSummarizer,
+  sessionService,
+  isModelInstalled: () => modelDownloadService.isModelInstalled(
+    modelDownloadService.getActiveModelId('summarization'),
+  ),
+  getActiveModelId: () => modelDownloadService.getActiveModelId('summarization'),
+  logger,
+})
+
+taskQueue.registerExecutor(summarizationExecutor)
+
+registerSummaryHandlers({ sessionService })
+```
+
+`resolveLlamaBinary()` is a small helper mirroring the whisper binary resolver; if `WhisperService` inlines its resolver, copy the pattern here (or factor both into `src/main/services/resolve-binary.ts`).
+
+The `logger` reference should use whatever the project's existing logging convention is (console, debug-namespace, pino, etc.) — do not introduce a new logger.
+
+- [ ] **Step 3: Start the app**
+
+Run: `npm run dev`
+
+Expected: app starts, no errors in main-process log.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main/index.ts src/main/services/ModelDownloadService.ts
+git commit -m "feat(main): wire LlamaSummarizer and summary handlers"
+```
+
+---
+
+## Task 12: Expose summary API in preload + IpcApi types
+
+**Files:**
+- Modify: `src/shared/types/IpcApi.ts`
+- Modify: `src/preload/index.ts`
+
+- [ ] **Step 1: Add `SummaryApi` to `IpcApi.ts`**
+
+```ts
+export interface SummaryRecord {
+  title: string | null
+  text: string
+  modelId: string | null
+  summarizedAt: string | null
+}
+
+export interface SummaryApi {
+  get(sessionId: string): Promise<SummaryRecord | null>
+  updateTitle(sessionId: string, title: string): Promise<void>
+  updateText(sessionId: string, text: string): Promise<void>
+}
+
+export interface IpcApi {
+  // ... existing
+  summary: SummaryApi
+}
+```
+
+No `generate` / `regenerate` / `clear` — initial generation runs automatically as the pipeline tail step, and re-triggering is not exposed in v1. Users can only view the persisted record or edit the title/text in place.
+
+- [ ] **Step 2: Expose via preload**
+
+In `src/preload/index.ts`, add to the `api` object passed to `contextBridge.exposeInMainWorld`:
+
+```ts
+summary: {
+  get: (sessionId: string) => ipcRenderer.invoke('summary:get', { sessionId }),
+  updateTitle: (sessionId: string, title: string) =>
+    ipcRenderer.invoke('summary:updateTitle', { sessionId, title }),
+  updateText: (sessionId: string, text: string) =>
+    ipcRenderer.invoke('summary:updateText', { sessionId, text }),
+},
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `npm run typecheck`
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/shared/types/IpcApi.ts src/preload/index.ts
+git commit -m "feat(preload): expose summary API"
+```
+
+---
+
+## Task 13: Add `SummaryPanel` component (TDD)
+
+**Files:**
+- Create: `src/renderer/src/components/review/SummaryPanel.tsx`
+- Test: `src/renderer/src/components/review/__tests__/SummaryPanel.test.tsx`
+
+Minimal behavior:
+- Fetches `summary:get(sessionId)` on mount.
+- If the result is `null` **or** its `text` is empty (title-only record) → the component renders `null`. No placeholder, no CTA, no missing-model notice.
+- If the result has a non-empty `text` → renders it as inline-editable `contenteditable` paragraph. `Enter` or blur saves via `summary:updateText`; `Esc` cancels. Empty-on-blur is accepted and persisted (user can clear the summary; after the commit the panel unmounts on next reload).
+- No provenance icons (no 🔒, no ✨). No regenerate button.
+
+- [ ] **Step 1: Write failing tests**
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { SummaryPanel } from '../SummaryPanel'
+
+const makeApi = (over: any = {}) => ({
+  summary: {
+    get: vi.fn().mockResolvedValue(null),
+    updateText: vi.fn().mockResolvedValue(undefined),
+    updateTitle: vi.fn().mockResolvedValue(undefined),
+    ...over.summary,
+  },
+})
+
+beforeEach(() => { (globalThis as any).window.api = makeApi() })
+
+describe('SummaryPanel', () => {
+  it('renders null when there is no summary', async () => {
+    const { container } = render(<SummaryPanel sessionId="abc" />)
+    await waitFor(() => {
+      expect((globalThis as any).window.api.summary.get).toHaveBeenCalledWith('abc')
+    })
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders the summary text when present', async () => {
+    ;(globalThis as any).window.api = makeApi({
+      summary: { get: vi.fn().mockResolvedValue({
+        title: 'Kurztitel', text: 'Eine Zusammenfassung.',
+        modelId: 'gemma-4-e4b-summarization', summarizedAt: '2026-04-24T10:00:00Z',
+      }) },
+    })
+    render(<SummaryPanel sessionId="abc" />)
+    await waitFor(() => expect(screen.getByText('Eine Zusammenfassung.')).toBeDefined())
+  })
+
+  it('persists an edit via summary:updateText on blur', async () => {
+    ;(globalThis as any).window.api = makeApi({
+      summary: { get: vi.fn().mockResolvedValue({
+        title: null, text: 'Alter Text.', modelId: null, summarizedAt: null,
+      }) },
+    })
+    render(<SummaryPanel sessionId="abc" />)
+    const para = await screen.findByText('Alter Text.')
+    para.textContent = 'Neuer Text.'
+    fireEvent.blur(para)
+    await waitFor(() => {
+      expect((globalThis as any).window.api.summary.updateText).toHaveBeenCalledWith('abc', 'Neuer Text.')
+    })
+  })
+
+  it('does not persist on Escape (reverts to original)', async () => {
+    ;(globalThis as any).window.api = makeApi({
+      summary: { get: vi.fn().mockResolvedValue({
+        title: null, text: 'Original.', modelId: null, summarizedAt: null,
+      }) },
+    })
+    render(<SummaryPanel sessionId="abc" />)
+    const para = await screen.findByText('Original.')
+    para.textContent = 'Draft.'
+    fireEvent.keyDown(para, { key: 'Escape' })
+    expect((globalThis as any).window.api.summary.updateText).not.toHaveBeenCalled()
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify FAIL**
+
+Run: `vitest run src/renderer/src/components/review/__tests__/SummaryPanel.test.tsx`
+
+Expected: FAIL.
+
+- [ ] **Step 3: Implement the component**
+
+```tsx
+import { useEffect, useRef, useState, KeyboardEvent, FocusEvent } from 'react'
+
+interface Props {
+  sessionId: string
+}
+
+export function SummaryPanel({ sessionId }: Props) {
+  const [text, setText] = useState<string | null>(null)
+  const originalRef = useRef<string>('')
+
+  useEffect(() => {
+    let cancelled = false
+    window.api.summary.get(sessionId).then(record => {
+      if (cancelled) return
+      if (record && record.text && record.text.length > 0) {
+        setText(record.text)
+        originalRef.current = record.text
+      } else {
+        setText(null)
+      }
+    })
+    return () => { cancelled = true }
+  }, [sessionId])
+
+  if (text === null) return null
+
+  const commit = (el: HTMLElement) => {
+    const next = (el.textContent ?? '').trim()
+    if (next === originalRef.current) return
+    originalRef.current = next
+    window.api.summary.updateText(sessionId, next).catch(err => {
+      console.error('Failed to save summary edit', err)
+    })
+  }
+
+  const onBlur = (e: FocusEvent<HTMLParagraphElement>) => commit(e.currentTarget)
+  const onKeyDown = (e: KeyboardEvent<HTMLParagraphElement>) => {
+    if (e.key === 'Escape') {
+      e.currentTarget.textContent = originalRef.current
+      e.currentTarget.blur()
+    }
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      e.currentTarget.blur()
+    }
+  }
+
+  return (
+    <section className="rounded border p-3">
+      <p
+        className="text-sm outline-none focus:ring-1 focus:ring-ring rounded-sm"
+        contentEditable
+        suppressContentEditableWarning
+        onBlur={onBlur}
+        onKeyDown={onKeyDown}
+      >
+        {text}
+      </p>
+    </section>
+  )
+}
+```
+
+- No mount when there's nothing to show (panel is invisible in that state).
+- `contentEditable` uses `suppressContentEditableWarning` because React doesn't manage the DOM text inside. The `originalRef` tracks the committed value for change detection and Escape-revert.
+- `Shift+Enter` stays as a newline in contenteditable; plain `Enter` commits and blurs (common chat/editor convention).
+- No optimistic UI with state updates on every keystroke — we read `textContent` at commit time. Keeps the component trivial.
+
+- [ ] **Step 4: Run tests**
+
+Run: `vitest run src/renderer/src/components/review/__tests__/SummaryPanel.test.tsx`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/renderer/src/components/review/SummaryPanel.tsx src/renderer/src/components/review/__tests__/SummaryPanel.test.tsx
+git commit -m "feat(ui): summary panel with states"
+```
+
+---
+
+## Task 14: Mount `SummaryPanel` + editable title in `ReviewEditor`
+
+**Files:**
+- Modify: `src/renderer/src/views/ReviewEditor.tsx`
+- Possibly create: `src/renderer/src/components/review/EditableSessionTitle.tsx` (inline-edit h1)
+
+The `SummaryPanel` renders itself as `null` when there's nothing to show, so no `modelAvailable` prop, no gating logic in the parent — just mount it unconditionally. The editable title is wider: it affects not only the Review Editor header but also the session list (Task 14b).
+
+- [ ] **Step 1: Create the `EditableSessionTitle` component**
+
+`src/renderer/src/components/review/EditableSessionTitle.tsx`:
+
+```tsx
+import { useRef, KeyboardEvent, FocusEvent } from 'react'
+
+interface Props {
+  sessionId: string
+  title: string | null
+  fallback: string // e.g. formatted date shown as CSS placeholder when title is empty
+}
+
+export function EditableSessionTitle({ sessionId, title, fallback }: Props) {
+  // The DOM text content is always the actual title (empty string if null).
+  // The fallback is shown via CSS `::before` from `data-placeholder`, NOT as real text.
+  // This avoids the fallback-promotion bug where focusing+blurring an empty field
+  // would otherwise commit the fallback string as the real title.
+  const originalRef = useRef(title ?? '')
+
+  const commit = (el: HTMLElement) => {
+    const next = (el.textContent ?? '').trim()
+    if (next === originalRef.current) return
+    originalRef.current = next
+    window.api.summary.updateTitle(sessionId, next).catch(err => {
+      console.error('Failed to save title edit', err)
+    })
+  }
+
+  const onBlur = (e: FocusEvent<HTMLHeadingElement>) => commit(e.currentTarget)
+  const onKeyDown = (e: KeyboardEvent<HTMLHeadingElement>) => {
+    if (e.key === 'Escape') {
+      e.currentTarget.textContent = originalRef.current
+      e.currentTarget.blur()
+    }
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      e.currentTarget.blur()
+    }
+  }
+
+  return (
+    <h1
+      className="session-title text-2xl font-semibold outline-none focus:ring-1 focus:ring-ring rounded-sm"
+      contentEditable
+      suppressContentEditableWarning
+      onBlur={onBlur}
+      onKeyDown={onKeyDown}
+      aria-label="Sitzungstitel bearbeiten"
+      data-placeholder={fallback}
+    >
+      {title ?? ''}
+    </h1>
+  )
+}
+```
+
+Add the placeholder CSS once (e.g. in the component's stylesheet or the app's global Tailwind layer):
+
+```css
+.session-title:empty::before {
+  content: attr(data-placeholder);
+  color: var(--muted-foreground, #6b7280);
+  pointer-events: none;
+}
+```
+
+Result: when `title` is null, the DOM text is empty and CSS shows the fallback date. Focusing + blurring without typing reads empty `textContent`, which equals `originalRef.current = ''` → no update fires. Fallback is never promoted to real content.
+
+- [ ] **Step 2: Wire into ReviewEditor header**
+
+Replace the existing static date/time label with `<EditableSessionTitle>`. Mount `<SummaryPanel>` below it (above transcript):
+
+```tsx
+import { EditableSessionTitle } from '../components/review/EditableSessionTitle'
+import { SummaryPanel } from '../components/review/SummaryPanel'
+
+// In the render:
+<header>
+  <EditableSessionTitle
+    sessionId={session.id}
+    title={summaryRecord?.title ?? null}
+    fallback={formatDateTime(session.createdAt)}
+  />
+  <p className="text-sm text-muted-foreground">
+    {formatDateTime(session.createdAt)} • {formatDuration(session.durationSeconds)}
+  </p>
+</header>
+<SummaryPanel sessionId={session.id} />
+{/* existing transcript editor below */}
+```
+
+Source of `summaryRecord`: load once in the ReviewEditor via `window.api.summary.get(sessionId)`, cache it in local state, pass the `title` down. SummaryPanel does its own fetch; acceptable duplication for isolation, or factor into a shared hook `useSummary(sessionId)` if the repo prefers hooks. Match existing patterns.
+
+- [ ] **Step 3: Manual smoke test**
+
+```bash
+npm run dev
+```
+
+Process a new session. In Review Editor:
+- Verify an auto-generated title appears as h1.
+- Verify the summary paragraph appears below.
+- Click the title → type → blur → reload the app → title persists.
+- Same for the summary text.
+- Clear the title to empty → blur → reload → h1 now shows the date fallback.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/renderer/src/views/ReviewEditor.tsx src/renderer/src/components/review/EditableSessionTitle.tsx
+git commit -m "feat(review): editable title + summary panel"
+```
+
+---
+
+## Task 14b: Show session title in session list
+
+**Files:**
+- Modify: the session-list component (find via `grep -rn "anonymizedPath\|session.createdAt" src/renderer/src/components` + `src/renderer/src/views`)
+
+The session list currently shows a date-based label as primary. Update it to prefer `session.title` (when non-empty), falling back to the date. Secondary metadata row keeps the date + duration + status.
+
+- [ ] **Step 1: Locate the list component**
+
+Run: `grep -rn "createdAt" src/renderer/src --include="*.tsx" | head -20`
+
+Identify the card/row component.
+
+- [ ] **Step 2: Read `title` from the session model in the renderer**
+
+The renderer's session type needs a `title: string | null` field. The IPC layer that serves sessions (list endpoint, grep for `session:list` or similar) should already select the new `title` column — if not, extend the SELECT to include it and update the shared type.
+
+- [ ] **Step 3: Render title as primary, date as secondary**
+
+```tsx
+<div className="flex flex-col">
+  <span className="font-medium line-clamp-2">
+    {session.title && session.title.length > 0 ? session.title : formatDateTime(session.createdAt)}
+  </span>
+  <span className="text-xs text-muted-foreground">
+    {formatDateTime(session.createdAt)} • {formatDuration(session.durationSeconds)} • {session.status}
+  </span>
+</div>
+```
+
+- [ ] **Step 4: Live-update after pipeline completes**
+
+If the list already re-renders when a session's status changes (most likely via an existing `sessions:changed` event or task completion event), no extra work. If not, subscribe to `task:completed` with `type === 'summarization'` to refresh the affected row.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add <touched-files>
+git commit -m "feat(sessions): show LLM-generated title as primary label"
+```
+
+---
+
+## Task 15: (removed — not needed)
+
+Earlier revisions of this plan required the renderer to query `modelDownload.isInstalled('gemma-4-e4b-summarization')` to decide whether to show a "model missing" notice in the SummaryPanel. The revised UI does not render anything when no summary is present, so the renderer does not need to know about model installation state. The server-side `ModelDownloadService.isModelInstalled(...)` is still used by `SummarizationExecutor` (Task 9b) to decide whether to skip — no IPC change needed.
+
+Skip to Task 16.
+
+---
+
+## Task 16: Add summarization to Settings → Modelle section
+
+**Files:**
+- Modify: `src/renderer/src/components/settings/ModelsSettingsSection.tsx` (find actual file via `grep -rn "activeModels" src/renderer/src/components`)
+
+- [ ] **Step 1: Render the summarization group**
+
+Add a new group block matching the existing pattern for ASR/diarization/NER, driven by `group === 'summarization'` entries in the model catalog. Show download size, installed state, and a download button — reuse existing subcomponents.
+
+- [ ] **Step 2: Manual smoke test**
+
+Open Settings → Modelle. Confirm the "Zusammenfassung" group appears with the Gemma 4 E4B entry, a size indicator (~2.5 GB), and a download button when not installed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add <touched-files>
+git commit -m "feat(settings): show summarization model group"
+```
+
+---
+
+## Task 17: Add Gemma 4 E4B to manifest publishing + electron-builder packaging
+
+**Files:**
+- Modify: `scripts/publish-manifest.sh`
+- Modify: `electron-builder.yml`
+
+- [ ] **Step 1: Add entry to `MODELS` array in `publish-manifest.sh`**
+
+Find the `MODELS=(` array. Add:
+
+```
+"gemma-4-e4b-summarization|<GGUF_FILENAME>|Gemma 4 E4B — Summarization|summarization/<GGUF_FILENAME>|false|summarization/<GGUF_FILENAME>"
+```
+
+Adjust field order to match the existing rows.
+
+- [ ] **Step 2: Confirm `electron-builder.yml` packages the binary + dylibs**
+
+Check the `extraResources` section. If `resources/bin/**` and `resources/lib/**` are not already globbed, add:
+
+```yaml
+extraResources:
+  - from: resources/bin
+    to: bin
+    filter: ["**/*"]
+  - from: resources/lib
+    to: lib
+    filter: ["**/*"]
+```
+
+If these globs are already present, nothing to do — `llama-cli` and its dylibs land there automatically.
+
+- [ ] **Step 3: Smoke-test a local package build**
+
+```bash
+npm run package
+```
+
+Expected: build succeeds, DMG produced. Open the app bundle (right-click → Show Package Contents) and confirm `Contents/Resources/bin/llama-cli` + `Contents/Resources/lib/libllama*.dylib` exist.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/publish-manifest.sh electron-builder.yml
+git commit -m "feat(build): package llama-cli + register Gemma 4 E4B in manifest"
+```
+
+---
+
+## Task 18: Update docs (CLAUDE.md + feature doc)
+
+**Files:**
+- Modify: `CLAUDE.md`
+- Create: `docs/product/features/summarization.md`
+
+- [ ] **Step 1: Extend CLAUDE.md Commands section**
+
+Add to the command list:
+
+```
+scripts/setup-llama.sh             # Install llama.cpp binary via Homebrew → resources/bin/ + resources/lib/
+scripts/setup-llama.sh --model     # Also download Gemma 4 E4B (~2.5 GB)
+```
+
+- [ ] **Step 2: Extend CLAUDE.md Architecture — ML pipeline section**
+
+Add a fourth ML runtime:
+
+```
+4. llama.cpp subprocess — optionale Zusammenfassung über auswählbares Modell aus Katalog
+   (Default: Gemma 4 E4B Q4_K_M). Registriert als letzter Schritt beider Pipeline-Chains
+   (Audio + PDF). Wenn Modell nicht installiert → Executor skippt den Step geräuschlos,
+   Summary bleibt NULL. Active model in electron-store (`activeModels.summarization`).
+```
+
+- [ ] **Step 3: Add a Gotcha entry**
+
+```
+- **Gemma 4 E4B GGUF source:** Community GGUF from bartowski's HuggingFace repo (no official
+  GGUF from Google). If upstream rehosts or renames, update `MODEL_DEFINITIONS` URL and re-run
+  `scripts/publish-manifest.sh` to mirror into R2.
+```
+
+- [ ] **Step 4: Write the feature doc**
+
+Create `docs/product/features/summarization.md` with: purpose, model choice + rationale, prompt design, failure modes, privacy note (all local), RAM + disk cost, UI entry points.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add CLAUDE.md docs/product/features/summarization.md
+git commit -m "docs: document local LLM summarization feature"
+```
+
+---
+
+## Task 19: End-to-end verification
+
+- [ ] **Step 1: Full build**
+
+```bash
+npm run lint && npm run typecheck && npm run test && npm run build
+```
+
+Expected: all green.
+
+- [ ] **Step 2: Dev run — happy path (automatic)**
+
+```bash
+npm run dev
+```
+
+- Record or import a new session.
+- Wait for the full pipeline to finish (transcription → diarization → anonymization → summarization).
+- Open the session in Review Editor. Expect:
+  - Header shows an auto-generated German title (h1) — **not** the date.
+  - Below the title, a Zusammenfassung panel with 2 sentences, no icons, no regenerate button.
+- Click the title → type → Enter → it persists (reload the app to confirm).
+- Click the summary text → edit → blur → it persists.
+- Clear the title to empty → blur → h1 reverts to the date fallback.
+
+- [ ] **Step 3: Session list**
+
+- Return to the session list. Confirm this session is listed by its auto-title (not the date) as the primary label; date + duration appear in the secondary row.
+- Sessions processed before the feature was installed still show the date as primary — no regression.
+
+- [ ] **Step 4: Dev run — concurrent session (the real RAM test)**
+
+- Start recording/processing Session A (long enough to reach the pipeline).
+- While Session A is still in pipeline, open Session B (already processed) in Review Editor and edit its summary text.
+- Expect: the UI works smoothly (editing the text calls `summary:updateText` with no queue interaction). The summarization step for Session A runs after anonymization and does not collide RAM-wise with any resident pipeline model (check Activity Monitor — only one ML model resident at any time).
+
+- [ ] **Step 5: Dev run — model not installed**
+
+Delete `~/.therascript/models/summarization/` and restart.
+
+- Process a new session. Verify in the main-process log: `Summarization skipped for session <id>: model not installed`. No error surfaces in UI.
+- Open the session in Review Editor. Expect: h1 shows the date fallback, no SummaryPanel visible, no hint, no CTA. Feature is silent when unavailable.
+
+- [ ] **Step 6: Dev run — empty anonymized text**
+
+Process a session whose anonymized document is empty (edge case — e.g. a recording of only silence). Expect: executor logs skip, `title` and `summary` stay NULL, no crash.
+
+- [ ] **Step 7: Dev run — abort mid-inference**
+
+During the pipeline's summarization step, kill the app (Cmd+Q). Confirm no zombie `llama-cli` process remains (`ps | grep llama-cli`).
+
+- [ ] **Step 8: Production build smoke test**
+
+```bash
+npm run package
+```
+
+Install the DMG, run the app, exercise summarization end-to-end. Confirm Metal acceleration is active (in Activity Monitor, `llama-cli` should show GPU usage briefly).
+
+- [ ] **Step 9: Final commit (if any fixes needed)**
+
+```bash
+git commit -am "chore: summarization E2E polish"
+```
+
+---
+
+## Risk Register
+
+- **Gemma 4 E4B GGUF availability:** mitigated by Task 1 verification + Gemma 3 4B fallback.
+- **Chat template name mismatch:** mitigated by Task 2 Step 4 smoke test — if `gemma` template fails, check `llama-cli --help` for valid values and update `buildLlamaArgs`.
+- **RAM spike during Metal load:** llama.cpp Q4_K_M for a 4B model peaks around 3 GB resident. Sequential-model safety comes from the TaskQueue — summarization is registered as the last step of both pipeline chains, so it only runs after all other models have unloaded. Never add a direct IPC spawn path; the queue registration is the only supported invocation surface.
+- **Prompt-injection via transcript content:** acceptable here — output is shown to the same user who owns the transcript and is never executed. No mitigation needed at this stage.
+- **Quality on Swiss-German:** transcripts arrive as standard German (ASR normalizes). Summaries should be fine. If users report quality issues on Swiss-German specifics, consider a future dedicated Swiss-German prompt variant — out of scope here.

--- a/scripts/setup-llama.sh
+++ b/scripts/setup-llama.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+BIN_DIR="$REPO_ROOT/resources/bin"
+LIB_DIR="$REPO_ROOT/resources/lib"
+
+# Gemma 4 E4B Q4_K_M GGUF was not yet published when this feature shipped — see
+# CLAUDE.md ("Gemma 4 E4B GGUF source"). Fallback: Gemma 3 4B Instruct Q4_K_M.
+# The repo is HuggingFace-gated → run `huggingface-cli login` before --model.
+GGUF_FILENAME='gemma-3-4b-it-Q4_K_M.gguf'
+GGUF_URL="https://huggingface.co/bartowski/gemma-3-4b-it-GGUF/resolve/main/${GGUF_FILENAME}"
+
+mkdir -p "$BIN_DIR" "$LIB_DIR"
+
+echo '==> Installing llama.cpp via Homebrew'
+if ! command -v brew >/dev/null 2>&1; then
+  echo 'Homebrew is required. Install from https://brew.sh' >&2
+  exit 1
+fi
+brew install llama.cpp
+
+BREW_PREFIX="$(brew --prefix llama.cpp)"
+echo '==> Copying llama-cli binary'
+cp "$BREW_PREFIX/bin/llama-cli" "$BIN_DIR/llama-cli"
+
+echo '==> Copying runtime dylibs'
+cp "$BREW_PREFIX/lib/"libllama*.dylib "$LIB_DIR/" 2>/dev/null || true
+cp "$BREW_PREFIX/lib/"libggml*.dylib "$LIB_DIR/" 2>/dev/null || true
+
+echo '==> Re-signing binary with ad-hoc signature'
+codesign --force --sign - "$BIN_DIR/llama-cli"
+for dylib in "$LIB_DIR/"libllama*.dylib "$LIB_DIR/"libggml*.dylib; do
+  [ -f "$dylib" ] && codesign --force --sign - "$dylib"
+done
+
+echo '==> Verifying binary'
+"$BIN_DIR/llama-cli" --version
+
+if [[ "${1:-}" == '--model' ]]; then
+  MODEL_DIR="$HOME/.therascript/models/summarization"
+  mkdir -p "$MODEL_DIR"
+  MODEL_FILE="$MODEL_DIR/$GGUF_FILENAME"
+  if [ ! -f "$MODEL_FILE" ]; then
+    echo "==> Downloading Gemma 3 4B Instruct Q4_K_M (~2.5 GB)"
+    if command -v huggingface-cli >/dev/null 2>&1; then
+      huggingface-cli download "bartowski/gemma-3-4b-it-GGUF" \
+        "$GGUF_FILENAME" --local-dir "$MODEL_DIR" --local-dir-use-symlinks False
+    else
+      echo "huggingface-cli not found — falling back to direct curl (will fail if model is gated)" >&2
+      curl -L --fail -o "$MODEL_FILE" "$GGUF_URL"
+    fi
+  else
+    echo "Model already present: $MODEL_FILE"
+  fi
+  echo '==> SHA-256:'
+  shasum -a 256 "$MODEL_FILE"
+fi
+
+echo '==> Done'

--- a/src/main/db/__tests__/test-utils.ts
+++ b/src/main/db/__tests__/test-utils.ts
@@ -13,4 +13,5 @@ export function applyTestSchema(db: Database.Database): void {
     readFileSync(join(migrationsDir, '005-add-aligned-transcript-and-extracted-paths.sql'), 'utf-8')
   )
   db.exec(readFileSync(join(migrationsDir, '006-add-word-count.sql'), 'utf-8'))
+  db.exec(readFileSync(join(migrationsDir, '007-add-summarization.sql'), 'utf-8'))
 }

--- a/src/main/db/migrations/007-add-summarization.sql
+++ b/src/main/db/migrations/007-add-summarization.sql
@@ -1,0 +1,31 @@
+-- Sessions: persist LLM-generated summary alongside the existing title field.
+-- The existing `title` column is reused (overwritten by summarization output);
+-- only the summary-specific columns are new here. summary_model_id is cleared
+-- when the user edits the summary text so we know it's no longer LLM-authoritative.
+ALTER TABLE sessions ADD COLUMN summary TEXT;
+ALTER TABLE sessions ADD COLUMN summary_model_id TEXT;
+ALTER TABLE sessions ADD COLUMN summarized_at TEXT;
+
+-- Add 'summarization' to task_queue type CHECK constraint
+-- SQLite requires table recreation to alter CHECK constraints
+CREATE TABLE IF NOT EXISTS task_queue_new (
+    id TEXT PRIMARY KEY,
+    session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    type TEXT NOT NULL CHECK(type IN (
+        'transcription', 'diarization', 'alignment',
+        'extraction', 'ocr', 'anonymization', 'summarization'
+    )),
+    status TEXT NOT NULL CHECK(status IN ('pending', 'running', 'completed', 'failed', 'cancelled')),
+    progress REAL DEFAULT 0,
+    error TEXT,
+    created_at TEXT DEFAULT (datetime('now')),
+    started_at TEXT,
+    completed_at TEXT
+);
+
+INSERT INTO task_queue_new SELECT * FROM task_queue;
+DROP TABLE task_queue;
+ALTER TABLE task_queue_new RENAME TO task_queue;
+
+CREATE INDEX IF NOT EXISTS idx_task_queue_status ON task_queue(status);
+CREATE INDEX IF NOT EXISTS idx_task_queue_session ON task_queue(session_id);

--- a/src/main/db/migrations/index.ts
+++ b/src/main/db/migrations/index.ts
@@ -4,6 +4,7 @@ import addReviewAt from './003-add-review-at.sql?raw'
 import addTaskCancelledStatus from './004-add-task-cancelled-status.sql?raw'
 import addAlignedTranscriptAndExtractedPaths from './005-add-aligned-transcript-and-extracted-paths.sql?raw'
 import addWordCount from './006-add-word-count.sql?raw'
+import addSummarization from './007-add-summarization.sql?raw'
 
 export interface Migration {
   version: number
@@ -16,5 +17,6 @@ export const migrations: Migration[] = [
   { version: 3, sql: addReviewAt },
   { version: 4, sql: addTaskCancelledStatus },
   { version: 5, sql: addAlignedTranscriptAndExtractedPaths },
-  { version: 6, sql: addWordCount }
+  { version: 6, sql: addWordCount },
+  { version: 7, sql: addSummarization }
 ]

--- a/src/main/db/repositories/SessionRepository.ts
+++ b/src/main/db/repositories/SessionRepository.ts
@@ -27,6 +27,9 @@ interface SessionRow {
   updated_at: string
   review_at: string | null
   word_count: number | null
+  summary: string | null
+  summary_model_id: string | null
+  summarized_at: string | null
 }
 
 function parseEntityMap(json: string | null, sessionId: string): EntityMap | null {
@@ -57,7 +60,10 @@ function rowToSession(row: SessionRow): Session {
     createdAt: row.created_at,
     updatedAt: row.updated_at,
     reviewAt: row.review_at,
-    wordCount: row.word_count
+    wordCount: row.word_count,
+    summary: row.summary,
+    summaryModelId: row.summary_model_id,
+    summarizedAt: row.summarized_at
   }
 }
 
@@ -159,6 +165,18 @@ export class SessionRepository {
     if (input.wordCount !== undefined) {
       sets.push('word_count = ?')
       values.push(input.wordCount)
+    }
+    if (input.summary !== undefined) {
+      sets.push('summary = ?')
+      values.push(input.summary)
+    }
+    if (input.summaryModelId !== undefined) {
+      sets.push('summary_model_id = ?')
+      values.push(input.summaryModelId)
+    }
+    if (input.summarizedAt !== undefined) {
+      sets.push('summarized_at = ?')
+      values.push(input.summarizedAt)
     }
 
     if (sets.length === 0) return this.findById(id)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -39,6 +39,16 @@ import { AlignmentService } from './ml/AlignmentService'
 import { AnonymizationService } from './ml/AnonymizationService'
 import { PDFExtractionExecutor } from './services/PDFExtractionExecutor'
 import { VisionOCRService } from './ml/VisionOCRService'
+import { LlamaSummarizer } from './ml/LlamaSummarizer'
+import { SummarizationExecutor } from './ml/SummarizationExecutor'
+import { SessionService } from './services/SessionService'
+import {
+  getActiveModelPath,
+  getActiveModelId,
+  isModelInstalled,
+  getModelsDir
+} from './services/ModelDownloadService'
+import { registerSummaryHandlers } from './ipc/summary-handlers'
 
 function createWindow(): void {
   // Set background color based on theme to prevent white flash in dark mode
@@ -148,6 +158,26 @@ app.whenReady().then(() => {
   taskQueue.registerExecutor('extraction', new PDFExtractionExecutor())
   taskQueue.registerExecutor('ocr', new VisionOCRService())
 
+  const llamaSummarizer = new LlamaSummarizer({
+    getModelPath: () => getActiveModelPath('summarization'),
+    getBinaryPath: () =>
+      app.isPackaged
+        ? join(process.resourcesPath, 'bin', 'llama-cli')
+        : join(app.getAppPath(), 'resources', 'bin', 'llama-cli'),
+    getAllowedModelsDir: () => join(getModelsDir(), 'summarization')
+  })
+  const sessionService = new SessionService(getDatabase())
+  taskQueue.registerExecutor(
+    'summarization',
+    new SummarizationExecutor({
+      llamaSummarizer,
+      sessionService,
+      isModelInstalled: () => isModelInstalled(getActiveModelId('summarization')),
+      getActiveModelId: () => getActiveModelId('summarization'),
+      logger: { info: (msg): void => console.log(msg), error: (msg): void => console.error(msg) }
+    })
+  )
+
   ensureSpotlightExclusion()
 
   registerSessionHandlers()
@@ -163,6 +193,7 @@ app.whenReady().then(() => {
   registerModelUpdateHandlers()
   registerPipelineHandlers()
   registerAppUpdateHandlers()
+  registerSummaryHandlers()
 
   setupCSP()
   createWindow()

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -193,7 +193,7 @@ app.whenReady().then(() => {
   registerModelUpdateHandlers()
   registerPipelineHandlers()
   registerAppUpdateHandlers()
-  registerSummaryHandlers()
+  registerSummaryHandlers({ sessionService })
 
   setupCSP()
   createWindow()

--- a/src/main/ipc/__tests__/summary-handlers.test.ts
+++ b/src/main/ipc/__tests__/summary-handlers.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi } from 'vitest'
+import {
+  handleSummaryGet,
+  handleSummaryUpdateTitle,
+  handleSummaryUpdateText
+} from '../summary-handlers'
+
+const makeDeps = (
+  over: {
+    getSummary?: ReturnType<typeof vi.fn>
+    updateTitle?: ReturnType<typeof vi.fn>
+    updateSummaryText?: ReturnType<typeof vi.fn>
+  } = {}
+) => ({
+  sessionService: {
+    getSummary: over.getSummary ?? vi.fn().mockReturnValue(null),
+    updateTitle: over.updateTitle ?? vi.fn(),
+    updateSummaryText: over.updateSummaryText ?? vi.fn()
+  }
+})
+
+describe('summary:get', () => {
+  it('rejects empty sessionId', () => {
+    expect(() => handleSummaryGet({ sessionId: '' }, makeDeps())).toThrow()
+  })
+
+  it('returns the cached SummaryRecord when present', () => {
+    const record = {
+      title: 'Kurztitel',
+      text: 'Cached.',
+      modelId: 'gemma-summarization',
+      summarizedAt: '2026-04-24T10:00:00Z'
+    }
+    const deps = makeDeps({ getSummary: vi.fn().mockReturnValue(record) })
+    expect(handleSummaryGet({ sessionId: 'abc' }, deps)).toBe(record)
+  })
+
+  it('returns null when no summary', () => {
+    expect(handleSummaryGet({ sessionId: 'abc' }, makeDeps())).toBeNull()
+  })
+})
+
+describe('summary:updateTitle', () => {
+  it('rejects empty sessionId', () => {
+    expect(() => handleSummaryUpdateTitle({ sessionId: '', title: 'x' }, makeDeps())).toThrow()
+  })
+
+  it('rejects title exceeding 120 chars', () => {
+    const long = 'x'.repeat(121)
+    expect(() => handleSummaryUpdateTitle({ sessionId: 'abc', title: long }, makeDeps())).toThrow()
+  })
+
+  it('delegates to SessionService.updateTitle', () => {
+    const deps = makeDeps()
+    handleSummaryUpdateTitle({ sessionId: 'abc', title: 'Neuer Titel' }, deps)
+    expect(deps.sessionService.updateTitle).toHaveBeenCalledWith('abc', 'Neuer Titel')
+  })
+
+  it('accepts empty title (resets to date-fallback in view layer)', () => {
+    const deps = makeDeps()
+    handleSummaryUpdateTitle({ sessionId: 'abc', title: '' }, deps)
+    expect(deps.sessionService.updateTitle).toHaveBeenCalledWith('abc', '')
+  })
+})
+
+describe('summary:updateText', () => {
+  it('delegates to SessionService.updateSummaryText', () => {
+    const deps = makeDeps()
+    handleSummaryUpdateText({ sessionId: 'abc', text: 'Editierte Zusammenfassung.' }, deps)
+    expect(deps.sessionService.updateSummaryText).toHaveBeenCalledWith(
+      'abc',
+      'Editierte Zusammenfassung.'
+    )
+  })
+
+  it('rejects text exceeding 2000 chars', () => {
+    const long = 'x'.repeat(2_001)
+    expect(() => handleSummaryUpdateText({ sessionId: 'abc', text: long }, makeDeps())).toThrow()
+  })
+})

--- a/src/main/ipc/summary-handlers.ts
+++ b/src/main/ipc/summary-handlers.ts
@@ -1,6 +1,4 @@
 import { ipcMain } from 'electron'
-import { getDatabase } from '../db/connection'
-import { SessionService } from '../services/SessionService'
 import type { SummaryRecord } from '../services/SessionService'
 import {
   SummaryGetInputSchema,
@@ -31,8 +29,7 @@ export function handleSummaryUpdateText(input: unknown, deps: SummaryHandlerDeps
   deps.sessionService.updateSummaryText(parsed.sessionId, parsed.text)
 }
 
-export function registerSummaryHandlers(): void {
-  const deps: SummaryHandlerDeps = { sessionService: new SessionService(getDatabase()) }
+export function registerSummaryHandlers(deps: SummaryHandlerDeps): void {
   ipcMain.handle('summary:get', (_evt, input: unknown) => handleSummaryGet(input, deps))
   ipcMain.handle('summary:updateTitle', (_evt, input: unknown) =>
     handleSummaryUpdateTitle(input, deps)

--- a/src/main/ipc/summary-handlers.ts
+++ b/src/main/ipc/summary-handlers.ts
@@ -1,0 +1,43 @@
+import { ipcMain } from 'electron'
+import { getDatabase } from '../db/connection'
+import { SessionService } from '../services/SessionService'
+import type { SummaryRecord } from '../services/SessionService'
+import {
+  SummaryGetInputSchema,
+  SummaryUpdateTitleInputSchema,
+  SummaryUpdateTextInputSchema
+} from '../../shared/validation/summary-schemas'
+
+export interface SummaryHandlerDeps {
+  sessionService: {
+    getSummary(id: string): SummaryRecord | null
+    updateTitle(id: string, title: string): unknown
+    updateSummaryText(id: string, text: string): unknown
+  }
+}
+
+export function handleSummaryGet(input: unknown, deps: SummaryHandlerDeps): SummaryRecord | null {
+  const parsed = SummaryGetInputSchema.parse(input)
+  return deps.sessionService.getSummary(parsed.sessionId)
+}
+
+export function handleSummaryUpdateTitle(input: unknown, deps: SummaryHandlerDeps): void {
+  const parsed = SummaryUpdateTitleInputSchema.parse(input)
+  deps.sessionService.updateTitle(parsed.sessionId, parsed.title)
+}
+
+export function handleSummaryUpdateText(input: unknown, deps: SummaryHandlerDeps): void {
+  const parsed = SummaryUpdateTextInputSchema.parse(input)
+  deps.sessionService.updateSummaryText(parsed.sessionId, parsed.text)
+}
+
+export function registerSummaryHandlers(): void {
+  const deps: SummaryHandlerDeps = { sessionService: new SessionService(getDatabase()) }
+  ipcMain.handle('summary:get', (_evt, input: unknown) => handleSummaryGet(input, deps))
+  ipcMain.handle('summary:updateTitle', (_evt, input: unknown) =>
+    handleSummaryUpdateTitle(input, deps)
+  )
+  ipcMain.handle('summary:updateText', (_evt, input: unknown) =>
+    handleSummaryUpdateText(input, deps)
+  )
+}

--- a/src/main/ml/LlamaSummarizer.ts
+++ b/src/main/ml/LlamaSummarizer.ts
@@ -1,0 +1,132 @@
+import { spawn } from 'node:child_process'
+import { writeFile, unlink } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve as resolvePath, relative } from 'node:path'
+import { randomUUID } from 'node:crypto'
+import { buildSummarizationPrompt } from './summarization-prompt'
+
+export interface LlamaArgsInput {
+  modelPath: string
+  promptFilePath: string
+  maxTokens: number
+}
+
+export function buildLlamaArgs(input: LlamaArgsInput): string[] {
+  return [
+    '-m',
+    input.modelPath,
+    '-f',
+    input.promptFilePath,
+    '--chat-template',
+    'gemma',
+    '-n',
+    String(input.maxTokens),
+    '--temp',
+    '0.3',
+    '--top-p',
+    '0.9',
+    '--no-display-prompt',
+    '-ngl',
+    '999'
+  ]
+}
+
+export interface SummarizeResult {
+  title: string
+  text: string
+}
+
+export function parseLlamaOutput(raw: string): SummarizeResult {
+  const cleaned = raw
+    .replace(/\[end of text\]\s*$/i, '')
+    .replace(/llama_print_timings[\s\S]*$/i, '')
+    .trim()
+
+  const titleMatch = cleaned.match(/^\s*titel\s*:\s*(.+?)\s*$/im)
+
+  // Capture ZUSAMMENFASSUNG as everything after the label until end-of-string.
+  // No /m flag — a two-sentence summary may span multiple lines.
+  const sumLabelIdx = cleaned.search(/(^|\n)\s*zusammenfassung\s*:/i)
+  let summary = ''
+  if (sumLabelIdx >= 0) {
+    const sliced = cleaned
+      .slice(sumLabelIdx)
+      .replace(/^\s*\n?/, '')
+      .replace(/^\s*zusammenfassung\s*:\s*/i, '')
+    summary = sliced.replace(/\s*\n\s*/g, ' ').trim()
+  }
+
+  if (!titleMatch || summary.length === 0) {
+    throw new Error(
+      `Unerwartetes LLM-Output: TITEL oder ZUSAMMENFASSUNG fehlt. Rohtext: ${cleaned.slice(0, 200)}`
+    )
+  }
+
+  return {
+    title: titleMatch[1].trim(),
+    text: summary
+  }
+}
+
+export function validateModelPath(modelPath: string, allowedDir: string): void {
+  const resolved = resolvePath(modelPath)
+  const allowedResolved = resolvePath(allowedDir)
+  const rel = relative(allowedResolved, resolved)
+  if (rel.startsWith('..') || resolvePath(allowedResolved, rel) !== resolved) {
+    throw new Error(`Model path escapes allowed directory: ${modelPath}`)
+  }
+}
+
+export interface LlamaSummarizerDeps {
+  getModelPath: () => string
+  getBinaryPath: () => string
+  getAllowedModelsDir: () => string
+}
+
+export class LlamaSummarizer {
+  constructor(private readonly deps: LlamaSummarizerDeps) {}
+
+  async summarize(text: string, signal: AbortSignal): Promise<SummarizeResult> {
+    const modelPath = this.deps.getModelPath()
+    validateModelPath(modelPath, this.deps.getAllowedModelsDir())
+
+    const prompt = buildSummarizationPrompt(text)
+    const promptFile = join(tmpdir(), `therascript-summary-${randomUUID()}.txt`)
+    await writeFile(promptFile, prompt, 'utf-8')
+
+    try {
+      const args = buildLlamaArgs({ modelPath, promptFilePath: promptFile, maxTokens: 260 })
+      const raw = await this.spawn(args, signal)
+      return parseLlamaOutput(raw)
+    } finally {
+      await unlink(promptFile).catch(() => {})
+    }
+  }
+
+  private spawn(args: string[], signal: AbortSignal): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const child = spawn(this.deps.getBinaryPath(), args, { stdio: ['ignore', 'pipe', 'pipe'] })
+      let stdout = ''
+      let stderr = ''
+
+      const abort = (): void => {
+        child.kill('SIGTERM')
+        reject(new Error('Summarization aborted'))
+      }
+      signal.addEventListener('abort', abort, { once: true })
+
+      child.stdout.on('data', (chunk) => {
+        stdout += chunk.toString()
+      })
+      child.stderr.on('data', (chunk) => {
+        stderr += chunk.toString()
+      })
+      child.on('error', reject)
+      child.on('close', (code) => {
+        signal.removeEventListener('abort', abort)
+        if (code === 0) resolve(stdout)
+        else reject(new Error(`llama-cli exited with code ${code}: ${stderr.slice(-500)}`))
+      })
+    })
+  }
+}

--- a/src/main/ml/SummarizationExecutor.ts
+++ b/src/main/ml/SummarizationExecutor.ts
@@ -1,0 +1,58 @@
+import type { Task } from '../../shared/types'
+import type { TaskExecutor } from '../services/task-executors'
+
+export interface SummarizationExecutorDeps {
+  llamaSummarizer: {
+    summarize(text: string, signal: AbortSignal): Promise<{ title: string; text: string }>
+  }
+  sessionService: {
+    getAnonymizedPlainText(sessionId: string): string
+    saveGeneratedSummary(sessionId: string, title: string, text: string, modelId: string): unknown
+  }
+  isModelInstalled: () => boolean
+  getActiveModelId: () => string
+  logger: { info(msg: string): void; error(msg: string): void }
+}
+
+export class SummarizationExecutor implements TaskExecutor {
+  constructor(private readonly deps: SummarizationExecutorDeps) {}
+
+  async execute(task: Task, _onProgress: (progress: number) => void, signal?: AbortSignal): Promise<void> {
+    if (!this.deps.isModelInstalled()) {
+      this.deps.logger.info(
+        `Summarization skipped for session ${task.sessionId}: model not installed`
+      )
+      return
+    }
+
+    let text: string
+    try {
+      text = this.deps.sessionService.getAnonymizedPlainText(task.sessionId)
+    } catch (err) {
+      // Anonymized doc may be missing for older or partially-processed sessions —
+      // skip silently rather than fail the whole task and turn the session into 'error'.
+      this.deps.logger.info(
+        `Summarization skipped for session ${task.sessionId}: ${err instanceof Error ? err.message : String(err)}`
+      )
+      return
+    }
+
+    if (!text || text.trim().length === 0) {
+      this.deps.logger.info(
+        `Summarization skipped for session ${task.sessionId}: empty anonymized text`
+      )
+      return
+    }
+
+    const result = await this.deps.llamaSummarizer.summarize(
+      text,
+      signal ?? new AbortController().signal
+    )
+    this.deps.sessionService.saveGeneratedSummary(
+      task.sessionId,
+      result.title,
+      result.text,
+      this.deps.getActiveModelId()
+    )
+  }
+}

--- a/src/main/ml/__tests__/LlamaSummarizer.test.ts
+++ b/src/main/ml/__tests__/LlamaSummarizer.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest'
+import { buildLlamaArgs, parseLlamaOutput, validateModelPath } from '../LlamaSummarizer'
+
+describe('buildLlamaArgs', () => {
+  it('includes required flags with given model + prompt path', () => {
+    const args = buildLlamaArgs({
+      modelPath: '/models/gemma.gguf',
+      promptFilePath: '/tmp/prompt.txt',
+      maxTokens: 200
+    })
+    expect(args).toContain('-m')
+    expect(args).toContain('/models/gemma.gguf')
+    expect(args).toContain('-f')
+    expect(args).toContain('/tmp/prompt.txt')
+    expect(args).toContain('--chat-template')
+    expect(args).toContain('gemma')
+    expect(args).toContain('-n')
+    expect(args).toContain('200')
+    expect(args).toContain('--no-display-prompt')
+  })
+})
+
+describe('parseLlamaOutput', () => {
+  it('extracts TITEL and ZUSAMMENFASSUNG fields into a structured result', () => {
+    const raw =
+      'TITEL: Schlafstörungen und Arbeitsstress\nZUSAMMENFASSUNG: Der Patient berichtet von Einschlafproblemen. Vereinbart wird ein Schlaftagebuch.\n[end of text]'
+    expect(parseLlamaOutput(raw)).toEqual({
+      title: 'Schlafstörungen und Arbeitsstress',
+      text: 'Der Patient berichtet von Einschlafproblemen. Vereinbart wird ein Schlaftagebuch.'
+    })
+  })
+
+  it('strips any trailing [end of text] marker and trims whitespace', () => {
+    const raw = 'TITEL: Thema\nZUSAMMENFASSUNG: Satz eins. Satz zwei.\n\nllama_print_timings: ...'
+    expect(parseLlamaOutput(raw)).toEqual({ title: 'Thema', text: 'Satz eins. Satz zwei.' })
+  })
+
+  it('tolerates lowercase variants and leading/trailing whitespace around keys', () => {
+    const raw = '  titel: Thema  \n  zusammenfassung:  Satz eins. Satz zwei.  '
+    expect(parseLlamaOutput(raw)).toEqual({ title: 'Thema', text: 'Satz eins. Satz zwei.' })
+  })
+
+  it('captures the full summary when the LLM splits it across multiple lines', () => {
+    const raw = 'TITEL: Thema\nZUSAMMENFASSUNG: Satz eins.\nSatz zwei.'
+    expect(parseLlamaOutput(raw)).toEqual({ title: 'Thema', text: 'Satz eins. Satz zwei.' })
+  })
+
+  it('throws a readable error when the output is missing either field', () => {
+    expect(() => parseLlamaOutput('something else entirely')).toThrow(/TITEL|ZUSAMMENFASSUNG/)
+  })
+})
+
+describe('validateModelPath', () => {
+  it('accepts paths under the allowed models directory', () => {
+    expect(() =>
+      validateModelPath('/root/models/summarization/gemma.gguf', '/root/models')
+    ).not.toThrow()
+  })
+
+  it('rejects paths that escape the allowed directory', () => {
+    expect(() => validateModelPath('/root/models/../etc/passwd', '/root/models')).toThrow()
+    expect(() => validateModelPath('/etc/passwd', '/root/models')).toThrow()
+  })
+})

--- a/src/main/ml/__tests__/SummarizationExecutor.test.ts
+++ b/src/main/ml/__tests__/SummarizationExecutor.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi } from 'vitest'
+import { SummarizationExecutor } from '../SummarizationExecutor'
+import type { Task } from '../../../shared/types'
+
+const makeDeps = (
+  over: {
+    llamaSummarizer?: { summarize?: ReturnType<typeof vi.fn> }
+    sessionService?: {
+      getAnonymizedPlainText?: ReturnType<typeof vi.fn>
+      saveGeneratedSummary?: ReturnType<typeof vi.fn>
+    }
+    isModelInstalled?: () => boolean
+    getActiveModelId?: () => string
+  } = {}
+): {
+  llamaSummarizer: { summarize: ReturnType<typeof vi.fn> }
+  sessionService: {
+    getAnonymizedPlainText: ReturnType<typeof vi.fn>
+    saveGeneratedSummary: ReturnType<typeof vi.fn>
+  }
+  isModelInstalled: () => boolean
+  getActiveModelId: () => string
+  logger: { info: ReturnType<typeof vi.fn>; error: ReturnType<typeof vi.fn> }
+} => ({
+  llamaSummarizer: {
+    summarize:
+      over.llamaSummarizer?.summarize ??
+      vi.fn().mockResolvedValue({ title: 'Kurztitel', text: 'Eine Zusammenfassung.' })
+  },
+  sessionService: {
+    getAnonymizedPlainText:
+      over.sessionService?.getAnonymizedPlainText ?? vi.fn().mockReturnValue('Der Patient war müde.'),
+    saveGeneratedSummary: over.sessionService?.saveGeneratedSummary ?? vi.fn()
+  },
+  isModelInstalled: over.isModelInstalled ?? ((): boolean => true),
+  getActiveModelId: over.getActiveModelId ?? ((): string => 'gemma-summarization'),
+  logger: { info: vi.fn(), error: vi.fn() }
+})
+
+const task = { id: 't1', type: 'summarization', sessionId: 'abc' } as Task
+const onProgress = (): void => {}
+const signal = new AbortController().signal
+
+describe('SummarizationExecutor', () => {
+  it('skips cleanly when model is not installed', async () => {
+    const deps = makeDeps({ isModelInstalled: () => false })
+    const exec = new SummarizationExecutor(deps)
+    await expect(exec.execute(task, onProgress, signal)).resolves.toBeUndefined()
+    expect(deps.llamaSummarizer.summarize).not.toHaveBeenCalled()
+    expect(deps.sessionService.saveGeneratedSummary).not.toHaveBeenCalled()
+    expect(deps.logger.info).toHaveBeenCalledWith(expect.stringMatching(/skip.*model/i))
+  })
+
+  it('summarizes anonymized text and persists title + text with active model id', async () => {
+    const deps = makeDeps()
+    const exec = new SummarizationExecutor(deps)
+    await exec.execute(task, onProgress, signal)
+    expect(deps.llamaSummarizer.summarize).toHaveBeenCalledWith('Der Patient war müde.', signal)
+    expect(deps.sessionService.saveGeneratedSummary).toHaveBeenCalledWith(
+      'abc',
+      'Kurztitel',
+      'Eine Zusammenfassung.',
+      'gemma-summarization'
+    )
+  })
+
+  it('propagates summarizer errors as task failure', async () => {
+    const deps = makeDeps({
+      llamaSummarizer: { summarize: vi.fn().mockRejectedValue(new Error('spawn failed')) }
+    })
+    const exec = new SummarizationExecutor(deps)
+    await expect(exec.execute(task, onProgress, signal)).rejects.toThrow('spawn failed')
+    expect(deps.sessionService.saveGeneratedSummary).not.toHaveBeenCalled()
+  })
+
+  it('skips cleanly when anonymized text is empty', async () => {
+    const deps = makeDeps({
+      sessionService: { getAnonymizedPlainText: vi.fn().mockReturnValue('') }
+    })
+    const exec = new SummarizationExecutor(deps)
+    await expect(exec.execute(task, onProgress, signal)).resolves.toBeUndefined()
+    expect(deps.llamaSummarizer.summarize).not.toHaveBeenCalled()
+    expect(deps.sessionService.saveGeneratedSummary).not.toHaveBeenCalled()
+  })
+
+  it('skips when getAnonymizedPlainText throws (e.g. missing anonymized doc)', async () => {
+    const deps = makeDeps({
+      sessionService: {
+        getAnonymizedPlainText: vi.fn(() => {
+          throw new Error('no anonymized doc')
+        })
+      }
+    })
+    const exec = new SummarizationExecutor(deps)
+    await expect(exec.execute(task, onProgress, signal)).resolves.toBeUndefined()
+    expect(deps.llamaSummarizer.summarize).not.toHaveBeenCalled()
+    expect(deps.sessionService.saveGeneratedSummary).not.toHaveBeenCalled()
+    expect(deps.logger.info).toHaveBeenCalledWith(expect.stringMatching(/skip/i))
+  })
+})

--- a/src/main/ml/__tests__/summarization-prompt.test.ts
+++ b/src/main/ml/__tests__/summarization-prompt.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest'
+import { buildSummarizationPrompt } from '../summarization-prompt'
+
+describe('buildSummarizationPrompt', () => {
+  it('requests structured TITEL + ZUSAMMENFASSUNG output in German', () => {
+    const prompt = buildSummarizationPrompt('Der Patient berichtet von Schlafstörungen.')
+    expect(prompt).toContain('TITEL:')
+    expect(prompt).toContain('ZUSAMMENFASSUNG:')
+    expect(prompt).toContain('zwei')
+    expect(prompt).toContain('Schlafstörungen')
+  })
+
+  it('truncates input exceeding 120k characters to fit model context', () => {
+    const long = 'a'.repeat(200_000)
+    const prompt = buildSummarizationPrompt(long)
+    expect(prompt.length).toBeLessThan(150_000)
+  })
+
+  it('preserves placeholder chips inside the anonymized text verbatim', () => {
+    const prompt = buildSummarizationPrompt('Der Patient [PERSON 1] war müde.')
+    expect(prompt).toContain('[PERSON 1]')
+  })
+})

--- a/src/main/ml/__tests__/tiptap-plain-text.test.ts
+++ b/src/main/ml/__tests__/tiptap-plain-text.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+import { tiptapToPlainText } from '../tiptap-plain-text'
+
+describe('tiptapToPlainText', () => {
+  it('joins text nodes across paragraphs with newlines', () => {
+    const doc = {
+      type: 'doc',
+      content: [
+        { type: 'paragraph', content: [{ type: 'text', text: 'Satz A.' }] },
+        { type: 'paragraph', content: [{ type: 'text', text: 'Satz B.' }] }
+      ]
+    }
+    expect(tiptapToPlainText(doc)).toBe('Satz A.\nSatz B.')
+  })
+
+  it('renders placeholderChip nodes using their label attribute', () => {
+    const doc = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: 'Der Patient ' },
+            { type: 'placeholderChip', attrs: { label: '[PERSON 1]' } },
+            { type: 'text', text: ' war müde.' }
+          ]
+        }
+      ]
+    }
+    expect(tiptapToPlainText(doc)).toBe('Der Patient [PERSON 1] war müde.')
+  })
+
+  it('drops speakerLabel and timestamp nodes (noise for LLM)', () => {
+    const doc = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'speakerLabel', attrs: { speaker: 'SPEAKER_00' } },
+            { type: 'timestamp', attrs: { seconds: 12.3 } },
+            { type: 'text', text: 'Hallo.' }
+          ]
+        }
+      ]
+    }
+    expect(tiptapToPlainText(doc)).toBe('Hallo.')
+  })
+
+  it('returns empty string for malformed input', () => {
+    expect(tiptapToPlainText(null)).toBe('')
+    expect(tiptapToPlainText(undefined)).toBe('')
+    expect(tiptapToPlainText({})).toBe('')
+  })
+})

--- a/src/main/ml/summarization-prompt.ts
+++ b/src/main/ml/summarization-prompt.ts
@@ -1,0 +1,19 @@
+const MAX_INPUT_CHARS = 120_000
+
+const INSTRUCTION = `Du bist ein professioneller Assistent für die Kurz-Beschreibung von Therapiesitzungen und medizinischen Dokumenten. Analysiere den folgenden Text und erzeuge zwei Ausgaben:
+
+1. Einen prägnanten deutschen Titel (Nominalphrase, 3–8 Wörter, max. 80 Zeichen). Kein vollständiger Satz, keine Anführungszeichen, keine Einleitung.
+2. Eine Zusammenfassung in genau zwei prägnanten deutschen Sätzen. Nenne die zentralen Themen und Schlüsselpunkte.
+
+Formatiere die Antwort exakt so (zwei Zeilen, keine weiteren Inhalte):
+
+TITEL: <dein Titel>
+ZUSAMMENFASSUNG: <deine zwei Sätze>
+
+Keine Einleitung, keine Aufzählungen, keine Meta-Kommentare, keine Markdown-Formatierung.`
+
+export function buildSummarizationPrompt(text: string): string {
+  const trimmed =
+    text.length > MAX_INPUT_CHARS ? text.slice(0, MAX_INPUT_CHARS) + '\n[... gekürzt ...]' : text
+  return `${INSTRUCTION}\n\nText:\n---\n${trimmed}\n---`
+}

--- a/src/main/ml/tiptap-plain-text.ts
+++ b/src/main/ml/tiptap-plain-text.ts
@@ -1,0 +1,37 @@
+interface TipTapNode {
+  type?: string
+  text?: string
+  attrs?: Record<string, unknown>
+  content?: TipTapNode[]
+}
+
+export function tiptapToPlainText(doc: TipTapNode | null | undefined): string {
+  if (!doc || typeof doc !== 'object') return ''
+
+  const walk = (node: TipTapNode | undefined, into: string[]): void => {
+    if (!node) return
+    switch (node.type) {
+      case 'text':
+        into.push(node.text ?? '')
+        return
+      case 'placeholderChip':
+        into.push(String(node.attrs?.label ?? ''))
+        return
+      case 'speakerLabel':
+      case 'timestamp':
+        return
+      case 'paragraph': {
+        const buf: string[] = []
+        for (const child of node.content ?? []) walk(child, buf)
+        into.push(buf.join(''))
+        return
+      }
+      default:
+        for (const child of node.content ?? []) walk(child, into)
+    }
+  }
+
+  const buf: string[] = []
+  walk(doc as TipTapNode, buf)
+  return buf.filter((s) => s.length > 0).join('\n')
+}

--- a/src/main/services/ModelDownloadService.ts
+++ b/src/main/services/ModelDownloadService.ts
@@ -338,8 +338,9 @@ export function abortModelDownload(): void {
 }
 
 /**
- * Lädt ein einziges ASR-Modell herunter (nicht für Pflicht-Modelle gedacht —
- * die laufen via startModelDownload auf First-Launch).
+ * Lädt ein einziges optionales Modell herunter (z.B. ASR-Variante oder
+ * Summarization-Modell). Pflicht-Modelle (`isRequired`) laufen via
+ * startModelDownload auf First-Launch und werden hier abgewiesen.
  *
  * Sendet denselben `modelDownload:status`-Channel wie startModelDownload,
  * damit die bestehende UI-Progress-Anzeige wiederverwendbar bleibt.
@@ -349,8 +350,10 @@ export async function downloadSingleModel(id: string): Promise<void> {
   if (!def) {
     throw new Error(`Download: unbekanntes Modell "${id}"`)
   }
-  if (def.group !== 'asr') {
-    throw new Error(`Download: nur ASR-Modelle sind einzeln ladbar (id=${id})`)
+  if (def.isRequired) {
+    throw new Error(
+      `Download: "${def.label}" ist ein Pflicht-Modell — wird über First-Launch geladen`
+    )
   }
   if (abortSignal && !abortSignal.aborted) {
     throw new Error('Download: bereits aktiv — zuerst abbrechen')

--- a/src/main/services/ModelDownloadService.ts
+++ b/src/main/services/ModelDownloadService.ts
@@ -57,7 +57,18 @@ export function getActiveModelId(group: ModelGroup): string {
   if (group === 'asr') return active.transcription
   if (group === 'diarization') return active.diarization
   if (group === 'ner') return active.ner
+  if (group === 'summarization') return active.summarization
   throw new Error(`Keine aktive Modell-Konfiguration für Gruppe "${group}"`)
+}
+
+/** Liefert den absoluten Pfad zum aktiven Modell einer Gruppe (für Subprozess-Aufrufe). */
+export function getActiveModelPath(group: ModelGroup): string {
+  const id = getActiveModelId(group)
+  const def = getModelById(id)
+  if (!def) {
+    throw new Error(`Aktive Modell-ID "${id}" für Gruppe "${group}" nicht im Katalog gefunden`)
+  }
+  return join(getModelsDir(), def.relativePath)
 }
 
 /**
@@ -450,10 +461,14 @@ export async function deleteModel(id: string): Promise<void> {
 // Explizites Mapping Group → Settings-Key. Der TypeScript-Compiler erzwingt Vollständigkeit:
 // Wird ModelGroup um einen neuen Wert erweitert, schlägt der Build fehl,
 // solange das Mapping nicht erweitert wird. Das verhindert silent-wrong-key-writes.
-const GROUP_TO_SETTINGS_KEY: Record<ModelGroup, 'transcription' | 'diarization' | 'ner'> = {
+const GROUP_TO_SETTINGS_KEY: Record<
+  ModelGroup,
+  'transcription' | 'diarization' | 'ner' | 'summarization'
+> = {
   asr: 'transcription',
   diarization: 'diarization',
-  ner: 'ner'
+  ner: 'ner',
+  summarization: 'summarization'
 }
 
 /**

--- a/src/main/services/ModelDownloadService.ts
+++ b/src/main/services/ModelDownloadService.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdirSync, rmSync, statSync, unlinkSync } from 'fs'
 import { join } from 'path'
 import { BrowserWindow } from 'electron'
 import { getDataDir } from '../db/connection'
-import { getSettings } from './SettingsService'
+import { getSettings, type AppSettings } from './SettingsService'
 import { downloadFile, verifyFileSha256, extractTarGz } from './DownloadService'
 import type { ModelGroup } from '../../shared/validation/model-catalog-schemas'
 import { MODEL_DEFINITIONS, type ModelDefinition } from '../../shared/model-catalog'
@@ -30,12 +30,33 @@ export type ModelDownloadStatus =
 
 let abortSignal: { aborted: boolean } | null = null
 
+// Sentinel for "hash not yet synced from R2 manifest" — keeps the catalog entry in
+// the source for IDE navigation + manifest extraction (publish-manifest.sh reads
+// MODEL_DEFINITIONS directly), but hides the model from runtime accessors so the
+// Settings UI doesn't list it and isModelInstalled returns false. Once the model
+// is uploaded and the hash is synced via scripts/publish-manifest.sh, the entry
+// becomes live automatically.
+const PLACEHOLDER_SHA256 = '0'.repeat(64)
+
+function isPublishable(m: ModelDefinition): boolean {
+  return m.sha256 !== PLACEHOLDER_SHA256
+}
+
+const _placeholderEntries = MODEL_DEFINITIONS.filter((m) => !isPublishable(m))
+if (_placeholderEntries.length > 0) {
+  console.warn(
+    `[ModelDownloadService] ${_placeholderEntries.length} catalog entries have placeholder sha256 ` +
+      `and are filtered from runtime accessors: ${_placeholderEntries.map((m) => m.id).join(', ')}. ` +
+      `Sync hashes from manifest.json after scripts/publish-manifest.sh.`
+  )
+}
+
 export function getModelDefinitions(): ModelDefinition[] {
-  return MODEL_DEFINITIONS
+  return MODEL_DEFINITIONS.filter(isPublishable)
 }
 
 export function getModelsByGroup(group: ModelGroup): ModelDefinition[] {
-  return MODEL_DEFINITIONS.filter((m) => m.group === group)
+  return MODEL_DEFINITIONS.filter((m) => m.group === group && isPublishable(m))
 }
 
 /** Backward-Compat-Alias — weiterhin verwendet von First-Launch + Update-Check. */
@@ -44,11 +65,12 @@ export function getAsrModels(): ModelDefinition[] {
 }
 
 export function getRequiredModels(): ModelDefinition[] {
-  return MODEL_DEFINITIONS.filter((m) => m.isRequired === true)
+  return MODEL_DEFINITIONS.filter((m) => m.isRequired === true && isPublishable(m))
 }
 
 export function getModelById(id: string): ModelDefinition | null {
-  return MODEL_DEFINITIONS.find((m) => m.id === id) ?? null
+  const def = MODEL_DEFINITIONS.find((m) => m.id === id)
+  return def && isPublishable(def) ? def : null
 }
 
 /** Liefert die aktuell aktive Model-ID für eine Gruppe aus den Settings. */
@@ -419,8 +441,16 @@ export async function downloadSingleModel(id: string): Promise<void> {
 /**
  * Löscht ein einzelnes Modell von Disk. Verboten für:
  *   - unbekannte IDs
- *   - Pflicht-Modelle (isRequired, z.B. flair NER)
- *   - das aktuell aktive Modell einer group-required Gruppe (ASR, Diarization)
+ *   - Pflicht-Modelle (isRequired, z.B. flair NER + pyannote-Suite)
+ *   - das aktuell aktive ASR-Modell (User muss zuerst auf ein anderes
+ *     Modell wechseln, sonst hätte die Transkriptions-Pipeline keinen
+ *     gültigen Modell-Pfad mehr)
+ *
+ * Optionale Modelle (z.B. Summarization) ohne harten Active-Guard:
+ *   - Wenn das aktive Summarization-Modell gelöscht wird, schaltet der
+ *     SummarizationExecutor automatisch in den Skip-Modus
+ *     (isModelInstalled = false). Die Pipeline läuft einfach ohne
+ *     Zusammenfassung weiter, kein Fehler.
  */
 export async function deleteModel(id: string): Promise<void> {
   const def = getModelById(id)
@@ -461,10 +491,12 @@ export async function deleteModel(id: string): Promise<void> {
 // Explizites Mapping Group → Settings-Key. Der TypeScript-Compiler erzwingt Vollständigkeit:
 // Wird ModelGroup um einen neuen Wert erweitert, schlägt der Build fehl,
 // solange das Mapping nicht erweitert wird. Das verhindert silent-wrong-key-writes.
-const GROUP_TO_SETTINGS_KEY: Record<
-  ModelGroup,
-  'transcription' | 'diarization' | 'ner' | 'summarization'
-> = {
+//
+// Die Value-Union wird aus AppSettings['activeModels'] abgeleitet, damit die
+// Mapping-Werte automatisch synchron bleiben mit den Property-Namen in den
+// Settings — Tippfehler oder umbenannte Felder werden vom Compiler gefangen,
+// statt dass eine zweite hand-gepflegte Union nötig wäre.
+const GROUP_TO_SETTINGS_KEY: Record<ModelGroup, keyof AppSettings['activeModels']> = {
   asr: 'transcription',
   diarization: 'diarization',
   ner: 'ner',

--- a/src/main/services/ProcessWatchdog.ts
+++ b/src/main/services/ProcessWatchdog.ts
@@ -6,7 +6,13 @@ const POLL_INTERVAL_MS = 15_000
 const STALL_THRESHOLDS: Partial<Record<TaskType, number>> = {
   diarization: 120_000,
   anonymization: 120_000,
-  ocr: 60_000
+  ocr: 60_000,
+  // LlamaSummarizer reports no fine-grained progress — onProgress is never called
+  // during inference, so the watchdog only sees the initial heartbeat. Cold-start
+  // of a 4B Q4_K_M GGUF on a loaded box can take ~30–60s; long anonymized inputs
+  // push that further. Generous 10-min cap protects against runaway processes
+  // without aborting healthy long-running inference.
+  summarization: 600_000
 }
 
 // In-process executors — watchdog is a no-op for these

--- a/src/main/services/SessionService.ts
+++ b/src/main/services/SessionService.ts
@@ -168,6 +168,16 @@ export class SessionService {
    * Returns a SummaryRecord if either title or summary is non-empty.
    * The renderer treats an empty title as "show date fallback" but still
    * needs the record to exist when only the title is present.
+   *
+   * Title-reuse semantics: `sessions.title` is the same column that backs
+   * both (a) auto-generated session labels written at createSession time
+   * (e.g. 'Sitzung 14.02.2026 14:30') and (b) the LLM-generated title
+   * written by SummarizationExecutor. We deliberately reuse the column
+   * instead of adding a separate `llm_title` field — pre-feature sessions
+   * already have non-NULL titles, and the renderer's contract is the
+   * same regardless of provenance: show the title, let the user edit it.
+   * Provenance is only knowable from `summaryModelId` (NULL after a
+   * user edit, set after an LLM run).
    */
   getSummary(sessionId: string): SummaryRecord | null {
     const session = this.repository.findById(sessionId)

--- a/src/main/services/SessionService.ts
+++ b/src/main/services/SessionService.ts
@@ -1,9 +1,18 @@
 import type Database from 'better-sqlite3'
+import { readFileSync } from 'fs'
 import { join } from 'path'
 import { SessionRepository } from '../db/repositories/SessionRepository'
 import { getDataDir } from '../db/connection'
 import { removeFile } from '../utils/file-ops'
+import { tiptapToPlainText } from '../ml/tiptap-plain-text'
 import type { Session, SessionStatus, UpdateSessionInput } from '../../shared/types'
+
+export interface SummaryRecord {
+  title: string | null
+  text: string
+  modelId: string | null
+  summarizedAt: string | null
+}
 
 const VALID_TRANSITIONS: Record<SessionStatus, SessionStatus[]> = {
   recording: ['transcribing', 'error'],
@@ -138,6 +147,73 @@ export class SessionService {
 
   generateAlignedTranscriptPath(sessionId: string): string {
     return join(getDataDir(), 'transcripts', `${sessionId}-aligned.json`)
+  }
+
+  /**
+   * Reads the persisted anonymized TipTap document for a session and flattens it
+   * to plain text suitable for LLM input (drops speaker labels + timestamps,
+   * inlines placeholder chips by label).
+   */
+  getAnonymizedPlainText(sessionId: string): string {
+    const session = this.repository.findById(sessionId)
+    if (!session?.anonymizedPath) {
+      throw new Error(`Session ${sessionId} hat kein anonymisiertes Dokument`)
+    }
+    const raw = readFileSync(session.anonymizedPath, 'utf-8')
+    const doc = JSON.parse(raw)
+    return tiptapToPlainText(doc)
+  }
+
+  /**
+   * Returns a SummaryRecord if either title or summary is non-empty.
+   * The renderer treats an empty title as "show date fallback" but still
+   * needs the record to exist when only the title is present.
+   */
+  getSummary(sessionId: string): SummaryRecord | null {
+    const session = this.repository.findById(sessionId)
+    if (!session) return null
+    const hasTitle = typeof session.title === 'string' && session.title.trim().length > 0
+    const hasSummary = typeof session.summary === 'string' && session.summary.trim().length > 0
+    if (!hasTitle && !hasSummary) return null
+    return {
+      title: hasTitle ? session.title : null,
+      text: session.summary ?? '',
+      modelId: session.summaryModelId,
+      summarizedAt: session.summarizedAt
+    }
+  }
+
+  /** Persists LLM-generated title + summary in one update. */
+  saveGeneratedSummary(
+    sessionId: string,
+    title: string,
+    text: string,
+    modelId: string
+  ): Session | null {
+    return this.repository.update(sessionId, {
+      title,
+      summary: text,
+      summaryModelId: modelId,
+      summarizedAt: new Date().toISOString()
+    })
+  }
+
+  /** User-edited title. Empty string triggers the date-based fallback in the view layer. */
+  updateTitle(sessionId: string, title: string): Session | null {
+    return this.repository.update(sessionId, { title: title.trim() })
+  }
+
+  /**
+   * User-edited summary text. Clearing the model id signals that the text is no longer
+   * LLM-authoritative — future model upgrades will not assume the user's edit can
+   * be regenerated automatically.
+   */
+  updateSummaryText(sessionId: string, text: string): Session | null {
+    const trimmed = text.trim()
+    return this.repository.update(sessionId, {
+      summary: trimmed.length > 0 ? trimmed : null,
+      summaryModelId: null
+    })
   }
 }
 

--- a/src/main/services/SessionService.ts
+++ b/src/main/services/SessionService.ts
@@ -6,13 +6,9 @@ import { getDataDir } from '../db/connection'
 import { removeFile } from '../utils/file-ops'
 import { tiptapToPlainText } from '../ml/tiptap-plain-text'
 import type { Session, SessionStatus, UpdateSessionInput } from '../../shared/types'
+import type { SummaryRecord } from '../../shared/types/IpcApi'
 
-export interface SummaryRecord {
-  title: string | null
-  text: string
-  modelId: string | null
-  summarizedAt: string | null
-}
+export type { SummaryRecord }
 
 const VALID_TRANSITIONS: Record<SessionStatus, SessionStatus[]> = {
   recording: ['transcribing', 'error'],

--- a/src/main/services/SettingsService.ts
+++ b/src/main/services/SettingsService.ts
@@ -22,6 +22,7 @@ export interface AppSettings {
     diarizationPipeline: DiarizationPipeline
     ner: string
     ocr: string
+    summarization: string
   }
   firstLaunchDone: boolean
   consentReminderShown: boolean
@@ -39,7 +40,8 @@ const defaults: AppSettings = {
     diarization: 'pyannote-suite',
     diarizationPipeline: DEFAULT_DIARIZATION_PIPELINE,
     ner: 'flair-ner-german-large',
-    ocr: 'apple-vision'
+    ocr: 'apple-vision',
+    summarization: 'gemma-summarization'
   },
   firstLaunchDone: false,
   consentReminderShown: false,
@@ -129,6 +131,18 @@ export function initSettings(): Store<AppSettings> {
     store.set('activeModels', {
       ...store.get('activeModels'),
       ner: EXPECTED_NER
+    })
+  }
+
+  // Defensiv: Bestehende electron-store-Instanzen haben kein activeModels.summarization,
+  // weil das Feld erst mit dem lokalen LLM eingeführt wurde. defaults füllt nested keys
+  // nicht nach, also Wert hier explizit setzen, falls nicht vorhanden.
+  const currentSummarization = (store.get('activeModels') as { summarization?: string })
+    .summarization
+  if (typeof currentSummarization !== 'string' || currentSummarization.length === 0) {
+    store.set('activeModels', {
+      ...store.get('activeModels'),
+      summarization: 'gemma-summarization'
     })
   }
 

--- a/src/main/services/TaskQueueService.ts
+++ b/src/main/services/TaskQueueService.ts
@@ -122,6 +122,11 @@ export class TaskQueueService {
       // OCR has no separate output file — always re-run if reached
       if (taskType === 'ocr') return i
 
+      // Summarization writes to sessions.summary directly (no separate file).
+      // It's also the last step in both pipelines, so once everything before
+      // succeeded the only remaining work is to (re-)run summarization.
+      if (taskType === 'summarization') return i
+
       const filePath = outputField[taskType]
       if (!filePath) return i
 
@@ -132,7 +137,9 @@ export class TaskQueueService {
       }
     }
 
-    // All steps have valid output — restart from last step (anonymization)
+    // All steps reported valid output — restart from the last step (summarization).
+    // In practice the explicit summarization branch above will have already
+    // returned; this is the defensive fallback if the pipeline ever changes shape.
     return pipeline.length - 1
   }
 

--- a/src/main/services/TaskQueueService.ts
+++ b/src/main/services/TaskQueueService.ts
@@ -9,8 +9,14 @@ import { sendToRenderer } from '../utils/ipc-helpers'
 import { validateIntermediateFile } from '../utils/file-ops'
 import type { Task, TaskType, Session, SessionStatus, SessionType } from '../../shared/types'
 
-const AUDIO_PIPELINE: TaskType[] = ['transcription', 'diarization', 'alignment', 'anonymization']
-const PDF_PIPELINE: TaskType[] = ['extraction', 'ocr', 'anonymization']
+const AUDIO_PIPELINE: TaskType[] = [
+  'transcription',
+  'diarization',
+  'alignment',
+  'anonymization',
+  'summarization'
+]
+const PDF_PIPELINE: TaskType[] = ['extraction', 'ocr', 'anonymization', 'summarization']
 
 // Maps a completed task type to the next session status
 const TASK_TO_SESSION_STATUS: Partial<Record<TaskType, SessionStatus>> = {
@@ -19,7 +25,10 @@ const TASK_TO_SESSION_STATUS: Partial<Record<TaskType, SessionStatus>> = {
   alignment: 'anonymizing',
   extraction: 'anonymizing',
   ocr: 'anonymizing',
-  anonymization: 'review'
+  // anonymization no longer transitions immediately — summarization (the new tail step)
+  // can still be pending. handleTaskCompletion handles the all-done case explicitly.
+  anonymization: 'anonymizing',
+  summarization: 'review'
 }
 
 const RECOVERY_INTERVAL_MS = 5 * 60 * 1000 // 5 minutes
@@ -351,7 +360,10 @@ export class TaskQueueService {
       alignment: 'diarizing', // alignment is part of diarization phase
       extraction: 'extracting',
       ocr: 'extracting',
-      anonymization: 'anonymizing'
+      anonymization: 'anonymizing',
+      // Summarization runs as the pipeline tail — keep the session in 'anonymizing'
+      // so the existing UX (no dedicated 'summarizing' status) covers the LLM step.
+      summarization: 'anonymizing'
     }
     return mapping[taskType] ?? null
   }

--- a/src/main/services/__tests__/ModelDownloadService.test.ts
+++ b/src/main/services/__tests__/ModelDownloadService.test.ts
@@ -99,15 +99,13 @@ describe('downloadSingleModel', () => {
     )
   })
 
-  it('throws when model is not in asr group (pyannote-suite)', async () => {
-    await expect(downloadSingleModel('pyannote-suite')).rejects.toThrow(
-      /nur ASR-Modelle/i
-    )
+  it('throws when model is required (pyannote-suite)', async () => {
+    await expect(downloadSingleModel('pyannote-suite')).rejects.toThrow(/Pflicht-Modell/i)
   })
 
-  it('throws when model is not in asr group (flair)', async () => {
+  it('throws when model is required (flair)', async () => {
     await expect(downloadSingleModel('flair-ner-german-large')).rejects.toThrow(
-      /nur ASR-Modelle/i
+      /Pflicht-Modell/i
     )
   })
 })

--- a/src/main/services/__tests__/SessionService.test.ts
+++ b/src/main/services/__tests__/SessionService.test.ts
@@ -357,4 +357,64 @@ describe('SessionService', () => {
       expect(path).toBe('/mock/home/.therascript/anonymized/abc-123.json')
     })
   })
+
+  describe('summary methods', () => {
+    it('saveGeneratedSummary persists title + text + modelId, getSummary round-trips', () => {
+      const session = service.createSession('Initial Title', 'audio')
+
+      service.saveGeneratedSummary(
+        session.id,
+        'Schlafstörungen und Arbeitsstress',
+        'Der Patient berichtet von Einschlafproblemen. Vereinbart wird ein Schlaftagebuch.',
+        'gemma-summarization'
+      )
+
+      const summary = service.getSummary(session.id)
+      expect(summary).not.toBeNull()
+      expect(summary?.title).toBe('Schlafstörungen und Arbeitsstress')
+      expect(summary?.text).toBe(
+        'Der Patient berichtet von Einschlafproblemen. Vereinbart wird ein Schlaftagebuch.'
+      )
+      expect(summary?.modelId).toBe('gemma-summarization')
+      expect(summary?.summarizedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+    })
+
+    it('getSummary returns the record when only title is set (text empty)', () => {
+      const session = service.createSession('Sitzung 14.02.2026', 'audio')
+
+      const summary = service.getSummary(session.id)
+      expect(summary).not.toBeNull()
+      expect(summary?.title).toBe('Sitzung 14.02.2026')
+      expect(summary?.text).toBe('')
+      expect(summary?.modelId).toBeNull()
+    })
+
+    it('updateSummaryText clears summary_model_id (user edit overrides LLM provenance)', () => {
+      const session = service.createSession('Original', 'audio')
+      service.saveGeneratedSummary(session.id, 'LLM Title', 'LLM text.', 'gemma-summarization')
+
+      service.updateSummaryText(session.id, 'User-edited summary.')
+
+      const summary = service.getSummary(session.id)
+      expect(summary?.text).toBe('User-edited summary.')
+      expect(summary?.modelId).toBeNull()
+    })
+
+    it('updateTitle persists trimmed title; empty string is stored as empty', () => {
+      const session = service.createSession('Old', 'audio')
+
+      service.updateTitle(session.id, '  Neuer Titel  ')
+      expect(service.getSummary(session.id)?.title).toBe('Neuer Titel')
+
+      service.updateTitle(session.id, '')
+      // Empty title still stored — view layer renders date fallback when empty.
+      const after = service.getSession(session.id)
+      expect(after?.title).toBe('')
+    })
+
+    it('getAnonymizedPlainText throws when session has no anonymized document', () => {
+      const session = service.createSession('Test', 'audio')
+      expect(() => service.getAnonymizedPlainText(session.id)).toThrow(/anonymisiertes Dokument/)
+    })
+  })
 })

--- a/src/main/services/__tests__/TaskQueueService.test.ts
+++ b/src/main/services/__tests__/TaskQueueService.test.ts
@@ -47,11 +47,12 @@ describe('TaskQueueService', () => {
     it('enqueues audio pipeline tasks in correct order', () => {
       const tasks = queue.enqueuePipeline(sessionId, 'audio')
 
-      expect(tasks).toHaveLength(4)
+      expect(tasks).toHaveLength(5)
       expect(tasks[0].type).toBe('transcription')
       expect(tasks[1].type).toBe('diarization')
       expect(tasks[2].type).toBe('alignment')
       expect(tasks[3].type).toBe('anonymization')
+      expect(tasks[4].type).toBe('summarization')
 
       for (const task of tasks) {
         expect(task.sessionId).toBe(sessionId)
@@ -68,10 +69,11 @@ describe('TaskQueueService', () => {
 
       const tasks = queue.enqueuePipeline(pdfSession.id, 'pdf')
 
-      expect(tasks).toHaveLength(3)
+      expect(tasks).toHaveLength(4)
       expect(tasks[0].type).toBe('extraction')
       expect(tasks[1].type).toBe('ocr')
       expect(tasks[2].type).toBe('anonymization')
+      expect(tasks[3].type).toBe('summarization')
     })
   })
 
@@ -80,7 +82,7 @@ describe('TaskQueueService', () => {
       queue.enqueuePipeline(sessionId, 'audio')
       const tasks = queue.getSessionTasks(sessionId)
 
-      expect(tasks).toHaveLength(4)
+      expect(tasks).toHaveLength(5)
     })
 
     it('returns empty array for session with no tasks', () => {
@@ -119,13 +121,20 @@ describe('TaskQueueService', () => {
       queue.registerExecutor('diarization', trackingExecutor)
       queue.registerExecutor('alignment', trackingExecutor)
       queue.registerExecutor('anonymization', trackingExecutor)
+      queue.registerExecutor('summarization', trackingExecutor)
 
       queue.enqueuePipeline(sessionId, 'audio')
 
       // Wait for all tasks to process
       await new Promise((resolve) => setTimeout(resolve, 200))
 
-      expect(executionOrder).toEqual(['transcription', 'diarization', 'alignment', 'anonymization'])
+      expect(executionOrder).toEqual([
+        'transcription',
+        'diarization',
+        'alignment',
+        'anonymization',
+        'summarization'
+      ])
     })
 
     it('marks tasks as completed after execution', async () => {
@@ -139,6 +148,7 @@ describe('TaskQueueService', () => {
       queue.registerExecutor('diarization', instantExecutor)
       queue.registerExecutor('alignment', instantExecutor)
       queue.registerExecutor('anonymization', instantExecutor)
+      queue.registerExecutor('summarization', instantExecutor)
 
       queue.enqueuePipeline(sessionId, 'audio')
 
@@ -163,6 +173,7 @@ describe('TaskQueueService', () => {
       queue.registerExecutor('diarization', instantExecutor)
       queue.registerExecutor('alignment', instantExecutor)
       queue.registerExecutor('anonymization', instantExecutor)
+      queue.registerExecutor('summarization', instantExecutor)
 
       queue.enqueuePipeline(sessionId, 'audio')
 
@@ -209,6 +220,7 @@ describe('TaskQueueService', () => {
       queue.registerExecutor('diarization', progressExecutor)
       queue.registerExecutor('alignment', progressExecutor)
       queue.registerExecutor('anonymization', progressExecutor)
+      queue.registerExecutor('summarization', progressExecutor)
 
       queue.enqueuePipeline(sessionId, 'audio')
 
@@ -220,7 +232,7 @@ describe('TaskQueueService', () => {
       const completedCalls = calls.filter((c) => c[0] === 'task:completed')
 
       expect(progressCalls.length).toBeGreaterThan(0)
-      expect(completedCalls).toHaveLength(4)
+      expect(completedCalls).toHaveLength(5)
     })
   })
 
@@ -244,7 +256,7 @@ describe('TaskQueueService', () => {
 
       expect(failed).toHaveLength(1)
       expect(failed[0].type).toBe('transcription')
-      expect(cancelled).toHaveLength(3) // diarization, alignment, anonymization
+      expect(cancelled).toHaveLength(4) // diarization, alignment, anonymization, summarization
     })
 
     it('does not execute cancelled tasks', async () => {
@@ -267,6 +279,7 @@ describe('TaskQueueService', () => {
       queue.registerExecutor('diarization', trackingExecutor)
       queue.registerExecutor('alignment', trackingExecutor)
       queue.registerExecutor('anonymization', trackingExecutor)
+      queue.registerExecutor('summarization', trackingExecutor)
 
       queue.enqueuePipeline(sessionId, 'audio')
 
@@ -298,6 +311,7 @@ describe('TaskQueueService', () => {
       queue.registerExecutor('diarization', trackingExecutor)
       queue.registerExecutor('alignment', trackingExecutor)
       queue.registerExecutor('anonymization', trackingExecutor)
+      queue.registerExecutor('summarization', trackingExecutor)
 
       queue.enqueuePipeline(sessionId, 'audio')
       queue.enqueuePipeline(session2.id, 'audio')
@@ -310,8 +324,8 @@ describe('TaskQueueService', () => {
       expect(s1?.status).toBe('review')
       expect(s2?.status).toBe('review')
 
-      // All 8 tasks should have executed
-      expect(executionOrder).toHaveLength(8)
+      // All 10 tasks (5 per session × 2 sessions) should have executed
+      expect(executionOrder).toHaveLength(10)
     })
 
     it('second session still processes when first fails', async () => {
@@ -334,6 +348,7 @@ describe('TaskQueueService', () => {
       queue.registerExecutor('diarization', failOnFirst)
       queue.registerExecutor('alignment', failOnFirst)
       queue.registerExecutor('anonymization', failOnFirst)
+      queue.registerExecutor('summarization', failOnFirst)
 
       queue.enqueuePipeline(sessionId, 'audio')
       queue.enqueuePipeline(session2.id, 'audio')
@@ -363,6 +378,7 @@ describe('TaskQueueService', () => {
       queue.registerExecutor('diarization', slowExecutor)
       queue.registerExecutor('alignment', slowExecutor)
       queue.registerExecutor('anonymization', slowExecutor)
+      queue.registerExecutor('summarization', slowExecutor)
 
       queue.enqueuePipeline(sessionId, 'audio')
 
@@ -372,8 +388,8 @@ describe('TaskQueueService', () => {
 
       await new Promise((resolve) => setTimeout(resolve, 200))
 
-      // Should not have processed all 4 tasks
-      expect(executionOrder.length).toBeLessThan(4)
+      // Should not have processed all 5 tasks
+      expect(executionOrder.length).toBeLessThan(5)
     })
   })
 })

--- a/src/main/services/task-executors.ts
+++ b/src/main/services/task-executors.ts
@@ -31,5 +31,6 @@ export function createStubExecutors(): Map<TaskType, TaskExecutor> {
   executors.set('extraction', stub)
   executors.set('ocr', stub)
   executors.set('anonymization', stub)
+  executors.set('summarization', stub)
   return executors
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -181,6 +181,13 @@ const api: IpcApi = {
         ipcRenderer.removeListener('appUpdate:status', handler)
       }
     }
+  },
+  summary: {
+    get: (sessionId: string) => ipcRenderer.invoke('summary:get', { sessionId }),
+    updateTitle: (sessionId: string, title: string) =>
+      ipcRenderer.invoke('summary:updateTitle', { sessionId, title }),
+    updateText: (sessionId: string, text: string) =>
+      ipcRenderer.invoke('summary:updateText', { sessionId, text })
   }
 }
 

--- a/src/renderer/src/__tests__/App.test.tsx
+++ b/src/renderer/src/__tests__/App.test.tsx
@@ -89,6 +89,11 @@ beforeEach(() => {
       check: vi.fn().mockResolvedValue({ modelUpdates: [], appUpdate: { available: false, latestVersion: null, checkedAt: null } }),
       openReleasePage: vi.fn(),
       onStatus: vi.fn().mockReturnValue(() => {})
+    },
+    summary: {
+      get: vi.fn().mockResolvedValue(null),
+      updateTitle: vi.fn().mockResolvedValue(undefined),
+      updateText: vi.fn().mockResolvedValue(undefined)
     }
   } as typeof window.api
 })

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -193,3 +193,12 @@
 .titlebar-no-drag {
   -webkit-app-region: no-drag;
 }
+
+/* Editable session title: when DOM text is empty, show the date fallback as a
+   pseudo-element placeholder. Real title text always lives in the DOM, so the
+   fallback never gets accidentally promoted to a real title on focus+blur. */
+.session-title:empty::before {
+  content: attr(data-placeholder);
+  color: var(--color-text-tertiary);
+  pointer-events: none;
+}

--- a/src/renderer/src/components/SessionCard.tsx
+++ b/src/renderer/src/components/SessionCard.tsx
@@ -99,7 +99,17 @@ export function SessionCard({
       </span>
 
       <div className="min-w-0 flex-1">
-        <p className="truncate text-sm font-medium text-text-primary">{session.title}</p>
+        <p className="truncate text-sm font-medium text-text-primary">
+          {session.title && session.title.trim().length > 0
+            ? session.title
+            : new Date(session.createdAt).toLocaleString('de-CH', {
+                day: '2-digit',
+                month: '2-digit',
+                year: 'numeric',
+                hour: '2-digit',
+                minute: '2-digit'
+              })}
+        </p>
         <div className="flex items-center gap-2">
           <span className={`text-xs font-medium ${statusConfig.color}`}>{statusLabel}</span>
           {session.wordCount != null && session.status === 'review' && (

--- a/src/renderer/src/components/SessionCard.tsx
+++ b/src/renderer/src/components/SessionCard.tsx
@@ -29,17 +29,19 @@ const TASK_LABELS: Record<TaskType, string> = {
   alignment: 'Zuordnung',
   extraction: 'Textextraktion',
   ocr: 'OCR',
-  anonymization: 'Anonymisierung'
+  anonymization: 'Anonymisierung',
+  summarization: 'Zusammenfassung'
 }
 
 const AUDIO_PIPELINE_STEPS: TaskType[] = [
   'transcription',
   'diarization',
   'alignment',
-  'anonymization'
+  'anonymization',
+  'summarization'
 ]
 
-const PDF_PIPELINE_STEPS: TaskType[] = ['extraction', 'ocr', 'anonymization']
+const PDF_PIPELINE_STEPS: TaskType[] = ['extraction', 'ocr', 'anonymization', 'summarization']
 
 function isProcessingStatus(status: SessionStatus): boolean {
   return (

--- a/src/renderer/src/components/__tests__/SessionDashboard.test.tsx
+++ b/src/renderer/src/components/__tests__/SessionDashboard.test.tsx
@@ -166,6 +166,11 @@ beforeEach(() => {
       check: vi.fn().mockResolvedValue({ modelUpdates: [], appUpdate: { available: false, latestVersion: null, checkedAt: null } }),
       openReleasePage: vi.fn(),
       onStatus: vi.fn().mockReturnValue(() => {})
+    },
+    summary: {
+      get: vi.fn().mockResolvedValue(null),
+      updateTitle: vi.fn().mockResolvedValue(undefined),
+      updateText: vi.fn().mockResolvedValue(undefined)
     }
   } as typeof window.api
   vi.clearAllMocks()

--- a/src/renderer/src/components/__tests__/SessionDashboard.test.tsx
+++ b/src/renderer/src/components/__tests__/SessionDashboard.test.tsx
@@ -24,6 +24,9 @@ function makeSession(overrides: Partial<Session> = {}): Session {
     updatedAt: new Date().toISOString(),
     reviewAt: null,
     wordCount: null,
+    summary: null,
+    summaryModelId: null,
+    summarizedAt: null,
     ...overrides
   }
 }

--- a/src/renderer/src/components/review/EditableSessionTitle.tsx
+++ b/src/renderer/src/components/review/EditableSessionTitle.tsx
@@ -20,6 +20,12 @@ export function EditableSessionTitle({
   // The fallback is shown via CSS ::before from data-placeholder, never as real text —
   // this avoids accidentally promoting the fallback string to a real title when the user
   // focuses + blurs an empty field.
+  //
+  // We deliberately render the h2 with NO React-controlled child. The `title` text is
+  // written imperatively via the useEffect below. If we used `{title}` as JSX child,
+  // the reconciler would clobber the user's draft any time the parent re-renders with
+  // a new `title` prop while the field is focused. Imperative writes give us a single
+  // gate (focus check) to decide whether to overwrite.
   const ref = useRef<HTMLHeadingElement | null>(null)
   const originalRef = useRef(title)
 
@@ -29,6 +35,16 @@ export function EditableSessionTitle({
       ref.current.textContent = title
     }
   }, [title])
+
+  // First-mount paint: ref is set after the empty render but before useEffect can
+  // run synchronously, so populate textContent here too. Without this the h2 shows
+  // the CSS placeholder briefly even when title is non-empty.
+  const setRef = (el: HTMLHeadingElement | null): void => {
+    ref.current = el
+    if (el && document.activeElement !== el && el.textContent !== title) {
+      el.textContent = title
+    }
+  }
 
   const commit = (el: HTMLElement): void => {
     const next = (el.textContent ?? '').trim()
@@ -56,7 +72,7 @@ export function EditableSessionTitle({
 
   return (
     <h2
-      ref={ref}
+      ref={setRef}
       className={`session-title outline-none focus:ring-1 focus:ring-primary rounded-sm ${className ?? ''}`}
       contentEditable
       suppressContentEditableWarning
@@ -64,8 +80,6 @@ export function EditableSessionTitle({
       onKeyDown={onKeyDown}
       aria-label="Sitzungstitel bearbeiten"
       data-placeholder={fallback}
-    >
-      {title}
-    </h2>
+    />
   )
 }

--- a/src/renderer/src/components/review/EditableSessionTitle.tsx
+++ b/src/renderer/src/components/review/EditableSessionTitle.tsx
@@ -1,0 +1,71 @@
+import { useRef, useEffect } from 'react'
+import type { KeyboardEvent, FocusEvent } from 'react'
+
+interface Props {
+  sessionId: string
+  title: string
+  fallback: string
+  onSaved?: (next: string) => void
+  className?: string
+}
+
+export function EditableSessionTitle({
+  sessionId,
+  title,
+  fallback,
+  onSaved,
+  className
+}: Props): React.JSX.Element {
+  // The DOM text content is always the actual title (empty string if user cleared it).
+  // The fallback is shown via CSS ::before from data-placeholder, never as real text —
+  // this avoids accidentally promoting the fallback string to a real title when the user
+  // focuses + blurs an empty field.
+  const ref = useRef<HTMLHeadingElement | null>(null)
+  const originalRef = useRef(title)
+
+  useEffect(() => {
+    originalRef.current = title
+    if (ref.current && document.activeElement !== ref.current) {
+      ref.current.textContent = title
+    }
+  }, [title])
+
+  const commit = (el: HTMLElement): void => {
+    const next = (el.textContent ?? '').trim()
+    if (next === originalRef.current) return
+    originalRef.current = next
+    window.api.summary
+      .updateTitle(sessionId, next)
+      .then(() => onSaved?.(next))
+      .catch((err) => {
+        console.error('Failed to save title edit', err)
+      })
+  }
+
+  const onBlur = (e: FocusEvent<HTMLHeadingElement>): void => commit(e.currentTarget)
+  const onKeyDown = (e: KeyboardEvent<HTMLHeadingElement>): void => {
+    if (e.key === 'Escape') {
+      e.currentTarget.textContent = originalRef.current
+      e.currentTarget.blur()
+    }
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      e.currentTarget.blur()
+    }
+  }
+
+  return (
+    <h2
+      ref={ref}
+      className={`session-title outline-none focus:ring-1 focus:ring-primary rounded-sm ${className ?? ''}`}
+      contentEditable
+      suppressContentEditableWarning
+      onBlur={onBlur}
+      onKeyDown={onKeyDown}
+      aria-label="Sitzungstitel bearbeiten"
+      data-placeholder={fallback}
+    >
+      {title}
+    </h2>
+  )
+}

--- a/src/renderer/src/components/review/SummaryPanel.tsx
+++ b/src/renderer/src/components/review/SummaryPanel.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useRef, useState } from 'react'
+import type { KeyboardEvent, FocusEvent } from 'react'
+
+interface Props {
+  sessionId: string
+}
+
+export function SummaryPanel({ sessionId }: Props): React.JSX.Element | null {
+  const [text, setText] = useState<string | null>(null)
+  const originalRef = useRef<string>('')
+
+  useEffect(() => {
+    let cancelled = false
+    window.api.summary.get(sessionId).then((record) => {
+      if (cancelled) return
+      if (record && record.text && record.text.length > 0) {
+        setText(record.text)
+        originalRef.current = record.text
+      } else {
+        setText(null)
+      }
+    })
+    return (): void => {
+      cancelled = true
+    }
+  }, [sessionId])
+
+  if (text === null) return null
+
+  const commit = (el: HTMLElement): void => {
+    const next = (el.textContent ?? '').trim()
+    if (next === originalRef.current) return
+    originalRef.current = next
+    window.api.summary.updateText(sessionId, next).catch((err) => {
+      console.error('Failed to save summary edit', err)
+    })
+  }
+
+  const onBlur = (e: FocusEvent<HTMLParagraphElement>): void => commit(e.currentTarget)
+  const onKeyDown = (e: KeyboardEvent<HTMLParagraphElement>): void => {
+    if (e.key === 'Escape') {
+      e.currentTarget.textContent = originalRef.current
+      e.currentTarget.blur()
+    }
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      e.currentTarget.blur()
+    }
+  }
+
+  return (
+    <section className="rounded-lg border border-border bg-surface-1 px-4 py-3">
+      <h2 className="mb-2 text-xs font-medium uppercase tracking-wide text-text-tertiary">
+        Zusammenfassung
+      </h2>
+      <p
+        className="rounded-sm text-sm leading-relaxed text-text-primary outline-none focus:ring-1 focus:ring-primary"
+        contentEditable
+        suppressContentEditableWarning
+        onBlur={onBlur}
+        onKeyDown={onKeyDown}
+      >
+        {text}
+      </p>
+    </section>
+  )
+}

--- a/src/renderer/src/components/review/SummaryPanel.tsx
+++ b/src/renderer/src/components/review/SummaryPanel.tsx
@@ -11,15 +11,24 @@ export function SummaryPanel({ sessionId }: Props): React.JSX.Element | null {
 
   useEffect(() => {
     let cancelled = false
-    window.api.summary.get(sessionId).then((record) => {
-      if (cancelled) return
-      if (record && record.text && record.text.length > 0) {
-        setText(record.text)
-        originalRef.current = record.text
-      } else {
-        setText(null)
-      }
-    })
+    window.api.summary
+      .get(sessionId)
+      .then((record) => {
+        if (cancelled) return
+        if (record && record.text && record.text.length > 0) {
+          setText(record.text)
+          originalRef.current = record.text
+        } else {
+          setText(null)
+        }
+      })
+      .catch((err) => {
+        // IPC failure (DB closed during shutdown, schema drift, etc.) — degrade
+        // to the no-summary state instead of leaving an unhandled rejection. The
+        // panel will render nothing, identical to the "no summary exists" path.
+        console.error('summary.get failed', err)
+        if (!cancelled) setText(null)
+      })
     return (): void => {
       cancelled = true
     }

--- a/src/renderer/src/components/review/__tests__/SummaryPanel.test.tsx
+++ b/src/renderer/src/components/review/__tests__/SummaryPanel.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { SummaryPanel } from '../SummaryPanel'
+
+const makeApi = (
+  over: { get?: ReturnType<typeof vi.fn>; updateText?: ReturnType<typeof vi.fn> } = {}
+): { summary: { get: ReturnType<typeof vi.fn>; updateText: ReturnType<typeof vi.fn>; updateTitle: ReturnType<typeof vi.fn> } } => ({
+  summary: {
+    get: over.get ?? vi.fn().mockResolvedValue(null),
+    updateText: over.updateText ?? vi.fn().mockResolvedValue(undefined),
+    updateTitle: vi.fn().mockResolvedValue(undefined)
+  }
+})
+
+beforeEach(() => {
+  ;(globalThis as unknown as { window: { api: unknown } }).window.api = makeApi()
+})
+
+describe('SummaryPanel', () => {
+  it('renders null when there is no summary', async () => {
+    const { container } = render(<SummaryPanel sessionId="abc" />)
+    await waitFor(() => {
+      expect(window.api.summary.get).toHaveBeenCalledWith('abc')
+    })
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders the summary text when present', async () => {
+    ;(globalThis as unknown as { window: { api: unknown } }).window.api = makeApi({
+      get: vi.fn().mockResolvedValue({
+        title: 'Kurztitel',
+        text: 'Eine Zusammenfassung.',
+        modelId: 'gemma-summarization',
+        summarizedAt: '2026-04-24T10:00:00Z'
+      })
+    })
+    render(<SummaryPanel sessionId="abc" />)
+    await waitFor(() => expect(screen.getByText('Eine Zusammenfassung.')).toBeDefined())
+  })
+
+  it('persists an edit via summary:updateText on blur', async () => {
+    const updateText = vi.fn().mockResolvedValue(undefined)
+    ;(globalThis as unknown as { window: { api: unknown } }).window.api = makeApi({
+      get: vi.fn().mockResolvedValue({
+        title: null,
+        text: 'Alter Text.',
+        modelId: null,
+        summarizedAt: null
+      }),
+      updateText
+    })
+    render(<SummaryPanel sessionId="abc" />)
+    const para = await screen.findByText('Alter Text.')
+    para.textContent = 'Neuer Text.'
+    fireEvent.blur(para)
+    await waitFor(() => {
+      expect(updateText).toHaveBeenCalledWith('abc', 'Neuer Text.')
+    })
+  })
+
+  it('does not persist on Escape (reverts to original)', async () => {
+    const updateText = vi.fn().mockResolvedValue(undefined)
+    ;(globalThis as unknown as { window: { api: unknown } }).window.api = makeApi({
+      get: vi.fn().mockResolvedValue({
+        title: null,
+        text: 'Original.',
+        modelId: null,
+        summarizedAt: null
+      }),
+      updateText
+    })
+    render(<SummaryPanel sessionId="abc" />)
+    const para = await screen.findByText('Original.')
+    para.textContent = 'Draft.'
+    fireEvent.keyDown(para, { key: 'Escape' })
+    expect(updateText).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/settings/ModelsSettings.tsx
+++ b/src/renderer/src/components/settings/ModelsSettings.tsx
@@ -10,13 +10,18 @@ import DiarizationPipelineSection from './DiarizationPipelineSection'
 export default function ModelsSettings(): React.JSX.Element {
   const toast = useToast()
   const [asrModels, setAsrModels] = useState<ModelCatalogEntry[]>([])
+  const [summarizationModels, setSummarizationModels] = useState<ModelCatalogEntry[]>([])
   const [downloadingId, setDownloadingId] = useState<string | null>(null)
   const [progress, setProgress] = useState<number | undefined>(undefined)
   const [deleteCandidate, setDeleteCandidate] = useState<ModelCatalogEntry | null>(null)
 
   const reload = async (): Promise<void> => {
-    const asr = await window.api.modelCatalog.list('asr')
+    const [asr, summarization] = await Promise.all([
+      window.api.modelCatalog.list('asr'),
+      window.api.modelCatalog.list('summarization')
+    ])
     setAsrModels(asr)
+    setSummarizationModels(summarization)
   }
 
   useEffect(() => {
@@ -40,8 +45,11 @@ export default function ModelsSettings(): React.JSX.Element {
   const handleDownload = async (id: string): Promise<void> => {
     setDownloadingId(id)
     try {
-      const updated = await window.api.modelCatalog.download(id)
-      setAsrModels(updated)
+      await window.api.modelCatalog.download(id)
+      // download returns the catalog for the model's group only — reload both
+      // to keep ASR + summarization grids in sync regardless of which one
+      // triggered the download.
+      await reload()
       toast.success('Modell erfolgreich heruntergeladen.')
     } catch (err) {
       toast.error(err instanceof Error ? err.message : String(err))
@@ -58,8 +66,8 @@ export default function ModelsSettings(): React.JSX.Element {
   const handleDeleteConfirmed = async (model: ModelCatalogEntry): Promise<void> => {
     setDeleteCandidate(null)
     try {
-      const updated = await window.api.modelCatalog.delete(model.id)
-      setAsrModels(updated)
+      await window.api.modelCatalog.delete(model.id)
+      await reload()
       toast.success(
         `"${model.label}" gelöscht — ${formatBytes(model.sizeBytes)} freigegeben.`
       )
@@ -70,8 +78,8 @@ export default function ModelsSettings(): React.JSX.Element {
 
   const handleActivate = async (model: ModelCatalogEntry): Promise<void> => {
     try {
-      const updated = await window.api.modelCatalog.setActive(model.group, model.id)
-      setAsrModels(updated)
+      await window.api.modelCatalog.setActive(model.group, model.id)
+      await reload()
       toast.success(
         `"${model.label}" aktiviert. Neue Transkriptionen verwenden ab jetzt dieses Modell — bereits verarbeitete Sitzungen bleiben unverändert.`
       )
@@ -143,6 +151,34 @@ export default function ModelsSettings(): React.JSX.Element {
       </section>
 
       <DiarizationPipelineSection />
+
+      <section className="space-y-3">
+        <div>
+          <h2 className="mb-1 text-lg font-semibold">Zusammenfassung (optional)</h2>
+          <p className="text-sm text-text-secondary">
+            Lokales Sprachmodell für 2-Satz-Zusammenfassungen am Ende der Verarbeitung.
+            Optional — ohne installiertes Modell wird der Schritt geräuschlos
+            übersprungen.
+          </p>
+        </div>
+
+        <div className="space-y-3">
+          {summarizationModels.map((m) => (
+            <ModelCard
+              key={m.id}
+              model={m}
+              activeUsageLabel="Wird für Zusammenfassungen verwendet"
+              downloading={downloadingId === m.id}
+              progress={downloadingId === m.id ? progress : undefined}
+              anyBusy={anyBusy}
+              onDownload={() => handleDownload(m.id)}
+              onCancelDownload={handleCancelDownload}
+              onDelete={() => setDeleteCandidate(m)}
+              onActivate={() => handleActivate(m)}
+            />
+          ))}
+        </div>
+      </section>
 
       <section>
         <h3 className="mb-2 text-sm font-medium text-text-tertiary">Pflicht-Modelle</h3>

--- a/src/renderer/src/views/ReviewEditor.tsx
+++ b/src/renderer/src/views/ReviewEditor.tsx
@@ -12,6 +12,8 @@ import { EditorContextMenu, type ContextMenuState } from '../components/editor/E
 import { BlocklistConfirmDialog } from '../components/editor/BlocklistConfirmDialog'
 import { RenameDialog } from '../components/RenameDialog'
 import { ConfirmDialog } from '../components/ConfirmDialog'
+import { EditableSessionTitle } from '../components/review/EditableSessionTitle'
+import { SummaryPanel } from '../components/review/SummaryPanel'
 import {
   batchRemovePlaceholder,
   anonymizeSelectionWithPropagation,
@@ -555,7 +557,13 @@ export default function ReviewEditor({ sessionId, onBack }: ReviewEditorProps): 
           <span className="shrink-0 text-lg" aria-hidden="true">
             {sessionType === 'audio' ? '\uD83C\uDFA4' : '\uD83D\uDCC4'}
           </span>
-          <h2 className="truncate text-lg font-semibold text-text-primary">{sessionTitle}</h2>
+          <EditableSessionTitle
+            sessionId={sessionId}
+            title={sessionTitle}
+            fallback="Sitzung ohne Titel"
+            onSaved={setSessionTitle}
+            className="min-w-0 flex-1 truncate text-lg font-semibold text-text-primary"
+          />
         </div>
         <div className="flex shrink-0 items-center gap-2">
           <button
@@ -614,6 +622,11 @@ export default function ReviewEditor({ sessionId, onBack }: ReviewEditorProps): 
           </button>
         </div>
       </header>
+
+      {/* Optional LLM-generated summary (only renders when present) */}
+      <div className="border-b border-border bg-surface-0 px-6 py-3 [&:empty]:border-b-0 [&:empty]:p-0">
+        <SummaryPanel sessionId={sessionId} />
+      </div>
 
       {/* Editor + Panel row */}
       <div className="flex min-h-0 flex-1">

--- a/src/shared/model-catalog.ts
+++ b/src/shared/model-catalog.ts
@@ -111,5 +111,22 @@ export const MODEL_DEFINITIONS: ModelDefinition[] = [
     archive: true,
     group: 'ner',
     isRequired: true
+  },
+  {
+    // Optional summarization model — Gemma 3 4B Instruct Q4_K_M (Gemma 4 E4B fallback,
+    // see CLAUDE.md "Gemma 4 E4B GGUF source"). Hash + size must be re-synced after
+    // running scripts/publish-manifest.sh per the model-hash-sync gotcha.
+    id: 'gemma-summarization',
+    label: 'Zusammenfassung (Gemma 3 4B Instruct)',
+    url: `${R2_CDN}/gemma-3-4b-it-Q4_K_M.gguf`,
+    relativePath: 'summarization/gemma-3-4b-it-Q4_K_M.gguf',
+    checkPath: 'summarization/gemma-3-4b-it-Q4_K_M.gguf',
+    sizeBytes: 2_490_000_000,
+    sha256: '0000000000000000000000000000000000000000000000000000000000000000',
+    group: 'summarization',
+    isRequired: false,
+    description:
+      'Lokales 4B-Parameter-Modell für 2-Satz-Zusammenfassungen deutscher Texte. Optional — kann später unter Einstellungen → Modelle nachgeladen werden.',
+    languages: ['de', 'en']
   }
 ]

--- a/src/shared/types/IpcApi.ts
+++ b/src/shared/types/IpcApi.ts
@@ -161,6 +161,19 @@ export interface AppUpdateApi {
   onStatus(callback: (status: AppUpdateStatus) => void): () => void
 }
 
+export interface SummaryRecord {
+  title: string | null
+  text: string
+  modelId: string | null
+  summarizedAt: string | null
+}
+
+export interface SummaryApi {
+  get(sessionId: string): Promise<SummaryRecord | null>
+  updateTitle(sessionId: string, title: string): Promise<void>
+  updateText(sessionId: string, text: string): Promise<void>
+}
+
 export interface ModelCatalogApi {
   list(group: ModelGroup): Promise<ModelCatalogEntry[]>
   listAsr(): Promise<ModelCatalogEntry[]>
@@ -190,4 +203,5 @@ export interface IpcApi {
   modelUpdate: ModelUpdateApi
   pipeline: PipelineApi
   appUpdate: AppUpdateApi
+  summary: SummaryApi
 }

--- a/src/shared/types/Session.ts
+++ b/src/shared/types/Session.ts
@@ -29,6 +29,9 @@ export interface Session {
   updatedAt: string
   reviewAt: string | null
   wordCount: number | null
+  summary: string | null
+  summaryModelId: string | null
+  summarizedAt: string | null
 }
 
 export interface CreateSessionInput {
@@ -53,4 +56,7 @@ export interface UpdateSessionInput {
   errorMessage?: string | null
   reviewAt?: string | null
   wordCount?: number | null
+  summary?: string | null
+  summaryModelId?: string | null
+  summarizedAt?: string | null
 }

--- a/src/shared/types/Task.ts
+++ b/src/shared/types/Task.ts
@@ -5,6 +5,7 @@ export type TaskType =
   | 'extraction'
   | 'ocr'
   | 'anonymization'
+  | 'summarization'
 
 export type TaskStatus = 'pending' | 'running' | 'completed' | 'failed' | 'cancelled'
 

--- a/src/shared/validation/__tests__/model-catalog-schemas.test.ts
+++ b/src/shared/validation/__tests__/model-catalog-schemas.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest'
+import { ModelGroupSchema } from '../model-catalog-schemas'
+
+describe('ModelGroupSchema', () => {
+  it('accepts "summarization" as a valid group', () => {
+    expect(ModelGroupSchema.parse('summarization')).toBe('summarization')
+  })
+
+  it('still accepts the existing groups', () => {
+    expect(ModelGroupSchema.parse('asr')).toBe('asr')
+    expect(ModelGroupSchema.parse('diarization')).toBe('diarization')
+    expect(ModelGroupSchema.parse('ner')).toBe('ner')
+  })
+
+  it('rejects unknown groups', () => {
+    expect(() => ModelGroupSchema.parse('unknown')).toThrow()
+  })
+})

--- a/src/shared/validation/model-catalog-schemas.ts
+++ b/src/shared/validation/model-catalog-schemas.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 
-export const ModelGroupSchema = z.enum(['asr', 'diarization', 'ner'])
+export const ModelGroupSchema = z.enum(['asr', 'diarization', 'ner', 'summarization'])
 export type ModelGroup = z.infer<typeof ModelGroupSchema>
 
 export const ModelCatalogEntrySchema = z.object({

--- a/src/shared/validation/summary-schemas.ts
+++ b/src/shared/validation/summary-schemas.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod'
+
+const MAX_TITLE_CHARS = 120
+const MAX_SUMMARY_CHARS = 2_000
+
+export const SummaryGetInputSchema = z.object({
+  sessionId: z.string().min(1)
+})
+
+export const SummaryUpdateTitleInputSchema = z.object({
+  sessionId: z.string().min(1),
+  title: z.string().max(MAX_TITLE_CHARS)
+})
+
+export const SummaryUpdateTextInputSchema = z.object({
+  sessionId: z.string().min(1),
+  text: z.string().max(MAX_SUMMARY_CHARS)
+})
+
+export type SummaryGetInput = z.infer<typeof SummaryGetInputSchema>
+export type SummaryUpdateTitleInput = z.infer<typeof SummaryUpdateTitleInputSchema>
+export type SummaryUpdateTextInput = z.infer<typeof SummaryUpdateTextInputSchema>


### PR DESCRIPTION
## Summary

Adds an optional local LLM tail step to the TaskQueue pipeline that produces a German title + 2-sentence summary for every audio + PDF session, fully on-device via llama.cpp + Gemma 3 4B Instruct (Q4_K_M GGUF).

- **Architecture**: `'summarization'` is appended to both `AUDIO_PIPELINE` and `PDF_PIPELINE` chains. `LlamaSummarizer` wraps `llama-cli` as a subprocess (Metal `-ngl 999`, `--temp 0.3`); `SummarizationExecutor` skips silently when the model is not installed or the anonymized text is empty. Strictly sequential by piggybacking on the existing `TaskQueue` — no extra coordination, no RAM-budget violation.
- **Persistence**: Migration 007 adds `summary`, `summary_model_id`, `summarized_at` columns to `sessions`. The existing `title` column is reused (overwritten by the LLM) instead of adding a parallel column — keeps legacy sessions consistent.
- **UI**: Review Editor mounts an inline-editable h1 (`EditableSessionTitle`) and `SummaryPanel`. Both edit via new IPC channels `summary:get`/`summary:updateTitle`/`summary:updateText` (Zod-validated, length-capped). Settings → Modelle gains a "Zusammenfassung (optional)" section. Session list falls back to formatted date when title is empty.
- **Privacy**: Local-only, `connect-src 'none'` preserved. Anonymized TipTap doc is flattened (drop speaker labels + timestamps, inline `[PERSON 1]`-style chips) before being passed to the LLM — raw transcripts never reach the model.

Plan: [docs/superpowers/plans/2026-04-24-local-llm-summarization.md](docs/superpowers/plans/2026-04-24-local-llm-summarization.md)
Feature doc: [docs/product/features/summarization.md](docs/product/features/summarization.md)

### Notable design decisions

- **Gemma 3 4B fallback**: Gemma 4 E4B GGUF was not yet published when this work started; the catalog points at bartowski's Gemma 3 4B Instruct Q4_K_M as documented in CLAUDE.md. Swap is a one-line URL/filename change once an upstream Gemma 4 E4B GGUF exists.
- **Optional model gating**: `MODEL_DEFINITIONS` ships with a placeholder `sha256` (`'0'.repeat(64)`) until the GGUF is uploaded to R2. Runtime catalog accessors filter placeholder entries, so the Settings UI and `isModelInstalled` correctly hide the model until the hash is synced from `manifest.json`.
- **No regenerate UI**: Initial generation runs only as the pipeline tail step. Users can edit title + summary inline; clearing the summary's `summary_model_id` on user edits flags the text as no-longer-LLM-authoritative.
- **Editable contentEditable without React clobbering**: `EditableSessionTitle` writes DOM text imperatively via ref-callback + useEffect (gated by `document.activeElement`) so a parent re-render with a stale `title` prop can't destroy an in-progress draft.

### Architecture review (post-implementation)

The senior-architect bewertung surfaced 8 actionable items, all addressed in commit `88435c5`:

1. Placeholder-sha256 filter at runtime accessors (item 1)
2. `summarization: 600_000` stall threshold in `ProcessWatchdog` (item 2)
3. `registerSummaryHandlers(deps)` accepts `sessionService` from composition root instead of instantiating its own (item 3)
4. `EditableSessionTitle` uses imperative DOM writes to avoid React-controlled `contentEditable` clobbering (item 4)
5. Explicit summarization branch in `findResumeIndex` + comment cleanup (item 5)
6. `GROUP_TO_SETTINGS_KEY` value type derived from `keyof AppSettings['activeModels']` (item 6)
7. Title-reuse semantics documented in `getSummary` JSDoc (item 7)
8. `deleteModel` JSDoc rewritten to match actual guard coverage (item 8)

False positives (LlamaSummarizer abort race, `code === null` logging, "dead" `TASK_TO_SESSION_STATUS` entry) were intentionally not changed — analysis in the architect bewertung.

## Follow-ups (not in this PR)

- Once the Gemma GGUF is on R2: sync `sha256` + `sizeBytes` in [src/shared/model-catalog.ts](src/shared/model-catalog.ts). The placeholder filter will deactivate automatically.
- Build the standalone `llama-cli` + dylibs into `resources/bin/` + `resources/lib/` via `scripts/setup-llama.sh` on the release machine before `npm run package`.
- Hardware E2E: process a real session end-to-end on M-series silicon to confirm Metal acceleration + watchdog behaviour.

## Test plan

- [x] `npm run typecheck` — both node + web configs clean
- [x] `npx vitest run` — 646/646 tests pass (added 36 new unit tests for prompt builder, LlamaSummarizer, SummarizationExecutor, SummaryPanel, summary handlers, SessionService summary methods, TipTap extractor, model-catalog schema)
- [x] `npm run build` — electron-vite production build succeeds
- [ ] `npm run dev` — process a new session, verify auto-generated h1 + summary appear in Review Editor; verify edits persist across reload
- [ ] Delete `~/.therascript/models/summarization/` and process a session — verify silent skip (no error in UI, log shows "Summarization skipped: model not installed")
- [ ] Process two sessions back-to-back — confirm only one ML model resident at a time (Activity Monitor)
- [ ] Settings → Modelle → "Zusammenfassung (optional)" — verify download/delete/activate flow once R2 hash is synced

🤖 Generated with [Claude Code](https://claude.com/claude-code)