### PR TITLE
fix(summarization): runtime fixes after on-hardware setup-llama + smoke test

### DIFF
--- a/scripts/setup-llama.sh
+++ b/scripts/setup-llama.sh
@@ -9,8 +9,9 @@ LIB_DIR="$REPO_ROOT/resources/lib"
 # Gemma 4 E4B Q4_K_M GGUF was not yet published when this feature shipped — see
 # CLAUDE.md ("Gemma 4 E4B GGUF source"). Fallback: Gemma 3 4B Instruct Q4_K_M.
 # The repo is HuggingFace-gated → run `huggingface-cli login` before --model.
-GGUF_FILENAME='gemma-3-4b-it-Q4_K_M.gguf'
-GGUF_URL="https://huggingface.co/bartowski/gemma-3-4b-it-GGUF/resolve/main/${GGUF_FILENAME}"
+GGUF_FILENAME='google_gemma-3-4b-it-Q4_K_M.gguf'
+GGUF_REPO='bartowski/google_gemma-3-4b-it-GGUF'
+GGUF_URL="https://huggingface.co/${GGUF_REPO}/resolve/main/${GGUF_FILENAME}"
 
 mkdir -p "$BIN_DIR" "$LIB_DIR"
 
@@ -26,12 +27,21 @@ echo '==> Copying llama-cli binary'
 cp "$BREW_PREFIX/bin/llama-cli" "$BIN_DIR/llama-cli"
 
 echo '==> Copying runtime dylibs'
+# llama-cli (>= b8920) links against libllama, libllama-common and libmtmd
+# from the llama.cpp formula plus libggml + libggml-base from the ggml
+# formula (separate Homebrew install). Copy all of them.
 cp "$BREW_PREFIX/lib/"libllama*.dylib "$LIB_DIR/" 2>/dev/null || true
+cp "$BREW_PREFIX/lib/"libmtmd*.dylib "$LIB_DIR/" 2>/dev/null || true
+GGML_PREFIX="$(brew --prefix ggml 2>/dev/null || true)"
+if [ -n "$GGML_PREFIX" ] && [ -d "$GGML_PREFIX/lib" ]; then
+  cp "$GGML_PREFIX/lib/"libggml*.dylib "$LIB_DIR/" 2>/dev/null || true
+fi
+# Fallback: some older formulas ship libggml in the llama.cpp prefix.
 cp "$BREW_PREFIX/lib/"libggml*.dylib "$LIB_DIR/" 2>/dev/null || true
 
 echo '==> Re-signing binary with ad-hoc signature'
 codesign --force --sign - "$BIN_DIR/llama-cli"
-for dylib in "$LIB_DIR/"libllama*.dylib "$LIB_DIR/"libggml*.dylib; do
+for dylib in "$LIB_DIR/"libllama*.dylib "$LIB_DIR/"libmtmd*.dylib "$LIB_DIR/"libggml*.dylib; do
   [ -f "$dylib" ] && codesign --force --sign - "$dylib"
 done
 
@@ -44,11 +54,16 @@ if [[ "${1:-}" == '--model' ]]; then
   MODEL_FILE="$MODEL_DIR/$GGUF_FILENAME"
   if [ ! -f "$MODEL_FILE" ]; then
     echo "==> Downloading Gemma 3 4B Instruct Q4_K_M (~2.5 GB)"
-    if command -v huggingface-cli >/dev/null 2>&1; then
-      huggingface-cli download "bartowski/gemma-3-4b-it-GGUF" \
+    # Prefer the new `hf` CLI (huggingface-hub >=0.26); fall back to the legacy
+    # `huggingface-cli` for older installs, then to a direct curl (which fails
+    # for gated repos like bartowski/gemma-3-4b-it-GGUF).
+    if command -v hf >/dev/null 2>&1; then
+      hf download "$GGUF_REPO" "$GGUF_FILENAME" --local-dir "$MODEL_DIR"
+    elif command -v huggingface-cli >/dev/null 2>&1; then
+      huggingface-cli download "$GGUF_REPO" \
         "$GGUF_FILENAME" --local-dir "$MODEL_DIR" --local-dir-use-symlinks False
     else
-      echo "huggingface-cli not found — falling back to direct curl (will fail if model is gated)" >&2
+      echo "Neither hf nor huggingface-cli found — falling back to direct curl (will fail if gated)" >&2
       curl -L --fail -o "$MODEL_FILE" "$GGUF_URL"
     fi
   else

--- a/src/main/ml/LlamaSummarizer.ts
+++ b/src/main/ml/LlamaSummarizer.ts
@@ -17,8 +17,12 @@ export function buildLlamaArgs(input: LlamaArgsInput): string[] {
     input.modelPath,
     '-f',
     input.promptFilePath,
-    '--chat-template',
-    'gemma',
+    // -st (single-turn) wraps the prompt in the model's jinja chat template
+    // (loaded from the GGUF) and exits after one assistant response. Without
+    // this, llama-cli b8920+ either ignores --chat-template (in raw -p mode,
+    // producing garbage continuations) or stays in interactive chat mode and
+    // never exits. -st is the only mode that gives us a clean one-shot run.
+    '-st',
     '-n',
     String(input.maxTokens),
     '--temp',

--- a/src/main/ml/__tests__/LlamaSummarizer.test.ts
+++ b/src/main/ml/__tests__/LlamaSummarizer.test.ts
@@ -12,8 +12,10 @@ describe('buildLlamaArgs', () => {
     expect(args).toContain('/models/gemma.gguf')
     expect(args).toContain('-f')
     expect(args).toContain('/tmp/prompt.txt')
-    expect(args).toContain('--chat-template')
-    expect(args).toContain('gemma')
+    // Single-turn mode: applies the model's jinja chat template + exits
+    // after one response. Without this, llama-cli b8920+ either skips the
+    // chat template (raw -p mode → garbage) or hangs in interactive mode.
+    expect(args).toContain('-st')
     expect(args).toContain('-n')
     expect(args).toContain('200')
     expect(args).toContain('--no-display-prompt')

--- a/src/shared/model-catalog.ts
+++ b/src/shared/model-catalog.ts
@@ -118,11 +118,11 @@ export const MODEL_DEFINITIONS: ModelDefinition[] = [
     // running scripts/publish-manifest.sh per the model-hash-sync gotcha.
     id: 'gemma-summarization',
     label: 'Zusammenfassung (Gemma 3 4B Instruct)',
-    url: `${R2_CDN}/gemma-3-4b-it-Q4_K_M.gguf`,
-    relativePath: 'summarization/gemma-3-4b-it-Q4_K_M.gguf',
-    checkPath: 'summarization/gemma-3-4b-it-Q4_K_M.gguf',
-    sizeBytes: 2_490_000_000,
-    sha256: '0000000000000000000000000000000000000000000000000000000000000000',
+    url: `${R2_CDN}/google_gemma-3-4b-it-Q4_K_M.gguf`,
+    relativePath: 'summarization/google_gemma-3-4b-it-Q4_K_M.gguf',
+    checkPath: 'summarization/google_gemma-3-4b-it-Q4_K_M.gguf',
+    sizeBytes: 2_489_758_112,
+    sha256: '4996030242583a40aa151ff93f49ed787ac8c25e4120c3ae4588b2e2a7d1ae94',
     group: 'summarization',
     isRequired: false,
     description:


### PR DESCRIPTION
## Summary

Three concrete runtime fixes after running `scripts/setup-llama.sh --model` on hardware (M-series Mac) and smoke-testing the Gemma 3 4B fallback through `llama-cli`. Without these, the optional summarization model PR #51 shipped is not actually usable end-to-end.

## What broke and why

1. **`scripts/setup-llama.sh` — wrong HF repo path + missing dylibs**
   - The catalog and script pointed at `bartowski/gemma-3-4b-it-GGUF` / `gemma-3-4b-it-Q4_K_M.gguf`, but bartowski's actual public repo uses the `google_` prefix in **both** repo name and filename (`bartowski/google_gemma-3-4b-it-GGUF` / `google_gemma-3-4b-it-Q4_K_M.gguf`). Old path returned 401-gated; corrected path returns 200.
   - Homebrew now ships only the new `hf` CLI (replacing legacy `huggingface-cli`); script now detects both.
   - `llama-cli` (b8920+) links against `libmtmd*.dylib` (new dependency) plus `libggml*` from the separate `ggml` Homebrew formula. Old glob copied only `libllama*` and `libggml*` from the `llama.cpp` prefix → resulting binary failed at startup with `Library not loaded: @rpath/libmtmd.0.dylib`.

2. **`src/main/ml/LlamaSummarizer.ts` — missing `-st` flag**
   - llama-cli b8920+ no longer applies `--chat-template` to a `-p`/`-f` prompt unless the prompt enters chat mode. Without `-st`, our calls either produced garbage continuations (Flask boilerplate code instead of the requested German summary) or hung forever in interactive chat mode at 0% CPU.
   - The only mode that gives a clean one-shot run (apply jinja template + emit one assistant response + exit) is `-st` (single-turn).
   - Verified locally on M4 hardware: 615 t/s prompt, 83 t/s generation, Metal acceleration active, output is a coherent German 2-sentence summary.

3. **`src/shared/model-catalog.ts` — sync real sha256/sizeBytes from manifest**
   - GGUF uploaded to R2 (2,489,758,112 bytes), manifest published. Hash now committed: `4996030242583a40aa151ff93f49ed787ac8c25e4120c3ae4588b2e2a7d1ae94`.
   - Catalog filename also realigned to `google_gemma-3-4b-it-Q4_K_M.gguf` (R2 key, HF source filename, on-disk filename now all match).
   - The `PLACEHOLDER_SHA256` filter introduced in #51 deactivates automatically — the catalog entry becomes live in the Settings UI + `isModelInstalled` path.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npx vitest run` — 646/646 pass (LlamaSummarizer test asserts `-st` is in the args)
- [x] On-hardware smoke test: `llama-cli` produces a German summary with Metal at 80+ t/s
- [x] R2 manifest published (`pub-f6971d643e3a464ba6977c0816c43e50.r2.dev/manifest.json`)
- [ ] `npm run dev` end-to-end: process a session, verify SummaryPanel shows the LLM-generated text

🤖 Generated with [Claude Code](https://claude.com/claude-code)