### PR TITLE
fix(review): tighten quality-failed guards and ratio computation

### DIFF
--- a/src/main/ml/__tests__/whisper-quality.test.ts
+++ b/src/main/ml/__tests__/whisper-quality.test.ts
@@ -61,6 +61,14 @@ describe('computeRepetitionRatio', () => {
     const segments = [seg('   '), seg('   '), seg('   '), seg('echter Text')]
     expect(computeRepetitionRatio(segments)).toBe(0)
   })
+
+  it('pairs containing an empty segment are excluded from the denominator', () => {
+    // Real loop interleaved with silence segments: only (A,A) pairs are
+    // counted, the (A,'')/('',A) pairs are skipped on both sides of the
+    // ratio so the loop signal isn't diluted.
+    const segments = [seg('A'), seg('A'), seg('   '), seg('A'), seg('A')]
+    expect(computeRepetitionRatio(segments)).toBe(1)
+  })
 })
 
 describe('classifyQuality', () => {

--- a/src/main/ml/whisper-quality.ts
+++ b/src/main/ml/whisper-quality.ts
@@ -32,9 +32,11 @@ function normalize(text: string): string {
 
 /**
  * Counts adjacent identical segments (whitespace-normalized, case-insensitive).
- * Returns ratio = adjacent-duplicate-pairs / total-pairs, where total-pairs = segments.length - 1.
+ * Returns ratio = adjacent-duplicate-pairs / non-empty-pairs.
  *
- * Empty/whitespace-only segments do not count as duplicates of each other.
+ * Pairs where either side is empty/whitespace-only are excluded from both
+ * sides of the ratio so a loop interleaved with silence segments isn't
+ * artificially diluted by the empty pairs in the denominator.
  *
  * Detects whisper hallucination loops: when the model rolls over its previous
  * window's output as prompt context and reproduces the same sentence per
@@ -43,16 +45,18 @@ function normalize(text: string): string {
 export function computeRepetitionRatio(segments: TranscriptSegment[]): number {
   if (segments.length < 2) return 0
 
+  let totalPairs = 0
   let duplicatePairs = 0
-  let prev = normalize(segments[0].text)
 
   for (let i = 1; i < segments.length; i++) {
+    const prev = normalize(segments[i - 1].text)
     const curr = normalize(segments[i].text)
-    if (curr.length > 0 && curr === prev) duplicatePairs++
-    prev = curr
+    if (prev.length === 0 || curr.length === 0) continue
+    totalPairs++
+    if (prev === curr) duplicatePairs++
   }
 
-  return duplicatePairs / (segments.length - 1)
+  return totalPairs === 0 ? 0 : duplicatePairs / totalPairs
 }
 
 /**

--- a/src/renderer/src/components/review/QualityWarningBanner.tsx
+++ b/src/renderer/src/components/review/QualityWarningBanner.tsx
@@ -54,7 +54,7 @@ export function QualityWarningBanner({
               : undefined
           }
         >
-          <RotateCw className="h-3.5 w-3.5" strokeWidth={2.25} aria-hidden />
+          <RotateCw className="h-3.5 w-3.5" strokeWidth={2} aria-hidden />
           Erneut transkribieren
         </button>
       )}

--- a/src/renderer/src/views/ReviewEditor.tsx
+++ b/src/renderer/src/views/ReviewEditor.tsx
@@ -56,7 +56,9 @@ export default function ReviewEditor({ sessionId, onBack }: ReviewEditorProps): 
   const [loadError, setLoadError] = useState<string | null>(null)
   const [sessionTitle, setSessionTitle] = useState('')
   const [sessionType, setSessionType] = useState<SessionType>('audio')
-  const [sessionStatus, setSessionStatus] = useState<SessionStatus>('review')
+  // null until load() resolves, so the auto-save guard cannot misfire on a
+  // quality-failed session before its real status is known.
+  const [sessionStatus, setSessionStatus] = useState<SessionStatus | null>(null)
   const [qualityFlag, setQualityFlag] = useState<QualityFlag | null>(null)
   const [canRetryTranscription, setCanRetryTranscription] = useState(false)
   const [retrying, setRetrying] = useState(false)
@@ -290,11 +292,15 @@ export default function ReviewEditor({ sessionId, onBack }: ReviewEditorProps): 
   // Auto-save is only meaningful for sessions that produced an anonymized
   // document. transcription_quality_failed sessions render a fallback view
   // built from the raw (broken) transcript — there is no anonymized doc to
-  // persist edits into, and ReviewService.save() would throw.
+  // persist edits into, and ReviewService.save() would throw. The explicit
+  // null check guards against a debounce misfire before load() resolves.
+  const autoSaveEnabled =
+    !!editor &&
+    !loading &&
+    sessionStatus !== null &&
+    sessionStatus !== 'transcription_quality_failed'
   const { saving, lastSavedAt } = useAutoSave(
-    editor && !loading && sessionStatus !== 'transcription_quality_failed'
-      ? handleSave
-      : null,
+    autoSaveEnabled ? handleSave : null,
     [updateCounter],
     2000
   )


### PR DESCRIPTION
Follow-up to PR #66. Three small, independent fixes from the post-merge review.

## Summary
- **Auto-save tri-state guard** ([ReviewEditor.tsx](src/renderer/src/views/ReviewEditor.tsx)): \`sessionStatus\` starts as \`null\` and the auto-save \`enabled\` predicate now requires non-null. Closes a theoretical race where the 2 s debounce could fire on a \`transcription_quality_failed\` session before \`load()\` resolves and trigger \`review.save\` (which \`ReviewService\` is not guarded for).
- **Repetition-ratio denominator fix** ([whisper-quality.ts](src/main/ml/whisper-quality.ts)): \`computeRepetitionRatio\` now skips pairs where either side is empty on both numerator AND denominator. Loops interleaved with silence segments are no longer artificially diluted (e.g. \`[A, A, '', A, A]\` → 1.0 instead of the previous 0.5). New unit test covers the case.
- **strokeWidth cosmetic** ([QualityWarningBanner.tsx](src/renderer/src/components/review/QualityWarningBanner.tsx)): retry icon uses \`strokeWidth={2}\` per CLAUDE.md icon convention.

The critical retry-lockout finding (pipeline-version persisted before quality verdict) is intentionally **not** included here — it touches \`WhisperService\` + retry semantics and warrants a separate, focused review.

## Test plan
- [x] \`npm run typecheck\` — green
- [x] \`npm run test\` — 677/677 (one new whisper-quality test added)
- [ ] Manual: open a session, trigger a hot-reload during \`load()\` → no spurious \`review.save\` IPC call
- [ ] Manual: visual check on retry-banner — icon stroke matches surrounding label weight

🤖 Generated with [Claude Code](https://claude.com/claude-code)