### PR TITLE
test(quality): cover WhisperService qualityFlag persistence + comment cleanup

### DIFF
--- a/src/main/ml/SummarizationExecutor.ts
+++ b/src/main/ml/SummarizationExecutor.ts
@@ -51,14 +51,12 @@ export class SummarizationExecutor implements TaskExecutor {
         signal ?? new AbortController().signal
       )
     } catch (err) {
-      // Per the plan's design intent ("Model-missing is a skip, not a
-      // failure" — Plan §35; "generation failed → render nothing extra"
-      // — Plan §16), summarization is an OPTIONAL pipeline tail step.
-      // Any failure (subprocess crash, abort, JSON-extraction failure,
-      // schema validation failure, transient model error) must NOT
-      // poison the whole session into 'error' state — the anonymized
-      // transcript upstream is intact and the user should still reach
-      // the Review Editor. Log + return cleanly; the task succeeds with
+      // Summarization is an OPTIONAL pipeline tail step. Any failure
+      // (subprocess crash, abort, JSON-extraction failure, schema
+      // validation failure, transient model error) must NOT poison the
+      // whole session into 'error' state — the anonymized transcript
+      // upstream is intact and the user should still reach the Review
+      // Editor. Log + return cleanly; the task succeeds with
       // sessions.summary staying NULL.
       this.deps.logger.error(
         `Summarization failed for session ${task.sessionId}: ${err instanceof Error ? err.message : String(err)}`

--- a/src/main/ml/WhisperService.ts
+++ b/src/main/ml/WhisperService.ts
@@ -14,7 +14,7 @@ import { writeFileAtomic } from '../utils/file-ops'
 import { removeFillerWords, rebuildSegments } from './filler-removal'
 import { filterSpecialTokens, mergeSubTokens } from './token-processing'
 import type { WhisperToken } from './token-processing'
-import { computeRepetitionRatio, classifyQuality } from './whisper-quality'
+import { persistQualityResult } from './whisper-quality'
 
 interface WhisperSegment {
   timestamps: { from: string; to: string }
@@ -103,18 +103,17 @@ export class WhisperService implements TaskExecutor {
     // Non-blocking: classification is persisted as a flag but the pipeline
     // continues either way so the user sees the full result and can spot
     // the bad output / file a bug report.
-    const ratio = computeRepetitionRatio(transcript.segments)
-    const classification = classifyQuality(ratio)
+    const { ratio, classification } = persistQualityResult(
+      sessionService,
+      task.sessionId,
+      transcriptPath,
+      transcript.segments
+    )
     console.log(
       `[WhisperService] quality_check sessionId=${task.sessionId} ` +
         `ratio=${ratio.toFixed(4)} segments=${transcript.segments.length} ` +
         `classification=${classification ?? 'ok'}`
     )
-
-    sessionService.updateSession(task.sessionId, {
-      transcriptPath,
-      qualityFlag: classification
-    })
   }
 
   private runWhisper(

--- a/src/main/ml/__tests__/whisper-quality.test.ts
+++ b/src/main/ml/__tests__/whisper-quality.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import type { TranscriptSegment } from '../../../shared/types'
 import {
   computeRepetitionRatio,
   classifyQuality,
+  persistQualityResult,
   REPETITION_WARN_THRESHOLD,
   REPETITION_CRITICAL_THRESHOLD
 } from '../whisper-quality'
@@ -84,5 +85,71 @@ describe('classifyQuality', () => {
     expect(classifyQuality(0.71)).toBe('repetition_critical')
     expect(classifyQuality(0.95)).toBe('repetition_critical')
     expect(classifyQuality(1)).toBe('repetition_critical')
+  })
+})
+
+describe('persistQualityResult', () => {
+  // Verifies the wiring used by WhisperService.execute(): compute ratio,
+  // classify, persist transcriptPath + qualityFlag in a single update.
+
+  function makeTarget(): { updateSession: ReturnType<typeof vi.fn> } {
+    return { updateSession: vi.fn() }
+  }
+
+  it('persists qualityFlag=null for clean transcripts', () => {
+    const target = makeTarget()
+    const segments: TranscriptSegment[] = [
+      seg('Hallo, wie geht es Ihnen heute?'),
+      seg('Mir geht es gut, danke der Nachfrage.'),
+      seg('Das freut mich zu hören.')
+    ]
+
+    const result = persistQualityResult(target, 'sess-1', '/tmp/t.json', segments)
+
+    expect(result.classification).toBeNull()
+    expect(result.ratio).toBe(0)
+    expect(target.updateSession).toHaveBeenCalledOnce()
+    expect(target.updateSession).toHaveBeenCalledWith('sess-1', {
+      transcriptPath: '/tmp/t.json',
+      qualityFlag: null
+    })
+  })
+
+  it("persists qualityFlag='repetition_warning' for ratio in (0.3, 0.7]", () => {
+    const target = makeTarget()
+    // 5 segments → 4 pairs. 2 duplicate pairs = ratio 0.5 → warning.
+    const segments: TranscriptSegment[] = [seg('A'), seg('A'), seg('B'), seg('B'), seg('C')]
+
+    const result = persistQualityResult(target, 'sess-2', '/tmp/t.json', segments)
+
+    expect(result.classification).toBe('repetition_warning')
+    expect(result.ratio).toBeCloseTo(0.5)
+    expect(target.updateSession).toHaveBeenCalledWith('sess-2', {
+      transcriptPath: '/tmp/t.json',
+      qualityFlag: 'repetition_warning'
+    })
+  })
+
+  it("persists qualityFlag='repetition_critical' for ratio > 0.7", () => {
+    const target = makeTarget()
+    // 20 identical segments → 19/19 = ratio 1.0 → critical.
+    const segments: TranscriptSegment[] = Array.from({ length: 20 }, () =>
+      seg('Vielen Dank für das Gespräch.')
+    )
+
+    const result = persistQualityResult(target, 'sess-3', '/tmp/t.json', segments)
+
+    expect(result.classification).toBe('repetition_critical')
+    expect(result.ratio).toBe(1)
+    expect(target.updateSession).toHaveBeenCalledWith('sess-3', {
+      transcriptPath: '/tmp/t.json',
+      qualityFlag: 'repetition_critical'
+    })
+  })
+
+  it('updates the session exactly once even when classification is null', () => {
+    const target = makeTarget()
+    persistQualityResult(target, 'sess-4', '/tmp/t.json', [seg('only one segment')])
+    expect(target.updateSession).toHaveBeenCalledOnce()
   })
 })

--- a/src/main/ml/whisper-quality.ts
+++ b/src/main/ml/whisper-quality.ts
@@ -1,5 +1,17 @@
 import type { TranscriptSegment, QualityFlag } from '../../shared/types'
 
+/**
+ * Minimal contract for the SessionService surface used to persist the
+ * quality-check result. Defined here (instead of importing the full class)
+ * so the helper stays trivially testable with a stub.
+ */
+export interface QualityPersistTarget {
+  updateSession(
+    sessionId: string,
+    input: { transcriptPath: string; qualityFlag: QualityFlag | null }
+  ): unknown
+}
+
 // ADR-006 thresholds. Strict greater-than comparisons.
 // Both severities are non-blocking: the pipeline runs to completion either
 // way, the only effect is a banner the user sees in the review editor.
@@ -55,4 +67,24 @@ export function classifyQuality(ratio: number): QualityClassification {
   if (ratio > REPETITION_CRITICAL_THRESHOLD) return 'repetition_critical'
   if (ratio > REPETITION_WARN_THRESHOLD) return 'repetition_warning'
   return null
+}
+
+/**
+ * Compute the repetition ratio for a transcript and persist the resulting
+ * quality flag onto the session together with the transcript path. Returns
+ * the computed ratio + classification so the caller can log them.
+ *
+ * Extracted from WhisperService.execute() so the wiring (compute → classify
+ * → updateSession) can be unit-tested without spawning whisper-cli.
+ */
+export function persistQualityResult(
+  target: QualityPersistTarget,
+  sessionId: string,
+  transcriptPath: string,
+  segments: TranscriptSegment[]
+): { ratio: number; classification: QualityClassification } {
+  const ratio = computeRepetitionRatio(segments)
+  const classification = classifyQuality(ratio)
+  target.updateSession(sessionId, { transcriptPath, qualityFlag: classification })
+  return { ratio, classification }
 }


### PR DESCRIPTION
Follow-up to PR #70. Closes the integration-coverage gap noted in the PR #70 architectural review and removes a couple of stale planning-artifact references.

## Summary
- **Extract \`persistQualityResult\` helper** from \`WhisperService.execute()\` so the compute → classify → updateSession wiring is testable without spawning whisper-cli. The helper accepts a minimal \`QualityPersistTarget\` interface (just \`updateSession\`), so a \`vi.fn\` stub suffices.
- **Add 4 unit tests** covering all classification branches + the call-count invariant:
  - clean transcript → \`qualityFlag: null\`
  - mid-ratio (~0.5) → \`'repetition_warning'\`
  - high-ratio (1.0) → \`'repetition_critical'\`
  - single-segment edge case → exactly one \`updateSession\` call
- **Drop dead \`Plan §35\` / \`Plan §16\` references** in \`SummarizationExecutor.ts\` (the planning artifact those citations point to was never committed). Behavioural rationale stays.

## Test plan
- [x] \`npm run typecheck\` — green
- [x] \`npm run test\` — 678/678 (+4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)