### PR TITLE
chore(quality): move quality-check log into the helper

### DIFF
--- a/src/main/ml/WhisperService.ts
+++ b/src/main/ml/WhisperService.ts
@@ -103,17 +103,7 @@ export class WhisperService implements TaskExecutor {
     // Non-blocking: classification is persisted as a flag but the pipeline
     // continues either way so the user sees the full result and can spot
     // the bad output / file a bug report.
-    const { ratio, classification } = persistQualityResult(
-      sessionService,
-      task.sessionId,
-      transcriptPath,
-      transcript.segments
-    )
-    console.log(
-      `[WhisperService] quality_check sessionId=${task.sessionId} ` +
-        `ratio=${ratio.toFixed(4)} segments=${transcript.segments.length} ` +
-        `classification=${classification ?? 'ok'}`
-    )
+    persistQualityResult(sessionService, task.sessionId, transcriptPath, transcript.segments)
   }
 
   private runWhisper(

--- a/src/main/ml/whisper-quality.ts
+++ b/src/main/ml/whisper-quality.ts
@@ -1,9 +1,10 @@
 import type { TranscriptSegment, QualityFlag } from '../../shared/types'
 
 /**
- * Minimal contract for the SessionService surface used to persist the
- * quality-check result. Defined here (instead of importing the full class)
- * so the helper stays trivially testable with a stub.
+ * Minimal contract for persisting both the transcript path and the
+ * quality-check classification onto the session. Defined here (instead of
+ * importing SessionService directly) so the helper stays trivially testable
+ * with a stub.
  */
 export interface QualityPersistTarget {
   updateSession(
@@ -85,6 +86,14 @@ export function persistQualityResult(
 ): { ratio: number; classification: QualityClassification } {
   const ratio = computeRepetitionRatio(segments)
   const classification = classifyQuality(ratio)
+  // Log before the DB write so the ratio survives a failing updateSession
+  // (rare — SQLite-Constraint, disk full — but the operator needs the
+  // value to correlate with the surfaced exception).
+  console.log(
+    `[WhisperService] quality_check sessionId=${sessionId} ` +
+      `ratio=${ratio.toFixed(4)} segments=${segments.length} ` +
+      `classification=${classification ?? 'ok'}`
+  )
   target.updateSession(sessionId, { transcriptPath, qualityFlag: classification })
   return { ratio, classification }
 }


### PR DESCRIPTION
Two micro-polish items left over from the PR #71 architectural review.

## Summary
- **Log before updateSession.** \`persistQualityResult\` now emits the ratio + classification log entry **before** the DB write so the value survives a failing \`updateSession\` (rare — SQLite constraint, disk full — but the operator needs the ratio to correlate with the surfaced exception). The previous code logged after the helper returned, which silently dropped the line on exception.
- **Drop duplicate log call.** The matching \`console.log\` in \`WhisperService.execute()\` is now redundant; removed so there's a single log source for the quality check.
- **JSDoc clarity.** \`QualityPersistTarget\` doc now names both responsibilities (transcript path AND classification) explicitly instead of just "the quality-check result".

## Test plan
- [x] \`npm run typecheck\` — green
- [x] \`npm run test\` — 678/678

🤖 Generated with [Claude Code](https://claude.com/claude-code)