### PR TITLE
Release: unicode escape cleanup

### DIFF
--- a/src/renderer/src/components/AboutPage.tsx
+++ b/src/renderer/src/components/AboutPage.tsx
@@ -64,7 +64,7 @@ export default function AboutPage(): React.JSX.Element {
         <div>
           <AppLogo size={64} className="mb-3" />
           <h3 className="text-lg font-semibold text-text-primary">
-            TheraScript v{info?.version ?? '\u2026'}
+            TheraScript v{info?.version ?? '…'}
           </h3>
           <p className="text-sm text-text-tertiary">Open Source (MIT-Lizenz)</p>
         </div>
@@ -77,14 +77,14 @@ export default function AboutPage(): React.JSX.Element {
               onClick={checkNow}
               disabled={checking}
             >
-              {checking ? 'Pr\u00FCfe\u2026' : 'Nach Updates suchen'}
+              {checking ? 'Prüfe…' : 'Nach Updates suchen'}
             </button>
             {appUpdateStatus?.available && (
               <button
                 className="text-sm font-medium text-primary transition-colors hover:text-primary-hover"
                 onClick={openReleasePage}
               >
-                Neue Version verf\u00FCgbar &mdash; herunterladen
+                Neue Version verfügbar &mdash; herunterladen
               </button>
             )}
             {appUpdateStatus && !appUpdateStatus.available && appUpdateStatus.checkedAt && (
@@ -113,7 +113,7 @@ export default function AboutPage(): React.JSX.Element {
           <h4 className="mb-1 text-sm font-medium text-text-secondary">App-Datenverzeichnis</h4>
           <div className="flex items-center gap-3">
             <p className="min-w-0 flex-1 truncate text-sm text-text-secondary">
-              {info?.dataDir ?? '\u2026'}
+              {info?.dataDir ?? '…'}
             </p>
             <button
               className="shrink-0 rounded-lg border border-border px-3 py-1.5 text-sm font-medium text-text-secondary transition-colors hover:bg-surface-2 disabled:opacity-50"
@@ -134,7 +134,7 @@ export default function AboutPage(): React.JSX.Element {
               <p>Transkriptionsdaten: {formatBytes(info.storageSessionsBytes)}</p>
             </div>
           ) : (
-            <p className="text-sm text-text-tertiary">Wird berechnet\u2026</p>
+            <p className="text-sm text-text-tertiary">Wird berechnet…</p>
           )}
         </div>
 
@@ -151,12 +151,12 @@ export default function AboutPage(): React.JSX.Element {
                 {info.fileVaultActive === null
                   ? 'Unbekannt'
                   : info.fileVaultActive
-                    ? '\u2713 Aktiv'
-                    : '\u2717 Nicht aktiv'}
+                    ? '✓ Aktiv'
+                    : '✗ Nicht aktiv'}
               </p>
             </div>
           ) : (
-            <p className="text-sm text-text-tertiary">Wird geladen\u2026</p>
+            <p className="text-sm text-text-tertiary">Wird geladen…</p>
           )}
         </div>
 
@@ -164,7 +164,7 @@ export default function AboutPage(): React.JSX.Element {
         <div className="rounded-lg border border-border bg-surface-1 p-4">
           <h4 className="mb-1 text-sm font-medium text-text-secondary">Daten</h4>
           <p className="text-sm text-text-secondary">
-            Transkriptionen werden automatisch 30 Tage nach Erstellung gel\u00F6scht.
+            Transkriptionen werden automatisch 30 Tage nach Erstellung gelöscht.
           </p>
           <p className="mt-1 text-sm text-text-secondary">
             Sie sind verantwortlich, den kopierten Text extern zu sichern.
@@ -189,14 +189,14 @@ export default function AboutPage(): React.JSX.Element {
           className="rounded-lg border border-error-border px-4 py-2 text-sm font-medium text-error-text transition-colors hover:bg-error-bg"
           onClick={() => setShowUninstall(true)}
         >
-          TheraScript vollst\u00E4ndig entfernen
+          TheraScript vollständig entfernen
         </button>
       </div>
 
       {showUninstall && (
         <ConfirmDialog
-          title="TheraScript vollst\u00E4ndig entfernen"
-          message="Alle Daten werden unwiderruflich gel\u00F6scht:"
+          title="TheraScript vollständig entfernen"
+          message="Alle Daten werden unwiderruflich gelöscht:"
           details={[
             'ML-Modelle (~4 GB)',
             'Alle Transkriptionen und Audiodateien',

--- a/src/renderer/src/components/BlocklistManager.tsx
+++ b/src/renderer/src/components/BlocklistManager.tsx
@@ -204,7 +204,7 @@ const BlocklistManager = forwardRef<BlocklistManagerHandle>(function BlocklistMa
       {deleteTarget && (
         <ConfirmDialog
           title="Eintrag löschen"
-          message={`\u201e${deleteTarget.term}\u201c aus der Sperrliste entfernen?`}
+          message={`„${deleteTarget.term}“ aus der Sperrliste entfernen?`}
           confirmLabel="Löschen"
           destructive
           onConfirm={handleDelete}

--- a/src/renderer/src/components/FirstLaunchScreen.tsx
+++ b/src/renderer/src/components/FirstLaunchScreen.tsx
@@ -171,10 +171,10 @@ export default function FirstLaunchScreen({
                     </div>
                   )}
                   {isCurrent && isExtracting && (
-                    <p className="text-xs text-text-tertiary">Wird entpackt\u2026</p>
+                    <p className="text-xs text-text-tertiary">Wird entpackt…</p>
                   )}
                   {isCurrent && isVerifying && (
-                    <p className="text-xs text-text-tertiary">Wird \u00FCberpr\u00FCft\u2026</p>
+                    <p className="text-xs text-text-tertiary">Wird überprüft…</p>
                   )}
                 </div>
               )
@@ -220,7 +220,7 @@ export default function FirstLaunchScreen({
         {/* Resume hint */}
         {started && !isError && (
           <p className="mt-4 text-center text-xs text-text-tertiary">
-            Hinweis: Bei Abbruch wird der Download beim n\u00E4chsten Start automatisch fortgesetzt.
+            Hinweis: Bei Abbruch wird der Download beim nächsten Start automatisch fortgesetzt.
           </p>
         )}
       </div>

--- a/src/renderer/src/components/ModelUpdateScreen.tsx
+++ b/src/renderer/src/components/ModelUpdateScreen.tsx
@@ -151,10 +151,10 @@ export default function ModelUpdateScreen({
                     </div>
                   )}
                   {isCurrent && isExtracting && (
-                    <p className="text-xs text-text-tertiary">Wird entpackt\u2026</p>
+                    <p className="text-xs text-text-tertiary">Wird entpackt…</p>
                   )}
                   {isCurrent && isVerifying && (
-                    <p className="text-xs text-text-tertiary">Wird \u00FCberpr\u00FCft\u2026</p>
+                    <p className="text-xs text-text-tertiary">Wird überprüft…</p>
                   )}
                 </div>
               )
@@ -189,7 +189,7 @@ export default function ModelUpdateScreen({
             </p>
             <p className="mb-3 text-sm text-error-text">{status.error}</p>
             <p className="mb-3 text-xs text-text-tertiary">
-              Bestehende Modelle sind unver\u00E4ndert. Das Update wird beim n\u00E4chsten Start
+              Bestehende Modelle sind unverändert. Das Update wird beim nächsten Start
               erneut versucht.
             </p>
             <button
@@ -203,7 +203,7 @@ export default function ModelUpdateScreen({
 
         {started && !isError && (
           <p className="mt-4 text-center text-xs text-text-tertiary">
-            Hinweis: Bei Abbruch wird das Update beim n\u00E4chsten Start automatisch fortgesetzt.
+            Hinweis: Bei Abbruch wird das Update beim nächsten Start automatisch fortgesetzt.
           </p>
         )}
       </div>


### PR DESCRIPTION
Promotes the source-readability cleanup from PR #74 to main.

\uXXXX escapes replaced with literal characters in four renderer components. No runtime change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)