### PR TITLE
feat: Feedback senden via Mailclient (#69)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -29,6 +29,7 @@ import {
 } from './services/AutoDeletionService'
 import { checkFileVaultOnStartup } from './services/FileVaultService'
 import { registerAppUpdateHandlers } from './ipc/app-update-handlers'
+import { registerFeedbackHandlers, sendFeedback } from './ipc/feedback-handlers'
 import {
   cleanupIncompleteUpdates,
   migrateInstalledVersions,
@@ -226,6 +227,7 @@ app.whenReady().then(() => {
   registerModelUpdateHandlers()
   registerPipelineHandlers()
   registerAppUpdateHandlers()
+  registerFeedbackHandlers()
   registerSummaryHandlers({ sessionService })
 
   setupCSP()
@@ -239,6 +241,11 @@ app.whenReady().then(() => {
   const tray = initTray()
   tray.onStop(() => stopRecordingFromTray())
   tray.onOpenSettings(() => sendToRenderer('nav:openSettings'))
+  tray.onSendFeedback(() => {
+    sendFeedback().catch((error) => {
+      console.error('[feedback] sendFeedback aus Tray fehlgeschlagen:', error)
+    })
+  })
 
   // Application Menu owns ⌘, (Einstellungen) and ⌘Q (Beenden) so the
   // shortcuts only fire while Therascript is the focused app.

--- a/src/main/ipc/feedback-handlers.ts
+++ b/src/main/ipc/feedback-handlers.ts
@@ -4,10 +4,7 @@ import { buildClipboardPayload, buildFeedbackContent } from '../services/Feedbac
 export async function sendFeedback(): Promise<void> {
   const content = buildFeedbackContent()
 
-  // Always write the clipboard, regardless of whether the mail client opens.
-  // AC #14: "Bei jedem Auslösen wird zusätzlich der vollständige Inhalt … in
-  // die Zwischenablage geschrieben — unabhängig davon, ob der Mailclient
-  // erfolgreich öffnet."
+  // Clipboard write is the primary contract — mail-client open is best-effort.
   clipboard.writeText(buildClipboardPayload(content))
 
   try {

--- a/src/main/ipc/feedback-handlers.ts
+++ b/src/main/ipc/feedback-handlers.ts
@@ -1,0 +1,24 @@
+import { clipboard, ipcMain, shell } from 'electron'
+import { buildClipboardPayload, buildFeedbackContent } from '../services/FeedbackService'
+
+export async function sendFeedback(): Promise<void> {
+  const content = buildFeedbackContent()
+
+  // Always write the clipboard, regardless of whether the mail client opens.
+  // AC #14: "Bei jedem Auslösen wird zusätzlich der vollständige Inhalt … in
+  // die Zwischenablage geschrieben — unabhängig davon, ob der Mailclient
+  // erfolgreich öffnet."
+  clipboard.writeText(buildClipboardPayload(content))
+
+  try {
+    await shell.openExternal(content.mailto)
+  } catch (error) {
+    console.warn('[feedback] Mailclient konnte nicht geöffnet werden:', error)
+  }
+}
+
+export function registerFeedbackHandlers(): void {
+  ipcMain.handle('feedback:send', async () => {
+    await sendFeedback()
+  })
+}

--- a/src/main/services/FeedbackService.ts
+++ b/src/main/services/FeedbackService.ts
@@ -1,0 +1,140 @@
+import { app } from 'electron'
+import { execSync } from 'child_process'
+import { release } from 'os'
+import { getSettings } from './SettingsService'
+import {
+  getModelById,
+  isModelInstalled
+} from './ModelDownloadService'
+import type { ModelGroup } from '../../shared/validation/model-catalog-schemas'
+
+export const FEEDBACK_RECIPIENT = 'therascript.flatworm325@passmail.com'
+
+export interface FeedbackContent {
+  recipient: string
+  subject: string
+  body: string
+  mailto: string
+}
+
+interface ModelLine {
+  label: string
+  group: ModelGroup
+  /** Empty active id is treated as "(deaktiviert)" instead of "(nicht installiert)". */
+  optional?: boolean
+}
+
+const MODEL_LINES: ModelLine[] = [
+  { label: 'Transkription', group: 'asr' },
+  { label: 'Diarisierung', group: 'diarization' },
+  { label: 'NER', group: 'ner' },
+  { label: 'Summarization', group: 'summarization', optional: true }
+]
+
+function getChipName(): string {
+  try {
+    return execSync('sysctl -n machdep.cpu.brand_string', {
+      encoding: 'utf-8',
+      timeout: 3000
+    }).trim()
+  } catch {
+    return 'Unbekannt'
+  }
+}
+
+function getMacOSVersion(): string {
+  try {
+    return execSync('sw_vers -productVersion', {
+      encoding: 'utf-8',
+      timeout: 3000
+    }).trim()
+  } catch {
+    return `Darwin ${release()}`
+  }
+}
+
+function getActiveIdForGroup(group: ModelGroup): string {
+  const active = getSettings().get('activeModels')
+  if (group === 'asr') return active.transcription
+  if (group === 'diarization') return active.diarization
+  if (group === 'ner') return active.ner
+  if (group === 'summarization') return active.summarization
+  return ''
+}
+
+function formatModelLine(line: ModelLine): string {
+  const activeId = getActiveIdForGroup(line.group)
+  if (!activeId) {
+    return `${line.label}: ${line.optional ? '(deaktiviert)' : '(nicht installiert)'}`
+  }
+  if (!isModelInstalled(activeId)) {
+    return `${line.label}: ${activeId} (nicht installiert)`
+  }
+  const def = getModelById(activeId)
+  const shortName = def?.label ?? activeId
+  return `${line.label}: ${shortName} (${activeId})`
+}
+
+export function buildFeedbackContent(): FeedbackContent {
+  const version = app.getVersion()
+  const osVersion = getMacOSVersion()
+  const chip = getChipName()
+
+  const subject = `Therascript Feedback – v${version}`
+
+  const modelLines = MODEL_LINES.map(formatModelLine).join('\n')
+
+  const body = [
+    'Beschreibung',
+    '(Was ist passiert?)',
+    '',
+    'Erwartetes Verhalten',
+    '(Was hätte passieren sollen?)',
+    '',
+    'Schritte zur Reproduktion',
+    '1. ',
+    '2. ',
+    '3. ',
+    '',
+    '— Bitte oberhalb dieser Zeile schreiben. Die folgenden Angaben helfen bei der Triage. —',
+    '',
+    'Systeminformationen',
+    `App-Version: ${version}`,
+    `macOS: ${osVersion}`,
+    `Chip: ${chip}`,
+    '',
+    'Aktive Modelle',
+    modelLines,
+    '',
+    'Hinweis zum Datenschutz',
+    'Bitte keine Patientendaten, Transkriptinhalte oder Audio-Auszüge beifügen.',
+    '',
+    'Hinweis zur Bearbeitung',
+    'Triage erfolgt im Rahmen der Möglichkeiten — es besteht keine garantierte Antwortfrist.'
+  ].join('\n')
+
+  const mailto = `mailto:${encodeURIComponent(FEEDBACK_RECIPIENT)}?subject=${encodeURIComponent(
+    subject
+  )}&body=${encodeURIComponent(body)}`
+
+  return {
+    recipient: FEEDBACK_RECIPIENT,
+    subject,
+    body,
+    mailto
+  }
+}
+
+/**
+ * Vollständiger Mail-Inhalt für die Zwischenablage — inklusive Empfänger und
+ * Betreff, da der User ohne funktionierenden Mailclient sonst beides nicht
+ * hat.
+ */
+export function buildClipboardPayload(content: FeedbackContent): string {
+  return [
+    `An: ${content.recipient}`,
+    `Betreff: ${content.subject}`,
+    '',
+    content.body
+  ].join('\n')
+}

--- a/src/main/services/FeedbackService.ts
+++ b/src/main/services/FeedbackService.ts
@@ -113,7 +113,8 @@ export function buildFeedbackContent(): FeedbackContent {
     'Triage erfolgt im Rahmen der Möglichkeiten — es besteht keine garantierte Antwortfrist.'
   ].join('\n')
 
-  const mailto = `mailto:${encodeURIComponent(FEEDBACK_RECIPIENT)}?subject=${encodeURIComponent(
+  // Per RFC 6068 the addr-spec is not percent-encoded — only the query values are.
+  const mailto = `mailto:${FEEDBACK_RECIPIENT}?subject=${encodeURIComponent(
     subject
   )}&body=${encodeURIComponent(body)}`
 

--- a/src/main/services/TrayService.ts
+++ b/src/main/services/TrayService.ts
@@ -145,7 +145,7 @@ export class TrayService {
     menuItems.push({ type: 'separator' })
 
     // Always visible — also during recording, review, first-launch download
-    // and pending model updates. Issue #69 AC #3.
+    // and pending model updates.
     menuItems.push({
       label: 'Feedback senden…',
       click: () => this.onSendFeedbackCallback?.()

--- a/src/main/services/TrayService.ts
+++ b/src/main/services/TrayService.ts
@@ -30,6 +30,7 @@ export class TrayService {
   private isRecording = false
   private onStopCallback: (() => void) | null = null
   private onOpenSettingsCallback: (() => void) | null = null
+  private onSendFeedbackCallback: (() => void) | null = null
 
   init(): void {
     this.idleIcon = loadTemplateIcon('TrayIconTemplate')
@@ -45,6 +46,10 @@ export class TrayService {
 
   onOpenSettings(callback: () => void): void {
     this.onOpenSettingsCallback = callback
+  }
+
+  onSendFeedback(callback: () => void): void {
+    this.onSendFeedbackCallback = callback
   }
 
   setRecordingState(recording: boolean, duration?: number): void {
@@ -92,6 +97,7 @@ export class TrayService {
     }
     this.onStopCallback = null
     this.onOpenSettingsCallback = null
+    this.onSendFeedbackCallback = null
     // Reset singleton so initTray() can re-create if needed
     trayService = null
   }
@@ -134,6 +140,15 @@ export class TrayService {
     menuItems.push({
       label: 'Fenster anzeigen',
       click: () => this.showWindow()
+    })
+
+    menuItems.push({ type: 'separator' })
+
+    // Always visible — also during recording, review, first-launch download
+    // and pending model updates. Issue #69 AC #3.
+    menuItems.push({
+      label: 'Feedback senden…',
+      click: () => this.onSendFeedbackCallback?.()
     })
 
     menuItems.push({ type: 'separator' })

--- a/src/main/services/__tests__/FeedbackService.test.ts
+++ b/src/main/services/__tests__/FeedbackService.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const getMock = vi.fn()
+const isModelInstalledMock = vi.fn()
+const getModelByIdMock = vi.fn()
+
+vi.mock('electron', () => ({
+  app: { getVersion: () => '0.8.0' }
+}))
+
+
+vi.mock('../SettingsService', () => ({
+  getSettings: () => ({ get: getMock })
+}))
+
+vi.mock('../ModelDownloadService', () => ({
+  isModelInstalled: (id: string) => isModelInstalledMock(id),
+  getModelById: (id: string) => getModelByIdMock(id)
+}))
+
+import {
+  buildFeedbackContent,
+  buildClipboardPayload,
+  FEEDBACK_RECIPIENT
+} from '../FeedbackService'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  isModelInstalledMock.mockReturnValue(true)
+  getModelByIdMock.mockImplementation((id: string) => ({ label: `Label of ${id}` }))
+})
+
+describe('buildFeedbackContent', () => {
+  it('produces a German subject containing the version', () => {
+    getMock.mockReturnValue({
+      transcription: 'whisper-large-v3-turbo',
+      diarization: 'pyannote-suite',
+      diarizationPipeline: 'pyannote/speaker-diarization-3.1',
+      ner: 'flair-ner-german-large',
+      ocr: 'apple-vision',
+      summarization: 'gemma-summarization'
+    })
+
+    const c = buildFeedbackContent()
+
+    expect(c.recipient).toBe(FEEDBACK_RECIPIENT)
+    expect(c.subject).toBe('Therascript Feedback – v0.8.0')
+  })
+
+  it('includes all required sections in the body', () => {
+    getMock.mockReturnValue({
+      transcription: 'whisper-large-v3-turbo',
+      diarization: 'pyannote-suite',
+      diarizationPipeline: 'pyannote/speaker-diarization-3.1',
+      ner: 'flair-ner-german-large',
+      ocr: 'apple-vision',
+      summarization: 'gemma-summarization'
+    })
+
+    const { body } = buildFeedbackContent()
+
+    expect(body).toContain('Beschreibung')
+    expect(body).toContain('Erwartetes Verhalten')
+    expect(body).toContain('Schritte zur Reproduktion')
+    expect(body).toContain('App-Version: 0.8.0')
+    expect(body).toMatch(/macOS: \S+/)
+    expect(body).toMatch(/Chip: \S+/)
+    expect(body).toContain('Transkription:')
+    expect(body).toContain('Diarisierung:')
+    expect(body).toContain('NER:')
+    expect(body).toContain('Summarization:')
+    expect(body).toContain('keine Patientendaten')
+    expect(body).toContain('keine garantierte Antwortfrist')
+  })
+
+  it('renders empty summarization slot as "(deaktiviert)"', () => {
+    getMock.mockReturnValue({
+      transcription: 'whisper-large-v3-turbo',
+      diarization: 'pyannote-suite',
+      diarizationPipeline: 'pyannote/speaker-diarization-3.1',
+      ner: 'flair-ner-german-large',
+      ocr: 'apple-vision',
+      summarization: ''
+    })
+
+    const { body } = buildFeedbackContent()
+
+    expect(body).toContain('Summarization: (deaktiviert)')
+  })
+
+  it('renders empty required slot as "(nicht installiert)"', () => {
+    getMock.mockReturnValue({
+      transcription: '',
+      diarization: '',
+      diarizationPipeline: 'pyannote/speaker-diarization-3.1',
+      ner: '',
+      ocr: 'apple-vision',
+      summarization: 'gemma-summarization'
+    })
+
+    const { body } = buildFeedbackContent()
+
+    expect(body).toContain('Transkription: (nicht installiert)')
+    expect(body).toContain('Diarisierung: (nicht installiert)')
+    expect(body).toContain('NER: (nicht installiert)')
+  })
+
+  it('marks an active but uninstalled model with "(nicht installiert)"', () => {
+    getMock.mockReturnValue({
+      transcription: 'whisper-large-v3-turbo',
+      diarization: 'pyannote-suite',
+      diarizationPipeline: 'pyannote/speaker-diarization-3.1',
+      ner: 'flair-ner-german-large',
+      ocr: 'apple-vision',
+      summarization: 'gemma-summarization'
+    })
+    isModelInstalledMock.mockImplementation((id: string) => id !== 'gemma-summarization')
+
+    const { body } = buildFeedbackContent()
+
+    expect(body).toContain('Summarization: gemma-summarization (nicht installiert)')
+  })
+
+  it('builds a valid mailto URL', () => {
+    getMock.mockReturnValue({
+      transcription: 'whisper-large-v3-turbo',
+      diarization: 'pyannote-suite',
+      diarizationPipeline: 'pyannote/speaker-diarization-3.1',
+      ner: 'flair-ner-german-large',
+      ocr: 'apple-vision',
+      summarization: 'gemma-summarization'
+    })
+
+    const { mailto } = buildFeedbackContent()
+
+    expect(mailto.startsWith(`mailto:${encodeURIComponent(FEEDBACK_RECIPIENT)}?`)).toBe(true)
+    expect(mailto).toContain('subject=')
+    expect(mailto).toContain('body=')
+  })
+})
+
+describe('buildClipboardPayload', () => {
+  it('prefixes recipient and subject for the clipboard fallback', () => {
+    getMock.mockReturnValue({
+      transcription: 'whisper-large-v3-turbo',
+      diarization: 'pyannote-suite',
+      diarizationPipeline: 'pyannote/speaker-diarization-3.1',
+      ner: 'flair-ner-german-large',
+      ocr: 'apple-vision',
+      summarization: 'gemma-summarization'
+    })
+
+    const c = buildFeedbackContent()
+    const payload = buildClipboardPayload(c)
+
+    expect(payload.startsWith(`An: ${FEEDBACK_RECIPIENT}`)).toBe(true)
+    expect(payload).toContain(`Betreff: ${c.subject}`)
+    expect(payload).toContain('Beschreibung')
+  })
+})

--- a/src/main/services/__tests__/FeedbackService.test.ts
+++ b/src/main/services/__tests__/FeedbackService.test.ts
@@ -133,7 +133,8 @@ describe('buildFeedbackContent', () => {
 
     const { mailto } = buildFeedbackContent()
 
-    expect(mailto.startsWith(`mailto:${encodeURIComponent(FEEDBACK_RECIPIENT)}?`)).toBe(true)
+    expect(mailto.startsWith(`mailto:${FEEDBACK_RECIPIENT}?`)).toBe(true)
+    expect(mailto).not.toContain('%40')
     expect(mailto).toContain('subject=')
     expect(mailto).toContain('body=')
   })

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -234,6 +234,9 @@ const api: IpcApi = {
         ipcRenderer.removeListener('nav:openSettings', handler)
       }
     }
+  },
+  feedback: {
+    send: () => ipcRenderer.invoke('feedback:send')
   }
 }
 

--- a/src/renderer/src/__tests__/App.test.tsx
+++ b/src/renderer/src/__tests__/App.test.tsx
@@ -1,6 +1,14 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import App from '../App'
+import { ToastProvider } from '../contexts/ToastContext'
+
+const renderApp = (): ReturnType<typeof render> =>
+  render(
+    <ToastProvider>
+      <App />
+    </ToastProvider>
+  )
 
 const mockModelUpdate = {
   check: vi.fn().mockResolvedValue([]),
@@ -100,13 +108,16 @@ beforeEach(() => {
     },
     nav: {
       onOpenSettings: vi.fn().mockReturnValue(() => {})
+    },
+    feedback: {
+      send: vi.fn().mockResolvedValue(undefined)
     }
   } as typeof window.api
 })
 
 describe('App', () => {
   it('renders bottom navigation', async () => {
-    render(<App />)
+    renderApp()
     await waitFor(() => {
       expect(screen.getByRole('tab', { name: 'Transkriptionen' })).toBeInTheDocument()
       expect(screen.getByRole('tab', { name: 'Einstellungen' })).toBeInTheDocument()
@@ -114,7 +125,7 @@ describe('App', () => {
   })
 
   it('shows empty state message when no sessions', async () => {
-    render(<App />)
+    renderApp()
 
     await waitFor(() => {
       expect(screen.getByText('Keine Transkriptionen')).toBeInTheDocument()

--- a/src/renderer/src/components/__tests__/SessionDashboard.test.tsx
+++ b/src/renderer/src/components/__tests__/SessionDashboard.test.tsx
@@ -180,6 +180,9 @@ beforeEach(() => {
     },
     nav: {
       onOpenSettings: vi.fn().mockReturnValue(() => {})
+    },
+    feedback: {
+      send: vi.fn().mockResolvedValue(undefined)
     }
   } as typeof window.api
   vi.clearAllMocks()

--- a/src/renderer/src/components/shell/BottomNav.tsx
+++ b/src/renderer/src/components/shell/BottomNav.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useLayoutEffect, useRef, useState } from 'react'
-import { Files, Settings } from 'lucide-react'
+import { Files, MessageSquare, Settings } from 'lucide-react'
 import { useAppUpdate } from '../../hooks/useAppUpdate'
+import { useToast } from '../../hooks/useToast'
 
 type View = 'sessions' | 'settings'
 
@@ -23,6 +24,19 @@ export default function BottomNav({ current, onChange }: BottomNavProps): React.
   const [pill, setPill] = useState<{ x: number; w: number } | null>(null)
   const [appVersion, setAppVersion] = useState<string | null>(null)
   const { status: appUpdateStatus, openReleasePage } = useAppUpdate()
+  const toast = useToast()
+
+  const handleSendFeedback = async (): Promise<void> => {
+    try {
+      await window.api.feedback.send()
+      toast.success(
+        'Feedback-Mail vorbereitet — Inhalt wurde zusätzlich in die Zwischenablage kopiert.'
+      )
+    } catch (error) {
+      console.error('[feedback] send failed:', error)
+      toast.error('Feedback konnte nicht vorbereitet werden.')
+    }
+  }
 
   useLayoutEffect(() => {
     const node = itemRefs.current[current]
@@ -90,6 +104,17 @@ export default function BottomNav({ current, onChange }: BottomNavProps): React.
             </button>
           )
         })}
+
+        <button
+          type="button"
+          onClick={handleSendFeedback}
+          className="bottom-nav-item titlebar-no-drag relative z-10 flex items-center gap-2 rounded-full px-3 py-1.5 text-sm font-medium text-text-tertiary transition-colors duration-200 hover:text-text-secondary"
+        >
+          <span className="bottom-nav-icon inline-flex">
+            <MessageSquare className="h-4 w-4" strokeWidth={1.75} aria-hidden="true" />
+          </span>
+          <span>Feedback senden</span>
+        </button>
       </nav>
 
       {updateAvailable ? (

--- a/src/shared/types/IpcApi.ts
+++ b/src/shared/types/IpcApi.ts
@@ -194,6 +194,10 @@ export interface NavApi {
   onOpenSettings(callback: () => void): () => void
 }
 
+export interface FeedbackApi {
+  send(): Promise<void>
+}
+
 export interface ModelCatalogApi {
   list(group: ModelGroup): Promise<ModelCatalogEntry[]>
   listAsr(): Promise<ModelCatalogEntry[]>
@@ -226,4 +230,5 @@ export interface IpcApi {
   appUpdate: AppUpdateApi
   summary: SummaryApi
   nav: NavApi
+  feedback: FeedbackApi
 }


### PR DESCRIPTION
## Summary
- Implements [#69](https://github.com/adbstyle/therascripter/issues/69) — "Feedback senden via Mailclient mit vorausgefüllten Metadaten".
- Adds tray entry "Feedback senden…" (always visible — recording/review/first-launch/model-update) and a BottomNav chip (hidden during recording/review) that open the registered mail client with a German template prefilled with version, macOS, chip and active model identifiers.
- Always mirrors the full mail content (incl. recipient + subject) to the clipboard, regardless of whether the mail client opens. German toast confirms the clipboard write.

## Behaviour notes
- Empty `activeModels.summarization` → `Summarization: (deaktiviert)` (AC #9).
- Active model whose binary is missing → `(nicht installiert)` (AC #10) — also covers FirstLaunchScreen state.
- IPC channel `feedback:send` is the entry point; renderer + tray both call it. No renderer-side `mailto:` since `setWindowOpenHandler` only whitelists `https:`/`http:`.
- No data leaves the app (CSP `connect-src 'none'` unchanged).

## Test plan
- [x] `npm run typecheck`
- [x] 7 new unit tests in `FeedbackService.test.ts` (subject, body sections, `(deaktiviert)`, `(nicht installiert)`, mailto encoding, clipboard payload)
- [x] Full vitest run — same 13 pre-existing failed files as `develop` baseline, +7 new passing tests, no regressions
- [ ] Manual: `npm run dev` → trigger from BottomNav, confirm Mail.app opens with prefilled mail and toast appears
- [ ] Manual: trigger from tray during recording, on FirstLaunchScreen, and during ModelUpdateScreen
- [ ] Manual: empty `activeModels.summarization` → `(deaktiviert)` shows in body
- [ ] Manual: ä/ö/ü render correctly in Mail.app, Outlook, Gmail-Web

🤖 Generated with [Claude Code](https://claude.com/claude-code)