### PR TITLE
feat(models): trustworthy model-status UI (epic #84)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ scripts/sim-clean-install.sh       # Simulate fresh / upgrade / models-only inst
 3. Python sidecar — flair NER + Regex + Blocklist → TipTap document (shared with audio) ✓ implemented
 4. llama.cpp subprocess — optional summarization (shared with audio). ✓ implemented
 
-**ML models:** Stored in `~/.therascript/models/<type>/` (e.g. `models/asr/`, `models/diarization/`, `models/ner/`). Directories created at startup by `initDatabase()`.
+**ML models:** Stored in `~/.therascript/models/<type>/` (e.g. `models/asr/`, `models/diarization/`, `models/ner/`). Required-group dirs are bootstrapped at startup by `initDatabase()`; optional-group dirs (e.g. `models/summarization/`) are created on-demand by `downloadSingleModel` — only existing once the user actually downloads an optional model.
 
 **First launch:** FirstLaunchScreen checks for models, validates disk space (5 GB minimum), downloads ~4.1 GB (Whisper 1.7 GB + Pyannote 0.2 GB + flair NER 2.2 GB) with progress tracking. Models persist across app updates.
 

--- a/src/main/db/migrations/014-processed-with-models.sql
+++ b/src/main/db/migrations/014-processed-with-models.sql
@@ -1,0 +1,13 @@
+-- Migration 014: processed_with_models column (Issue #84 Story I)
+-- Purpose: persist a snapshot of the active models per pipeline group at the
+-- moment processing started, so the Review-Editor can show the user which
+-- model identity (id + version + sha256 + label + size) produced each
+-- session.
+--
+-- NULL = legacy row (session reached 'review' before this commit). The UI
+-- surfaces these as "Diese Sitzung wurde vor Einführung der detaillierten
+-- Modell-Protokollierung verarbeitet." — no retroactive backfill, by spec.
+-- Column carries a JSON-encoded ProcessedModelsSnapshot (see
+-- src/shared/types/Provenance.ts) when populated.
+
+ALTER TABLE sessions ADD COLUMN processed_with_models TEXT;

--- a/src/main/db/migrations/index.ts
+++ b/src/main/db/migrations/index.ts
@@ -11,6 +11,7 @@ import dropPipelineVersion from './010-drop-pipeline-version.sql?raw'
 import pipelineInversion from './011-pipeline-inversion.sql?raw'
 import statusReductionPlannedStepsRetry from './012-status-reduction-planned-steps-retry.sql?raw'
 import pdfHasScannedPages from './013-pdf-has-scanned-pages.sql?raw'
+import processedWithModels from './014-processed-with-models.sql?raw'
 
 export interface Migration {
   version: number
@@ -30,5 +31,6 @@ export const migrations: Migration[] = [
   { version: 10, sql: dropPipelineVersion },
   { version: 11, sql: pipelineInversion },
   { version: 12, sql: statusReductionPlannedStepsRetry },
-  { version: 13, sql: pdfHasScannedPages }
+  { version: 13, sql: pdfHasScannedPages },
+  { version: 14, sql: processedWithModels }
 ]

--- a/src/main/db/repositories/SessionRepository.ts
+++ b/src/main/db/repositories/SessionRepository.ts
@@ -7,7 +7,8 @@ import type {
   CreateSessionInput,
   UpdateSessionInput,
   EntityMap,
-  TaskType
+  TaskType,
+  ProcessedModelsSnapshot
 } from '../../../shared/types'
 
 interface SessionRow {
@@ -34,6 +35,7 @@ interface SessionRow {
   planned_steps: string | null
   retry_count: number
   pdf_has_scanned_pages: number | null
+  processed_with_models: string | null
 }
 
 function parseEntityMap(json: string | null, sessionId: string): EntityMap | null {
@@ -42,6 +44,23 @@ function parseEntityMap(json: string | null, sessionId: string): EntityMap | nul
     return JSON.parse(json) as EntityMap
   } catch {
     console.error(`Corrupted entity_map in session ${sessionId}, treating as null`)
+    return null
+  }
+}
+
+function parseProcessedModels(
+  json: string | null,
+  sessionId: string
+): ProcessedModelsSnapshot | null {
+  if (!json) return null
+  try {
+    return JSON.parse(json) as ProcessedModelsSnapshot
+  } catch {
+    // A corrupted blob shouldn't hide the session — degrade to "legacy
+    // unknown" so the UI shows the neutral hint instead of crashing.
+    console.error(
+      `Corrupted processed_with_models in session ${sessionId}, treating as null`
+    )
     return null
   }
 }
@@ -71,7 +90,8 @@ function rowToSession(row: SessionRow): Session {
     plannedSteps: row.planned_steps ? (JSON.parse(row.planned_steps) as TaskType[]) : null,
     retryCount: row.retry_count,
     pdfHasScannedPages:
-      row.pdf_has_scanned_pages == null ? null : row.pdf_has_scanned_pages === 1
+      row.pdf_has_scanned_pages == null ? null : row.pdf_has_scanned_pages === 1,
+    processedWithModels: parseProcessedModels(row.processed_with_models, row.id)
   }
 }
 
@@ -198,6 +218,12 @@ export class SessionRepository {
       sets.push('pdf_has_scanned_pages = ?')
       values.push(
         input.pdfHasScannedPages == null ? null : input.pdfHasScannedPages ? 1 : 0
+      )
+    }
+    if (input.processedWithModels !== undefined) {
+      sets.push('processed_with_models = ?')
+      values.push(
+        input.processedWithModels === null ? null : JSON.stringify(input.processedWithModels)
       )
     }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -18,6 +18,7 @@ import { registerSystemHandlers } from './ipc/system-handlers'
 import { registerModelDownloadHandlers } from './ipc/model-download-handlers'
 import { registerModelCatalogHandlers } from './ipc/model-catalog-handlers'
 import { registerModelUpdateHandlers } from './ipc/model-update-handlers'
+import { registerModelReconcileHandlers } from './ipc/model-reconcile-handlers'
 import { registerPipelineHandlers } from './ipc/pipeline-handlers'
 import { initTray, getTray } from './services/TrayService'
 import { initAppMenu } from './services/AppMenuService'
@@ -48,8 +49,8 @@ import { SessionService } from './services/SessionService'
 import {
   getActiveModelPath,
   getActiveModelId,
-  isModelInstalled,
-  getModelsDir
+  getModelsDir,
+  reconcileActiveModels
 } from './services/ModelDownloadService'
 import { registerSummaryHandlers } from './ipc/summary-handlers'
 
@@ -173,6 +174,13 @@ app.whenReady().then(() => {
   // Clean up any incomplete model updates from a previous crashed update
   cleanupIncompleteUpdates()
 
+  // Issue #84 / Story C — verify the invariant that every active-model slot
+  // either points at an installed catalog model or is null. Heals stale slots
+  // (e.g. a model the user deleted in Finder) before any executor or the
+  // FirstLaunchScreen reads them. Skipped on a truly-fresh install — see
+  // reconcileActiveModels().
+  reconcileActiveModels()
+
   // Initialize task queue + crash recovery (before IPC handlers that may enqueue tasks)
   const taskQueue = initTaskQueue(getDatabase())
   const recovered = taskQueue.recoverStuckTasks()
@@ -193,7 +201,18 @@ app.whenReady().then(() => {
   taskQueue.registerExecutor('ocr', new VisionOCRService())
 
   const llamaSummarizer = new LlamaSummarizer({
-    getModelPath: () => getActiveModelPath('summarization'),
+    getModelPath: () => {
+      const path = getActiveModelPath('summarization')
+      if (path === null) {
+        // The SummarizationExecutor checks isModelInstalled() before reaching
+        // summarize(), so this throw is a defensive belt: it would only fire
+        // on a race where the model is deleted between the gate and the
+        // subprocess launch. Caught by SummarizationExecutor's try/catch and
+        // logged; session reaches review with summary=NULL.
+        throw new Error('Summarization-Modell ist nicht aktiv')
+      }
+      return path
+    },
     getBinaryPath: () =>
       app.isPackaged
         ? join(process.resourcesPath, 'bin', 'llama-cli')
@@ -206,7 +225,9 @@ app.whenReady().then(() => {
     new SummarizationExecutor({
       llamaSummarizer,
       sessionService,
-      isModelInstalled: () => isModelInstalled(getActiveModelId('summarization')),
+      // Both checks delegate to getActiveModelId, which returns null whenever
+      // the slot is empty / unknown / file-missing — see ModelDownloadService.
+      isModelInstalled: () => getActiveModelId('summarization') !== null,
       getActiveModelId: () => getActiveModelId('summarization'),
       logger: { info: (msg): void => console.log(msg), error: (msg): void => console.error(msg) }
     })
@@ -225,6 +246,7 @@ app.whenReady().then(() => {
   registerModelDownloadHandlers()
   registerModelCatalogHandlers()
   registerModelUpdateHandlers()
+  registerModelReconcileHandlers()
   registerPipelineHandlers()
   registerAppUpdateHandlers()
   registerFeedbackHandlers()

--- a/src/main/ipc/model-catalog-handlers.ts
+++ b/src/main/ipc/model-catalog-handlers.ts
@@ -5,7 +5,7 @@ import {
   clearActiveModel,
   deleteModel,
   downloadSingleModel,
-  getActiveModelId,
+  getActiveModelIdBelief,
   getModelById,
   getModelsByGroup,
   isModelInstalled,
@@ -21,7 +21,12 @@ import {
 } from '../../shared/validation/model-catalog-schemas'
 
 function buildCatalogEntries(group: ModelGroup): ModelCatalogEntry[] {
-  const activeId = getActiveModelId(group)
+  // Issue #84 Story E follow-up — read the raw settings belief, not the
+  // disk-filtered active id. The two flags must be reported independently
+  // so the renderer's <ModelStatusBadge> can surface the `inconsistent`
+  // state (active=true ∧ installed=false) when settings drift from disk.
+  // Executors keep using `getActiveModelId` (the filtered variant).
+  const activeBeliefId = getActiveModelIdBelief(group)
   return getModelsByGroup(group).map((def) => ({
     id: def.id,
     label: def.label,
@@ -34,7 +39,7 @@ function buildCatalogEntries(group: ModelGroup): ModelCatalogEntry[] {
     speedScore: def.speedScore,
     hfRepo: def.hfRepo,
     isInstalled: isModelInstalled(def.id),
-    isActive: def.id === activeId
+    isActive: def.id === activeBeliefId
   }))
 }
 

--- a/src/main/ipc/model-reconcile-handlers.ts
+++ b/src/main/ipc/model-reconcile-handlers.ts
@@ -1,0 +1,27 @@
+import { ipcMain } from 'electron'
+import {
+  dismissReconcileEvents,
+  getReconcileEvents,
+  markReconcileEventsSeen
+} from '../services/ModelDownloadService'
+
+/**
+ * Renderer-facing IPC for the reconciler's pending events. The reconciler
+ * itself runs at bootstrap (see `reconcileActiveModels` in
+ * ModelDownloadService); these handlers expose its persisted output to the
+ * BottomNav dot and the Settings → Modelle banner.
+ *
+ * Lifecycle exposed to the renderer:
+ *   getReconcileEvents()     → read all events (pending + seen)
+ *   markReconcileEventsSeen()→ called when Settings → Modelle mounts; the
+ *                              dot disappears, banner stays.
+ *   dismissReconcileEvents() → called when the user clicks "Verstanden";
+ *                              all events are deleted from the store.
+ */
+export function registerModelReconcileHandlers(): void {
+  ipcMain.handle('modelReconcile:getEvents', () => getReconcileEvents())
+  ipcMain.handle('modelReconcile:markSeen', () => markReconcileEventsSeen())
+  ipcMain.handle('modelReconcile:dismiss', () => {
+    dismissReconcileEvents()
+  })
+}

--- a/src/main/ipc/model-update-handlers.ts
+++ b/src/main/ipc/model-update-handlers.ts
@@ -3,11 +3,15 @@ import { getSettings } from '../services/SettingsService'
 import {
   checkForUpdates,
   triggerUpdateRestart,
-  executeUpdates
+  executeUpdates,
+  dismissManifestVersions
 } from '../services/UpdateCheckService'
 import { getActiveSessionId } from './recording-handlers'
 import { getTaskQueue } from '../services/TaskQueueService'
-import { RestartUpdateSchema } from '../../shared/validation/model-update-schemas'
+import {
+  DismissUpdatesSchema,
+  RestartUpdateSchema
+} from '../../shared/validation/model-update-schemas'
 
 export function registerModelUpdateHandlers(): void {
   // Check for updates (returns list of available model updates)
@@ -49,5 +53,13 @@ export function registerModelUpdateHandlers(): void {
   // Clear pending updates (called when user skips the update)
   ipcMain.handle('modelUpdate:clearPending', () => {
     getSettings().set('pendingModelUpdates', null)
+  })
+
+  // Issue #84 / Story F+G — record manifest entries the user actively
+  // dismissed. Subsequent checkForUpdates calls filter these out until the
+  // manifest publishes a new sha256 for the same id.
+  ipcMain.handle('modelUpdate:dismissVersions', (_event, args: unknown) => {
+    const { updates } = DismissUpdatesSchema.parse(args)
+    dismissManifestVersions(updates.map((u) => ({ id: u.id, sha256: u.sha256 })))
   })
 }

--- a/src/main/ipc/pdf-handlers.ts
+++ b/src/main/ipc/pdf-handlers.ts
@@ -134,7 +134,7 @@ export function registerPDFHandlers(): void {
     const result = await dialog.showOpenDialog(window, {
       properties: ['openFile', 'multiSelections'],
       filters: [{ name: 'PDF-Dokumente', extensions: ['pdf'] }],
-      message: 'PDF-Dokumente zum Anonymisieren auswählen'
+      message: 'PDF-Dokumente zur Pseudonymisierung auswählen'
     })
 
     if (result.canceled) return []

--- a/src/main/ml/AnonymizationService.ts
+++ b/src/main/ml/AnonymizationService.ts
@@ -58,7 +58,7 @@ export class AnonymizationService implements TaskExecutor {
       // unreadable file) — surface as 'error' so the user knows to re-import,
       // matching the pre-inversion behaviour.
       if (session?.type !== 'audio') {
-        throw new Error('Transkript enthält keine Segmente für die Anonymisierung')
+        throw new Error('Transkript enthält keine Segmente für die Pseudonymisierung')
       }
       const emptyDoc = { type: 'doc', content: [{ type: 'paragraph' }] }
       const anonymizedPath = sessionService.generateAnonymizedPath(task.sessionId)

--- a/src/main/ml/SummarizationExecutor.ts
+++ b/src/main/ml/SummarizationExecutor.ts
@@ -10,7 +10,7 @@ export interface SummarizationExecutorDeps {
     saveGeneratedSummary(sessionId: string, title: string, text: string, modelId: string): unknown
   }
   isModelInstalled: () => boolean
-  getActiveModelId: () => string
+  getActiveModelId: () => string | null
   logger: { info(msg: string): void; error(msg: string): void }
 }
 
@@ -64,11 +64,22 @@ export class SummarizationExecutor implements TaskExecutor {
       return
     }
 
+    const modelId = this.deps.getActiveModelId()
+    if (modelId === null) {
+      // Unreachable — `isModelInstalled()` above already gates on the same
+      // accessor. Guard kept narrow so saveGeneratedSummary's modelId param
+      // stays `string`.
+      this.deps.logger.info(
+        `Summarization completed but active model became null mid-run for session ${task.sessionId}`
+      )
+      return
+    }
+
     this.deps.sessionService.saveGeneratedSummary(
       task.sessionId,
       result.title,
       result.text,
-      this.deps.getActiveModelId()
+      modelId
     )
   }
 }

--- a/src/main/ml/WhisperService.ts
+++ b/src/main/ml/WhisperService.ts
@@ -13,9 +13,9 @@ import type {
 } from '../../shared/types'
 import type { TaskExecutor, ExecutorRuntime } from '../services/task-executors'
 import { SessionService } from '../services/SessionService'
-import { getDatabase, getDataDir } from '../db/connection'
+import { getDatabase } from '../db/connection'
 import { getSettings } from '../services/SettingsService'
-import { getModelById } from '../services/ModelDownloadService'
+import { getActiveModelPath } from '../services/ModelDownloadService'
 import { writeFileAtomic } from '../utils/file-ops'
 import { removeFillerWords, rebuildSegments } from './filler-removal'
 import { filterSpecialTokens, mergeSubTokens } from './token-processing'
@@ -87,14 +87,13 @@ export class WhisperService implements TaskExecutor {
   }
 
   private getModelPath(): string {
-    const activeAsrId = getSettings().get('activeModels').transcription
-    const def = getModelById(activeAsrId)
-    if (!def) {
+    const path = getActiveModelPath('asr')
+    if (path === null) {
       throw new Error(
-        `WhisperService: aktives ASR-Modell "${activeAsrId}" nicht im Katalog registriert.`
+        'Kein aktives Transkriptions-Modell — bitte ein Modell unter Einstellungen → Modelle aktivieren.'
       )
     }
-    return join(getDataDir(), 'models', def.relativePath)
+    return path
   }
 
   async execute(
@@ -383,7 +382,10 @@ export class WhisperService implements TaskExecutor {
 
     const duration = cleanedWords.length > 0 ? cleanedWords[cleanedWords.length - 1].end : 0
 
-    const activeAsrId = getSettings().get('activeModels').transcription
+    // Belt-and-braces — getModelPath() above already throws if no model is
+    // active, so this fallback is unreachable in practice but keeps the type
+    // narrow.
+    const activeAsrId = getSettings().get('activeModels').transcription ?? 'unknown'
 
     return {
       words: cleanedWords,

--- a/src/main/ml/__tests__/SummarizationExecutor.test.ts
+++ b/src/main/ml/__tests__/SummarizationExecutor.test.ts
@@ -10,7 +10,7 @@ const makeDeps = (
       saveGeneratedSummary?: ReturnType<typeof vi.fn>
     }
     isModelInstalled?: () => boolean
-    getActiveModelId?: () => string
+    getActiveModelId?: () => string | null
   } = {}
 ): {
   llamaSummarizer: { summarize: ReturnType<typeof vi.fn> }
@@ -19,7 +19,7 @@ const makeDeps = (
     saveGeneratedSummary: ReturnType<typeof vi.fn>
   }
   isModelInstalled: () => boolean
-  getActiveModelId: () => string
+  getActiveModelId: () => string | null
   logger: { info: ReturnType<typeof vi.fn>; error: ReturnType<typeof vi.fn> }
 } => ({
   llamaSummarizer: {
@@ -33,7 +33,7 @@ const makeDeps = (
     saveGeneratedSummary: over.sessionService?.saveGeneratedSummary ?? vi.fn()
   },
   isModelInstalled: over.isModelInstalled ?? ((): boolean => true),
-  getActiveModelId: over.getActiveModelId ?? ((): string => 'gemma-summarization'),
+  getActiveModelId: over.getActiveModelId ?? ((): string | null => 'gemma-summarization'),
   logger: { info: vi.fn(), error: vi.fn() }
 })
 

--- a/src/main/services/Channel.ts
+++ b/src/main/services/Channel.ts
@@ -1,0 +1,46 @@
+/**
+ * Issue #84 / Story D — Pre-Release-Verifikations-Channel.
+ *
+ * The active channel is fixed at app start by the env var
+ * `THERASCRIPT_CHANNEL` (set at build/dev time, not user-switchable).
+ * It tags every entry written into `installedModelVersions` so that
+ * switching the build between `prod` and a non-prod channel cannot
+ * leak stale install records into the other channel — which would
+ * otherwise produce false-positive "Update verfügbar" banners (NFR-3).
+ *
+ * The `prod` default keeps shipped builds and the existing electron-
+ * store data fully backward-compatible: untagged legacy keys are
+ * migrated to the `prod:` prefix on first launch (see SettingsService).
+ */
+
+export const CHANNELS = ['prod', 'staging', 'local'] as const
+export type Channel = (typeof CHANNELS)[number]
+
+const DEFAULT_CHANNEL: Channel = 'prod'
+
+function isChannel(value: string | undefined): value is Channel {
+  return (CHANNELS as readonly string[]).includes(value ?? '')
+}
+
+let cached: Channel | null = null
+
+/** Returns the active channel, validated against {prod, staging, local}. */
+export function getChannel(): Channel {
+  if (cached) return cached
+  const raw = process.env.THERASCRIPT_CHANNEL
+  if (raw && !isChannel(raw)) {
+    console.warn(
+      `[channel] THERASCRIPT_CHANNEL="${raw}" is not one of ${CHANNELS.join('|')} — falling back to "${DEFAULT_CHANNEL}".`
+    )
+  }
+  cached = isChannel(raw) ? raw : DEFAULT_CHANNEL
+  if (cached !== 'prod') {
+    console.log(`[channel] Active channel: ${cached}`)
+  }
+  return cached
+}
+
+/** Test-only — clears the cache so a different env value can be picked up. */
+export function _resetChannelCacheForTests(): void {
+  cached = null
+}

--- a/src/main/services/FeedbackService.ts
+++ b/src/main/services/FeedbackService.ts
@@ -53,13 +53,13 @@ function getMacOSVersion(): string {
   }
 }
 
-function getActiveIdForGroup(group: ModelGroup): string {
+function getActiveIdForGroup(group: ModelGroup): string | null {
   const active = getSettings().get('activeModels')
   if (group === 'asr') return active.transcription
   if (group === 'diarization') return active.diarization
   if (group === 'ner') return active.ner
   if (group === 'summarization') return active.summarization
-  return ''
+  return null
 }
 
 function formatModelLine(line: ModelLine): string {

--- a/src/main/services/InstalledVersionsStore.ts
+++ b/src/main/services/InstalledVersionsStore.ts
@@ -1,0 +1,85 @@
+import type { InstalledModelVersion } from '../../shared/types/ModelUpdate'
+import { getSettings } from './SettingsService'
+import { getChannel } from './Channel'
+
+/**
+ * Issue #84 / Story D — channel-aware adapter over electron-store's
+ * `installedModelVersions`. The on-disk record stores keys as
+ * `${channel}:${modelId}`; this module is the only place that knows
+ * about that prefix so call sites work in plain modelId terms and a
+ * channel switch can never bleed install records across channels
+ * (NFR-3 — no false-positive update banners after a channel switch).
+ */
+
+function tagKey(modelId: string): string {
+  return `${getChannel()}:${modelId}`
+}
+
+function readRaw(): Record<string, InstalledModelVersion> {
+  // electron-store can return undefined or a non-object if the file was
+  // tampered with; coerce to an empty record rather than crashing.
+  const raw = getSettings().get('installedModelVersions')
+  if (!raw || typeof raw !== 'object') return {}
+  return raw as Record<string, InstalledModelVersion>
+}
+
+function writeRaw(next: Record<string, InstalledModelVersion>): void {
+  getSettings().set('installedModelVersions', next)
+}
+
+/**
+ * Returns the installed-versions view for the active channel, keyed by
+ * plain model id (no prefix). Other channels' entries are filtered out.
+ */
+export function getInstalledVersions(): Record<string, InstalledModelVersion> {
+  const raw = readRaw()
+  const prefix = `${getChannel()}:`
+  const result: Record<string, InstalledModelVersion> = {}
+  for (const [key, val] of Object.entries(raw)) {
+    if (key.startsWith(prefix)) {
+      result[key.slice(prefix.length)] = val
+    }
+  }
+  return result
+}
+
+/** Returns the installed-version record for one model in the active channel. */
+export function getInstalledVersion(modelId: string): InstalledModelVersion | null {
+  return readRaw()[tagKey(modelId)] ?? null
+}
+
+/** Upserts an installed-version record for the active channel. */
+export function setInstalledVersion(modelId: string, val: InstalledModelVersion): void {
+  const next = { ...readRaw() }
+  next[tagKey(modelId)] = val
+  writeRaw(next)
+}
+
+/** Removes the installed-version record for the active channel. */
+export function deleteInstalledVersion(modelId: string): void {
+  const next = { ...readRaw() }
+  delete next[tagKey(modelId)]
+  writeRaw(next)
+}
+
+/**
+ * Bulk replacement of the active channel's view. Used by the legacy-rename
+ * migration path inside UpdateCheckService.migrateInstalledVersions —
+ * other channels' entries stay intact.
+ */
+export function replaceInstalledVersionsForChannel(
+  next: Record<string, InstalledModelVersion>
+): void {
+  const channel = getChannel()
+  const prefix = `${channel}:`
+  const all = readRaw()
+  // Strip every entry for the active channel, then re-add what the caller passes.
+  const merged: Record<string, InstalledModelVersion> = {}
+  for (const [key, val] of Object.entries(all)) {
+    if (!key.startsWith(prefix)) merged[key] = val
+  }
+  for (const [id, val] of Object.entries(next)) {
+    merged[`${channel}:${id}`] = val
+  }
+  writeRaw(merged)
+}

--- a/src/main/services/ModelDownloadService.ts
+++ b/src/main/services/ModelDownloadService.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'crypto'
 import { existsSync, mkdirSync, rmSync, statSync, unlinkSync } from 'fs'
-import { join } from 'path'
+import { dirname, join } from 'path'
 import { BrowserWindow } from 'electron'
 import { getDataDir } from '../db/connection'
 import { getSettings, type AppSettings } from './SettingsService'
@@ -458,6 +458,12 @@ export async function downloadSingleModel(id: string): Promise<void> {
   const targetPath = def.archive
     ? join(modelsDir, `${def.id}.tar.gz`)
     : join(modelsDir, def.relativePath)
+  // Required-group dirs (asr/diarization/ner) are bootstrapped at startup by
+  // initDatabase. Optional groups (summarization, …) are not — first
+  // download for such a group lands in a parent that does not exist yet.
+  // Mirroring the same defensive mkdirSync used in executeUpdates' atomic
+  // swap path, the entry point for download owns the parent.
+  mkdirSync(dirname(targetPath), { recursive: true })
 
   const result = await downloadFile(
     def.url,

--- a/src/main/services/ModelDownloadService.ts
+++ b/src/main/services/ModelDownloadService.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'crypto'
 import { existsSync, mkdirSync, rmSync, statSync, unlinkSync } from 'fs'
 import { join } from 'path'
 import { BrowserWindow } from 'electron'
@@ -6,6 +7,7 @@ import { getSettings, type AppSettings } from './SettingsService'
 import { downloadFile, verifyFileSha256, extractTarGz } from './DownloadService'
 import type { ModelGroup } from '../../shared/validation/model-catalog-schemas'
 import { MODEL_DEFINITIONS, type ModelDefinition } from '../../shared/model-catalog'
+import type { ReconcileEvent, ReconcileReason } from '../../shared/types/ReconcileEvent'
 
 export type { ModelGroup, ModelDefinition }
 
@@ -73,23 +75,45 @@ export function getModelById(id: string): ModelDefinition | null {
   return def && isPublishable(def) ? def : null
 }
 
-/** Liefert die aktuell aktive Model-ID für eine Gruppe aus den Settings. */
-export function getActiveModelId(group: ModelGroup): string {
+/**
+ * Liefert die aktuell aktive Model-ID für eine Gruppe aus den Settings, oder
+ * `null` wenn kein ausführbares Modell aktiv ist. "Ausführbar" heisst:
+ *   1. die Slot-Spalte enthält eine ID,
+ *   2. die ID existiert im Katalog,
+ *   3. die zugehörige `checkPath`-Datei liegt auf Disk.
+ *
+ * Issue #84 / Story A: Diese defensive Disk-Prüfung ist der Hot-Path-Backstop
+ * gegen "App glaubt Aktiv, aber Datei fehlt"-Inkonsistenzen (z. B. nach manuellem
+ * Löschen im Finder, nach abgebrochenem Update, nach Spotlight-Cleanup). Der
+ * Bootstrap-Reconciler `reconcileActiveModels` repariert solche Zustände
+ * proaktiv beim App-Start; `getActiveModelId` ist die zweite Verteidigungslinie
+ * für Inkonsistenzen, die _während_ einer Session entstehen.
+ */
+export function getActiveModelId(group: ModelGroup): string | null {
   const active = getSettings().get('activeModels')
-  if (group === 'asr') return active.transcription
-  if (group === 'diarization') return active.diarization
-  if (group === 'ner') return active.ner
-  if (group === 'summarization') return active.summarization
-  throw new Error(`Keine aktive Modell-Konfiguration für Gruppe "${group}"`)
+  let id: string | null
+  if (group === 'asr') id = active.transcription
+  else if (group === 'diarization') id = active.diarization
+  else if (group === 'ner') id = active.ner
+  else if (group === 'summarization') id = active.summarization
+  else throw new Error(`Keine aktive Modell-Konfiguration für Gruppe "${group}"`)
+
+  if (id === null || id === '') return null
+  if (!isModelInstalled(id)) return null
+  return id
 }
 
-/** Liefert den absoluten Pfad zum aktiven Modell einer Gruppe (für Subprozess-Aufrufe). */
-export function getActiveModelPath(group: ModelGroup): string {
+/**
+ * Liefert den absoluten Pfad zum aktiven Modell einer Gruppe — oder `null`,
+ * wenn die Gruppe kein installiertes aktives Modell hat. Aufrufer (Executors,
+ * Pipeline-Plan) müssen den Null-Fall explizit behandeln (Pflicht-Gruppen:
+ * Fehler werfen; optionale: Step skippen).
+ */
+export function getActiveModelPath(group: ModelGroup): string | null {
   const id = getActiveModelId(group)
+  if (id === null) return null
   const def = getModelById(id)
-  if (!def) {
-    throw new Error(`Aktive Modell-ID "${id}" für Gruppe "${group}" nicht im Katalog gefunden`)
-  }
+  if (!def) return null
   return join(getModelsDir(), def.relativePath)
 }
 
@@ -106,13 +130,13 @@ export function getActiveModelPath(group: ModelGroup): string {
  * `activeDiarId` wird aus Backward-Compat-Gründen akzeptiert, aber ignoriert.
  */
 export function getModelsToLoadOnFirstLaunch(
-  activeAsrId: string,
-  _activeDiarId?: string
+  activeAsrId: string | null,
+  _activeDiarId?: string | null
 ): ModelDefinition[] {
   const seen = new Set<string>()
   const out: ModelDefinition[] = []
 
-  const activeAsr = getModelById(activeAsrId)
+  const activeAsr = activeAsrId ? getModelById(activeAsrId) : null
   if (activeAsr && activeAsr.group === 'asr' && !seen.has(activeAsr.id)) {
     seen.add(activeAsr.id)
     out.push(activeAsr)
@@ -128,18 +152,21 @@ export function getModelsToLoadOnFirstLaunch(
 
 /**
  * Prüft, ob die Minimal-Menge (required + aktives ASR + aktives Diarization) installiert ist.
+ * Wenn `activeAsrId` null ist (z. B. nach Reconcile auf einer frisch installierten App),
+ * fehlt strukturell ein ASR-Modell → false; FirstLaunchScreen wird angezeigt.
  */
 export function checkRequiredAndActiveExist(
-  activeAsrId: string,
-  activeDiarId: string
+  activeAsrId: string | null,
+  activeDiarId: string | null
 ): boolean {
+  if (activeAsrId === null) return false
   const modelsDir = getModelsDir()
   const toCheck = getModelsToLoadOnFirstLaunch(activeAsrId, activeDiarId)
   return toCheck.every((m) => existsSync(join(modelsDir, m.checkPath)))
 }
 
 /** Backward-Compat-Alias. */
-export function checkRequiredAndActiveAsrExist(activeAsrId: string): boolean {
+export function checkRequiredAndActiveAsrExist(activeAsrId: string | null): boolean {
   const activeDiar = getSettings().get('activeModels').diarization
   return checkRequiredAndActiveExist(activeAsrId, activeDiar)
 }
@@ -155,6 +182,30 @@ export function isModelInstalled(id: string): boolean {
 
 export function getModelsDir(): string {
   return join(getDataDir(), 'models')
+}
+
+/**
+ * Persist that a model with the given catalog hash is installed on disk.
+ * Called from the download paths immediately after SHA-256 verification +
+ * archive extraction succeed — at that point we KNOW the catalog hash matches
+ * the bytes on disk (we just verified). Writing the real hash here closes the
+ * Erstinstallation false-positive update banner: the next manifest check
+ * compares string-equal against this hash and only flags an update when the
+ * manifest publishes a new version.
+ *
+ * Distinct from the `''` sentinel written by `migrateInstalledVersions` for
+ * pre-existing installs from app builds that did not yet track per-install
+ * hashes; those entries are healed lazily by `UpdateCheckService.checkForUpdates`.
+ */
+export function recordInstalledVersion(id: string, sha256: string): void {
+  const settings = getSettings()
+  const installed = { ...settings.get('installedModelVersions') }
+  installed[id] = {
+    version: 'installed',
+    sha256,
+    installedAt: new Date().toISOString()
+  }
+  settings.set('installedModelVersions', installed)
 }
 
 export function checkModelsExist(): boolean {
@@ -322,6 +373,15 @@ export async function startModelDownload(): Promise<void> {
       }
     }
 
+    // Only record the install hash once `checkPath` is observable on disk —
+    // a successful tar exit doesn't guarantee the inner file we use as the
+    // installed-marker actually landed (malformed archive, disk-full mid-write).
+    // Skipping the recordInstalledVersion call here lets `migrateInstalledVersions`
+    // / lazy heal recover on the next manifest check rather than persisting a
+    // hash for a half-installed model.
+    if (existsSync(join(modelsDir, model.checkPath))) {
+      recordInstalledVersion(model.id, model.sha256)
+    }
     overallDownloaded += model.sizeBytes
   }
 
@@ -437,6 +497,12 @@ export async function downloadSingleModel(id: string): Promise<void> {
     }
   }
 
+  // Disk-presence guard before recording — see startModelDownload for the
+  // reasoning. A successful tar exit isn't a guarantee that `checkPath` is
+  // populated.
+  if (existsSync(join(modelsDir, def.checkPath))) {
+    recordInstalledVersion(def.id, def.sha256)
+  }
   sendProgress({ state: 'complete' })
   abortSignal = null
 }
@@ -497,7 +563,7 @@ export async function deleteModel(id: string): Promise<void> {
   if (def.group && OPTIONAL_GROUPS.has(def.group)) {
     const slot = GROUP_TO_SETTINGS_KEY[def.group]
     if (active[slot] === id) {
-      settings.set('activeModels', { ...settings.get('activeModels'), [slot]: '' })
+      settings.set('activeModels', { ...settings.get('activeModels'), [slot]: null })
     }
   }
 }
@@ -555,10 +621,166 @@ export function clearActiveModel(group: ModelGroup): void {
   }
   const settings = getSettings()
   const current = settings.get('activeModels')
-  settings.set('activeModels', { ...current, [GROUP_TO_SETTINGS_KEY[group]]: '' })
+  settings.set('activeModels', { ...current, [GROUP_TO_SETTINGS_KEY[group]]: null })
 }
 
 /** Backward-Compat-Alias. */
 export function setActiveAsrModel(id: string): void {
   setActiveModel('asr', id)
+}
+
+// ─── Bootstrap reconcile (Issue #84 / Story C) ────────────────────────────────
+// "Disk ist die einzige Wahrheit": die App darf keinen Belief-State haben, der
+// von der beobachtbaren Realität abweichen kann. Wo sie es heute hat (Slot
+// zeigt auf gelöschte Datei nach Finder-Mülleimer-Aktion / abgebrochenem
+// Update / Disk-Korruption), gewinnt die Realität — beim nächsten Bootstrap.
+
+/**
+ * Pipeline-Pflichtgruppen im Sinne der Reconcile-Logik: ohne ein installiertes
+ * Modell in jeder dieser Gruppen ist die Audio-Pipeline nicht ausführbar.
+ * `summarization` lebt in OPTIONAL_GROUPS (oben definiert).
+ */
+const REQUIRED_GROUPS_FOR_RECONCILE: ReadonlySet<ModelGroup> = new Set([
+  'asr',
+  'diarization',
+  'ner'
+])
+
+/**
+ * Katalog-Default pro Gruppe — manuell synchron gehalten mit
+ * `defaults.activeModels` in `SettingsService.ts`. Der Reconciler bevorzugt den
+ * Default beim Auto-Activate, fällt aber auf das nächste installierte
+ * Gruppenmitglied zurück, wenn der Default selbst fehlt (ASR-Variante anstelle
+ * des multilingualen Default).
+ */
+const GROUP_DEFAULTS: Record<ModelGroup, string> = {
+  asr: 'whisper-large-v3-turbo',
+  diarization: 'pyannote-suite',
+  ner: 'flair-ner-german-large',
+  summarization: 'gemma-summarization'
+}
+
+function pickInstalledForGroup(group: ModelGroup): string | null {
+  const preferred = GROUP_DEFAULTS[group]
+  if (isModelInstalled(preferred)) return preferred
+  for (const m of getModelsByGroup(group)) {
+    if (isModelInstalled(m.id)) return m.id
+  }
+  return null
+}
+
+export interface ReconcileRepair {
+  group: ModelGroup
+  fromModelId: string | null
+  toModelId: string | null
+  reason: ReconcileReason
+}
+
+/**
+ * Bootstrap reconciler — läuft einmal beim App-Start, NACH `initSettings()`
+ * und VOR `createWindow()`. Geht jede Modell-Gruppe durch und stellt das
+ * Invariant sicher:
+ *   "Der active-Slot zeigt entweder auf ein installiertes Katalog-Modell
+ *    oder ist null."
+ *
+ * Inkonsistenzen werden so repariert:
+ *   - Pflicht-Gruppe mit fehlendem aktiven Modell → installierten Katalog-
+ *     Default aktivieren (oder ein anderes installiertes Gruppenmitglied,
+ *     wenn der Default nicht installiert ist); andernfalls null + der
+ *     FirstLaunchScreen wird angezeigt.
+ *   - Optionale Gruppe mit fehlendem aktiven Modell → null (Pipeline-Step
+ *     wird zur Laufzeit übersprungen).
+ *
+ * Wird auf wirklich frischen Installationen (`modelsDownloaded === false`)
+ * komplett übersprungen — dort ist der FirstLaunchScreen das Gate. Jede
+ * Reparatur wird als `pending` ReconcileEvent persistiert, was den Dot im
+ * BottomNav und das Banner in Settings → Modelle treibt.
+ *
+ * Performance: nur `existsSync`-Calls (≤ Katalog-Größe, derzeit 6), kein I/O
+ * darüber hinaus. Crash-sicher per design — Disk ist Source of Truth,
+ * electron-store ist Cache; ein Crash mitten im Write heilt sich beim nächsten
+ * Bootstrap.
+ */
+export function reconcileActiveModels(): ReadonlyArray<ReconcileRepair> {
+  const settings = getSettings()
+  if (settings.get('modelsDownloaded') !== true) return []
+
+  const groups: readonly ModelGroup[] = ['asr', 'diarization', 'ner', 'summarization']
+  const repairs: ReconcileRepair[] = []
+  let nextActive = { ...settings.get('activeModels') }
+  let activeChanged = false
+
+  for (const group of groups) {
+    const slot = GROUP_TO_SETTINGS_KEY[group]
+    const current: string | null = nextActive[slot] ?? null
+
+    // Steady state — slot points at an installed catalog model.
+    if (current !== null && isModelInstalled(current)) continue
+
+    // Steady state for optional groups the user has deactivated — no event.
+    if (current === null && !REQUIRED_GROUPS_FOR_RECONCILE.has(group)) continue
+
+    let next: string | null
+    let reason: ReconcileReason
+
+    if (REQUIRED_GROUPS_FOR_RECONCILE.has(group)) {
+      next = pickInstalledForGroup(group)
+      reason = next === null ? 'model-removed' : 'default-promoted'
+    } else {
+      next = null
+      reason = 'group-cleared'
+    }
+
+    if (next === current) continue
+
+    nextActive = { ...nextActive, [slot]: next }
+    activeChanged = true
+    repairs.push({ group, fromModelId: current, toModelId: next, reason })
+  }
+
+  if (activeChanged) {
+    settings.set('activeModels', nextActive)
+  }
+
+  if (repairs.length > 0) {
+    const previous = settings.get('reconcileEvents') ?? []
+    const additions: ReconcileEvent[] = repairs.map((r) => ({
+      id: randomUUID(),
+      timestamp: new Date().toISOString(),
+      group: r.group,
+      fromModelId: r.fromModelId,
+      toModelId: r.toModelId,
+      reason: r.reason,
+      status: 'pending'
+    }))
+    settings.set('reconcileEvents', [...previous, ...additions])
+    for (const r of repairs) {
+      console.log(
+        `[reconcile] ${r.group}: ${r.fromModelId ?? '<null>'} → ${r.toModelId ?? '<null>'} (${r.reason})`
+      )
+    }
+  }
+
+  return repairs
+}
+
+// ─── Reconcile event lifecycle ────────────────────────────────────────────────
+
+export function getReconcileEvents(): ReconcileEvent[] {
+  return getSettings().get('reconcileEvents') ?? []
+}
+
+/** Renderer hat Settings → Modelle gemountet — Banner gesehen, BottomNav-Dot kann weg. */
+export function markReconcileEventsSeen(): ReconcileEvent[] {
+  const settings = getSettings()
+  const events = settings.get('reconcileEvents') ?? []
+  if (events.length === 0 || events.every((e) => e.status === 'seen')) return events
+  const next: ReconcileEvent[] = events.map((e) => ({ ...e, status: 'seen' as const }))
+  settings.set('reconcileEvents', next)
+  return next
+}
+
+/** User klickte "Verstanden" — alle Events permanent löschen. */
+export function dismissReconcileEvents(): void {
+  getSettings().set('reconcileEvents', [])
 }

--- a/src/main/services/ModelDownloadService.ts
+++ b/src/main/services/ModelDownloadService.ts
@@ -4,6 +4,10 @@ import { join } from 'path'
 import { BrowserWindow } from 'electron'
 import { getDataDir } from '../db/connection'
 import { getSettings, type AppSettings } from './SettingsService'
+import {
+  deleteInstalledVersion,
+  setInstalledVersion
+} from './InstalledVersionsStore'
 import { downloadFile, verifyFileSha256, extractTarGz } from './DownloadService'
 import type { ModelGroup } from '../../shared/validation/model-catalog-schemas'
 import { MODEL_DEFINITIONS, type ModelDefinition } from '../../shared/model-catalog'
@@ -198,14 +202,11 @@ export function getModelsDir(): string {
  * hashes; those entries are healed lazily by `UpdateCheckService.checkForUpdates`.
  */
 export function recordInstalledVersion(id: string, sha256: string): void {
-  const settings = getSettings()
-  const installed = { ...settings.get('installedModelVersions') }
-  installed[id] = {
+  setInstalledVersion(id, {
     version: 'installed',
     sha256,
     installedAt: new Date().toISOString()
-  }
-  settings.set('installedModelVersions', installed)
+  })
 }
 
 export function checkModelsExist(): boolean {
@@ -552,9 +553,7 @@ export async function deleteModel(id: string): Promise<void> {
     }
   }
 
-  const installed = { ...settings.get('installedModelVersions') }
-  delete installed[id]
-  settings.set('installedModelVersions', installed)
+  deleteInstalledVersion(id)
 
   // Optionale Gruppen: war das gelöschte Modell aktiv, Active-Slot räumen,
   // damit die UI nicht „Aktiv" auf etwas Nichtexistentem anzeigt. Erlaubt durch

--- a/src/main/services/ModelDownloadService.ts
+++ b/src/main/services/ModelDownloadService.ts
@@ -94,6 +94,25 @@ export function getModelById(id: string): ModelDefinition | null {
  * für Inkonsistenzen, die _während_ einer Session entstehen.
  */
 export function getActiveModelId(group: ModelGroup): string | null {
+  const id = getActiveModelIdBelief(group)
+  if (id === null) return null
+  if (!isModelInstalled(id)) return null
+  return id
+}
+
+/**
+ * Issue #84 / Story E follow-up — raw settings-belief without the disk
+ * presence check. Used by the catalog handler to expose the "user has
+ * marked this active" bit independently of "the file is there", so the
+ * Settings UI can surface the `inconsistent` ModelStatusBadge state when
+ * the two diverge (e.g. user deletes the file in Finder mid-session and
+ * re-opens Settings → Modelle before restarting).
+ *
+ * Executors must keep using `getActiveModelId` (the disk-checked variant);
+ * trusting belief without the file check would re-introduce the original
+ * trust gap this epic closes.
+ */
+export function getActiveModelIdBelief(group: ModelGroup): string | null {
   const active = getSettings().get('activeModels')
   let id: string | null
   if (group === 'asr') id = active.transcription
@@ -103,7 +122,6 @@ export function getActiveModelId(group: ModelGroup): string | null {
   else throw new Error(`Keine aktive Modell-Konfiguration für Gruppe "${group}"`)
 
   if (id === null || id === '') return null
-  if (!isModelInstalled(id)) return null
   return id
 }
 

--- a/src/main/services/PDFExtractionExecutor.ts
+++ b/src/main/services/PDFExtractionExecutor.ts
@@ -94,16 +94,17 @@ export class PDFExtractionExecutor implements TaskExecutor {
     const extractedPath = join(getDataDir(), 'extracted', `${task.sessionId}.json`)
     writeFileAtomic(extractedPath, JSON.stringify(extractionResult, null, 2))
 
-    sessionService.updateSession(task.sessionId, { extractedPath })
+    // Always write a transcript from extracted text — guarantees the
+    // anonymization step has a transcriptPath to read even when the
+    // import-time scanned-page heuristic disagrees with extraction-time
+    // detection. If OCR runs after this, it overwrites the transcript with
+    // a merged version that includes OCR'd scanned pages.
+    const transcriptPath = buildPDFTranscript(task.sessionId, pages, 'pdfjs-dist', sessionService)
 
-    // If all pages have text (no scanned pages), build the transcript directly
-    // so the OCR step can skip quickly
-    const hasScannedPages = pages.some((p) => p.contentType === 'scanned')
-
-    if (!hasScannedPages) {
-      const transcriptPath = buildPDFTranscript(task.sessionId, pages, 'pdfjs-dist', sessionService)
-      sessionService.updateSession(task.sessionId, { transcriptPath })
-    }
+    // Single DB write so a crash between updates can't leave the session in
+    // the (extractedPath set, transcriptPath null) state that previously
+    // wedged retries at anonymization.
+    sessionService.updateSession(task.sessionId, { extractedPath, transcriptPath })
 
     onProgress(1)
   }

--- a/src/main/services/ProvenanceCapture.ts
+++ b/src/main/services/ProvenanceCapture.ts
@@ -1,5 +1,5 @@
 import { getActiveModelId, getModelById } from './ModelDownloadService'
-import { getSettings } from './SettingsService'
+import { getInstalledVersion } from './InstalledVersionsStore'
 import type { ModelGroup } from '../../shared/validation/model-catalog-schemas'
 import type {
   ModelSnapshot,
@@ -27,7 +27,7 @@ function snapshotGroup(group: ModelGroup): ModelSnapshot | null {
   if (!id) return null
   const def = getModelById(id)
   if (!def) return null
-  const installed = getSettings().get('installedModelVersions')?.[id]
+  const installed = getInstalledVersion(id)
   return {
     id,
     label: def.label,

--- a/src/main/services/ProvenanceCapture.ts
+++ b/src/main/services/ProvenanceCapture.ts
@@ -1,0 +1,61 @@
+import { getActiveModelId, getModelById } from './ModelDownloadService'
+import { getSettings } from './SettingsService'
+import type { ModelGroup } from '../../shared/validation/model-catalog-schemas'
+import type {
+  ModelSnapshot,
+  ProcessedModelsSnapshot,
+  TaskType
+} from '../../shared/types'
+
+/**
+ * Issue #84 / Story I — captures the active models per pipeline group at the
+ * moment processing starts. Called once per session from TaskQueueService:
+ *   1. enqueuePipeline — first run after recording / PDF import.
+ *   2. retrySession   — overwrites the previous snapshot because the user
+ *      may have switched the active model between runs; the relevant
+ *      provenance is what actually produced the next attempt.
+ *
+ * `getActiveModelId()` already runs Story A's defensive disk check, so a
+ * snapshot's id is guaranteed to point at an installed model. `version`
+ * comes from electron-store's `installedModelVersions` map (populated at
+ * download/update time, Story B). `label` and `sizeBytes` are captured
+ * from the catalog so a future catalog rename or repackage does not
+ * rewrite history.
+ */
+function snapshotGroup(group: ModelGroup): ModelSnapshot | null {
+  const id = getActiveModelId(group)
+  if (!id) return null
+  const def = getModelById(id)
+  if (!def) return null
+  const installed = getSettings().get('installedModelVersions')?.[id]
+  return {
+    id,
+    label: def.label,
+    version: installed?.version ?? 'unknown',
+    sha256: def.sha256,
+    sizeBytes: def.sizeBytes
+  }
+}
+
+/**
+ * Build a ProcessedModelsSnapshot from the planned pipeline. Each group's
+ * slot is null when the corresponding step is not in `plannedSteps` (e.g.
+ * summarization is skipped for sessions without an active LLM, ASR is
+ * absent for PDF pipelines).
+ *
+ * `extraction` (pdfjs) and `ocr` (Apple Vision) are not catalog-backed
+ * pipeline steps and intentionally have no snapshot — those tools ship
+ * with the app binary and their identity is the app version.
+ */
+export function captureProcessedModels(
+  plannedSteps: TaskType[]
+): ProcessedModelsSnapshot {
+  const planned = new Set(plannedSteps)
+  return {
+    capturedAt: new Date().toISOString(),
+    asr: planned.has('transcription') ? snapshotGroup('asr') : null,
+    diarization: planned.has('diarization') ? snapshotGroup('diarization') : null,
+    ner: planned.has('anonymization') ? snapshotGroup('ner') : null,
+    summarization: planned.has('summarization') ? snapshotGroup('summarization') : null
+  }
+}

--- a/src/main/services/ReviewService.ts
+++ b/src/main/services/ReviewService.ts
@@ -33,7 +33,9 @@ export class ReviewService {
       document,
       entityMap,
       sessionType: session.type,
-      sessionTitle: session.title
+      sessionTitle: session.title,
+      processedWithModels: session.processedWithModels,
+      reviewAt: session.reviewAt
     }
   }
 

--- a/src/main/services/SettingsService.ts
+++ b/src/main/services/SettingsService.ts
@@ -41,6 +41,13 @@ export interface AppSettings {
   pendingModelUpdates: PendingModelUpdate[] | null
   cachedAppUpdateStatus: AppUpdateStatus | null
   reconcileEvents: ReconcileEvent[]
+  /**
+   * Issue #84 / Story F+G — manifest entries the user has actively dismissed.
+   * Each entry is `${modelId}@${sha256}`; the SHA-256 is what makes the entry
+   * obsolete on its own when a new manifest publishes a different hash for the
+   * same id, so no explicit cleanup is needed.
+   */
+  dismissedManifestVersions: string[]
 }
 
 const defaults: AppSettings = {
@@ -61,7 +68,8 @@ const defaults: AppSettings = {
   installedModelVersions: {},
   pendingModelUpdates: null,
   cachedAppUpdateStatus: null,
-  reconcileEvents: []
+  reconcileEvents: [],
+  dismissedManifestVersions: []
 }
 
 let store: Store<AppSettings> | null = null
@@ -187,6 +195,11 @@ export function initSettings(): Store<AppSettings> {
   // into already-persisted instances).
   if (!Array.isArray(store.get('reconcileEvents'))) {
     store.set('reconcileEvents', [])
+  }
+
+  // Issue #84 / Story F+G — same reasoning for dismissedManifestVersions.
+  if (!Array.isArray(store.get('dismissedManifestVersions'))) {
+    store.set('dismissedManifestVersions', [])
   }
 
   // installedModelVersions: Altlasten-Keys (Legacy + PR-Zwischenstände) auf den neuen

--- a/src/main/services/SettingsService.ts
+++ b/src/main/services/SettingsService.ts
@@ -204,7 +204,8 @@ export function initSettings(): Store<AppSettings> {
 
   // installedModelVersions: Altlasten-Keys (Legacy + PR-Zwischenstände) auf den neuen
   // Key umbenennen, sonst bleiben sie für immer verwaist (UpdateCheckService iteriert
-  // über Manifest-IDs, nicht über installed-keys).
+  // über Manifest-IDs, nicht über installed-keys). Läuft VOR der Channel-Tag-Migration
+  // weiter unten, weil die Renames untagged-Keys erwarten.
   const installed = { ...store.get('installedModelVersions') }
   const legacyInstalledKeys = [
     'pyannote-community-1',
@@ -221,6 +222,25 @@ export function initSettings(): Store<AppSettings> {
   }
   if (installedChanged) {
     store.set('installedModelVersions', installed)
+  }
+
+  // Issue #84 / Story D — channel-tag migration. Pre-D installs wrote raw
+  // model-id keys; tag them as `prod:` so the channel-aware adapter (see
+  // InstalledVersionsStore.ts) can read them. Already-tagged keys (anything
+  // containing `:`) are passed through unchanged. Idempotent.
+  const installedForChannelTag = { ...store.get('installedModelVersions') }
+  let channelTagChanged = false
+  const tagged: Record<string, InstalledModelVersion> = {}
+  for (const [key, val] of Object.entries(installedForChannelTag)) {
+    if (key.includes(':')) {
+      tagged[key] = val
+    } else {
+      tagged[`prod:${key}`] = val
+      channelTagChanged = true
+    }
+  }
+  if (channelTagChanged) {
+    store.set('installedModelVersions', tagged)
   }
 
   return store

--- a/src/main/services/SettingsService.ts
+++ b/src/main/services/SettingsService.ts
@@ -5,6 +5,7 @@ import type {
   InstalledModelVersion,
   AppUpdateStatus
 } from '../../shared/types/ModelUpdate'
+import type { ReconcileEvent } from '../../shared/types/ReconcileEvent'
 import { getModelDefinitions } from './ModelDownloadService'
 import {
   DIARIZATION_PIPELINES,
@@ -17,12 +18,18 @@ export { DIARIZATION_PIPELINES, DEFAULT_DIARIZATION_PIPELINE }
 
 export interface AppSettings {
   activeModels: {
-    transcription: string
-    diarization: string
+    // null when no model is selected for the slot — optional groups (summarization)
+    // ship deactivated; required groups become null only transiently when the
+    // active model is missing on disk and no installed default exists, in which
+    // case the FirstLaunchScreen forces re-download. The bootstrap reconciler
+    // (`reconcileActiveModels`) maintains the invariant that either the slot
+    // points to an installed catalog model or it is null.
+    transcription: string | null
+    diarization: string | null
     diarizationPipeline: DiarizationPipeline
-    ner: string
+    ner: string | null
     ocr: string
-    summarization: string
+    summarization: string | null
   }
   firstLaunchDone: boolean
   consentReminderShown: boolean
@@ -33,6 +40,7 @@ export interface AppSettings {
   installedModelVersions: Record<string, InstalledModelVersion>
   pendingModelUpdates: PendingModelUpdate[] | null
   cachedAppUpdateStatus: AppUpdateStatus | null
+  reconcileEvents: ReconcileEvent[]
 }
 
 const defaults: AppSettings = {
@@ -52,7 +60,8 @@ const defaults: AppSettings = {
   reviewPanelOpen: false,
   installedModelVersions: {},
   pendingModelUpdates: null,
-  cachedAppUpdateStatus: null
+  cachedAppUpdateStatus: null,
+  reconcileEvents: []
 }
 
 let store: Store<AppSettings> | null = null
@@ -91,7 +100,13 @@ export function initSettings(): Store<AppSettings> {
   )
   const EXPECTED_DIAR = 'pyannote-suite'
 
-  if (!knownDiarIds.has(active.diarization) || active.diarization !== EXPECTED_DIAR) {
+  // null is a valid post-migration state for the diarization slot (cleared by
+  // the reconciler when the suite is missing on disk); only fire the legacy
+  // reset for known-bad string IDs, not for null.
+  if (
+    active.diarization !== null &&
+    (!knownDiarIds.has(active.diarization) || active.diarization !== EXPECTED_DIAR)
+  ) {
     const inferredPipeline = inferPipelineFromLegacyId(active.diarization)
     console.warn(
       `[settings-migration] activeModels.diarization="${active.diarization}" → reset auf "${EXPECTED_DIAR}" (Pipeline: ${inferredPipeline})`
@@ -126,7 +141,7 @@ export function initSettings(): Store<AppSettings> {
   )
   const EXPECTED_NER = 'flair-ner-german-large'
   const currentNer = store.get('activeModels').ner
-  if (!knownNerIds.has(currentNer)) {
+  if (currentNer === null || !knownNerIds.has(currentNer)) {
     console.warn(
       `[settings-migration] activeModels.ner="${currentNer}" unbekannt → reset auf "${EXPECTED_NER}"`
     )
@@ -139,14 +154,39 @@ export function initSettings(): Store<AppSettings> {
   // Defensiv: Bestehende electron-store-Instanzen haben kein activeModels.summarization,
   // weil das Feld erst mit dem lokalen LLM eingeführt wurde. defaults füllt nested keys
   // nicht nach, also Wert hier explizit setzen, falls nicht vorhanden.
-  // Leerer String ist ein gültiger Wert ("Zusammenfassung deaktiviert") — nicht überschreiben.
-  const currentSummarization = (store.get('activeModels') as { summarization?: string })
-    .summarization
-  if (typeof currentSummarization !== 'string') {
+  const currentSummarization = (
+    store.get('activeModels') as { summarization?: string | null }
+  ).summarization
+  if (typeof currentSummarization !== 'string' && currentSummarization !== null) {
     store.set('activeModels', {
       ...store.get('activeModels'),
       summarization: 'gemma-summarization'
     })
+  }
+
+  // Issue #84 / Story C — convert the legacy '' sentinel ("deaktiviert") to null,
+  // matching the new `string | null` type. The reconciler relies on null to
+  // detect "no active model" without ambiguity. `ocr` and `diarizationPipeline`
+  // are not user-clearable and stay non-null.
+  const activeForLegacy = store.get('activeModels') as Record<string, string | null>
+  const legacyEmptyKeys = ['transcription', 'diarization', 'ner', 'summarization'] as const
+  let activeChanged = false
+  const next = { ...activeForLegacy }
+  for (const key of legacyEmptyKeys) {
+    if (next[key] === '') {
+      next[key] = null
+      activeChanged = true
+    }
+  }
+  if (activeChanged) {
+    store.set('activeModels', next as AppSettings['activeModels'])
+  }
+
+  // Issue #84 / Story C — ensure reconcileEvents exists for stores from
+  // previous app versions (electron-store does not deep-merge top-level defaults
+  // into already-persisted instances).
+  if (!Array.isArray(store.get('reconcileEvents'))) {
+    store.set('reconcileEvents', [])
   }
 
   // installedModelVersions: Altlasten-Keys (Legacy + PR-Zwischenstände) auf den neuen

--- a/src/main/services/SettingsService.ts
+++ b/src/main/services/SettingsService.ts
@@ -142,6 +142,13 @@ export function initSettings(): Store<AppSettings> {
   // einer rückgängig gemachten Multi-Backend-Iteration) auf den einzig
   // verfügbaren NER-Default zurücksetzen, damit AnonymizationService nicht
   // mit "ungültiges NER-Modell" abbricht.
+  //
+  // null ist ein gültiger Post-Reconciler-Zustand (Story C clears the slot
+  // when the model file is missing on disk) und darf hier NICHT zurück auf
+  // den Default gesetzt werden — sonst stösst jeder Boot ein neues
+  // ReconcileEvent an: initSettings setzt ner = EXPECTED_NER, der gleich
+  // danach laufende Reconciler räumt es wieder auf null und schreibt ein
+  // pending Event. Spiegelt das Diarization-Pattern weiter oben.
   const knownNerIds = new Set(
     getModelDefinitions()
       .filter((m) => m.group === 'ner')
@@ -149,7 +156,7 @@ export function initSettings(): Store<AppSettings> {
   )
   const EXPECTED_NER = 'flair-ner-german-large'
   const currentNer = store.get('activeModels').ner
-  if (currentNer === null || !knownNerIds.has(currentNer)) {
+  if (currentNer !== null && !knownNerIds.has(currentNer)) {
     console.warn(
       `[settings-migration] activeModels.ner="${currentNer}" unbekannt → reset auf "${EXPECTED_NER}"`
     )
@@ -251,4 +258,9 @@ export function getSettings(): Store<AppSettings> {
     throw new Error('Settings not initialized. Call initSettings() first.')
   }
   return store
+}
+
+/** Test-only — clears the module-level singleton so a fresh initSettings() runs. */
+export function _resetSettingsForTests(): void {
+  store = null
 }

--- a/src/main/services/TaskQueueService.ts
+++ b/src/main/services/TaskQueueService.ts
@@ -10,6 +10,7 @@ import { validateIntermediateFile } from '../utils/file-ops'
 import type { Task, TaskType, Session, SessionStatus, SessionType } from '../../shared/types'
 import { AUDIO_PIPELINE, PDF_PIPELINE } from '../../shared/constants/pipeline'
 import { getActiveModelId } from './ModelDownloadService'
+import { captureProcessedModels } from './ProvenanceCapture'
 
 // Issue #80 / DR-5: tasks[] is the source of truth for "current step".
 // SessionStatus only carries lifecycle phase (queued / processing / review / error / recording).
@@ -93,7 +94,11 @@ export class TaskQueueService {
     // "Schritt 0/N" flicker for filtered-out tasks (summarization without
     // model installed, ocr on text-only PDFs).
     const plannedSteps = computePlannedSteps(session)
-    this.sessionService.updateSession(sessionId, { plannedSteps })
+    // Issue #84 Story I — capture-at-source: snapshot the active models per
+    // group for this run so the Review-Editor can show provenance later.
+    // Done together with plannedSteps so both states are consistent.
+    const processedWithModels = captureProcessedModels(plannedSteps)
+    this.sessionService.updateSession(sessionId, { plannedSteps, processedWithModels })
 
     const tasks: Task[] = []
     for (const type of plannedSteps) {
@@ -190,11 +195,17 @@ export class TaskQueueService {
     // so the renderer doesn't surface stale state from the failed run while the
     // retry is in flight. Issue #80 DR-7: increment retryCount so the UI can
     // surface the 3-stage support hint after repeated failures.
+    // Issue #84 Story I — re-capture provenance: the user may have switched
+    // the active model between runs; the relevant snapshot is what actually
+    // produces the next attempt, not the previous failed one.
+    const processedWithModels = captureProcessedModels(pipeline)
+
     this.sessionService.updateSession(sessionId, {
       status: 'queued',
       errorMessage: null,
       retryCount: (session.retryCount ?? 0) + 1,
-      plannedSteps: pipeline
+      plannedSteps: pipeline,
+      processedWithModels
     })
 
     console.log(

--- a/src/main/services/TaskQueueService.ts
+++ b/src/main/services/TaskQueueService.ts
@@ -31,8 +31,13 @@ const RECOVERY_INTERVAL_MS = 5 * 60 * 1000 // 5 minutes
  *     installed on disk. The executor itself also gracefully skips at runtime
  *     if the model becomes unavailable, but we omit it from plannedSteps so
  *     the UI doesn't show a step that won't actually do anything.
- *   - ocr (PDF only): included iff session.pdfHasScannedPages === true (set
- *     at import time by the PDF importer's heuristic — Phase G).
+ *   - ocr (PDF only): always included. The executor self-skips when extraction
+ *     reports no scanned pages, so the cost for text-only PDFs is one no-op
+ *     task. Previously gated on the import-time pdfHasScannedPages heuristic,
+ *     but that heuristic samples only the first 3 pages and could disagree
+ *     with extraction-time per-page detection, leaving partially-scanned PDFs
+ *     stuck without a transcriptPath when extraction discovered scanned pages
+ *     beyond the sample window.
  */
 export function computePlannedSteps(session: Session): TaskType[] {
   // getActiveModelId already verifies disk presence and returns null on
@@ -44,16 +49,7 @@ export function computePlannedSteps(session: Session): TaskType[] {
     return AUDIO_PIPELINE.filter((step) => step !== 'summarization' || summarizationActive)
   }
 
-  // PDF: include ocr only when import-time detection said scanned pages exist.
-  // Phase G adds the pdfHasScannedPages column; until then it's always undefined
-  // and OCR is omitted from plannedSteps (matching today's PDF UI behaviour).
-  const hasScannedPages =
-    'pdfHasScannedPages' in session && (session as Session & { pdfHasScannedPages?: boolean }).pdfHasScannedPages === true
-  return PDF_PIPELINE.filter((step) => {
-    if (step === 'ocr') return hasScannedPages
-    if (step === 'summarization') return summarizationActive
-    return true
-  })
+  return PDF_PIPELINE.filter((step) => step !== 'summarization' || summarizationActive)
 }
 
 export class TaskQueueService {
@@ -217,12 +213,18 @@ export class TaskQueueService {
   }
 
   private findResumeIndex(session: Session, pipeline: readonly TaskType[]): number {
-    // Maps each task type to the session field that proves it completed successfully
+    // Maps each task type to the session field that proves it completed successfully.
+    // PDF extraction's success is gated on BOTH extractedPath AND transcriptPath:
+    // pre-fix sessions could end up with extractedPath set but transcriptPath
+    // missing, which used to wedge retries at anonymization. Treating the pair
+    // as a single proof restarts those sessions from extraction on retry.
+    const extractionOutput =
+      session.extractedPath && session.transcriptPath ? session.extractedPath : null
     const outputField: Partial<Record<TaskType, string | null>> = {
       transcription: session.transcriptPath,
       diarization: session.diarizationPath,
       alignment: session.alignedTranscriptPath,
-      extraction: session.extractedPath,
+      extraction: extractionOutput,
       anonymization: session.anonymizedPath
     }
 

--- a/src/main/services/TaskQueueService.ts
+++ b/src/main/services/TaskQueueService.ts
@@ -9,7 +9,7 @@ import { sendToRenderer } from '../utils/ipc-helpers'
 import { validateIntermediateFile } from '../utils/file-ops'
 import type { Task, TaskType, Session, SessionStatus, SessionType } from '../../shared/types'
 import { AUDIO_PIPELINE, PDF_PIPELINE } from '../../shared/constants/pipeline'
-import { getActiveModelId, isModelInstalled } from './ModelDownloadService'
+import { getActiveModelId } from './ModelDownloadService'
 
 // Issue #80 / DR-5: tasks[] is the source of truth for "current step".
 // SessionStatus only carries lifecycle phase (queued / processing / review / error / recording).
@@ -34,14 +34,10 @@ const RECOVERY_INTERVAL_MS = 5 * 60 * 1000 // 5 minutes
  *     at import time by the PDF importer's heuristic — Phase G).
  */
 export function computePlannedSteps(session: Session): TaskType[] {
-  const summarizationActive = (() => {
-    try {
-      const id = getActiveModelId('summarization')
-      return id.length > 0 && isModelInstalled(id)
-    } catch {
-      return false
-    }
-  })()
+  // getActiveModelId already verifies disk presence and returns null on
+  // missing/unknown — so a non-null result implies the model is installed
+  // and the executor has a real path to work with.
+  const summarizationActive = getActiveModelId('summarization') !== null
 
   if (session.type === 'audio') {
     return AUDIO_PIPELINE.filter((step) => step !== 'summarization' || summarizationActive)

--- a/src/main/services/UpdateCheckService.ts
+++ b/src/main/services/UpdateCheckService.ts
@@ -88,6 +88,30 @@ function fetchManifestJson(url: string): Promise<unknown> {
   })
 }
 
+// ─── Manifest dismissal ──────────────────────────────────────────────────────
+
+/**
+ * Issue #84 / Story F+G — stable key for "this exact manifest entry was
+ * dismissed by the user". Combines model id and sha256 so that a new manifest
+ * publishing a different hash for the same id is automatically eligible again,
+ * without explicit cleanup.
+ */
+export function manifestEntryKey(id: string, sha256: string): string {
+  return `${id}@${sha256}`
+}
+
+/** Append entries to the dismiss list, preserving order and dropping duplicates. */
+export function dismissManifestVersions(entries: Array<{ id: string; sha256: string }>): void {
+  const settings = getSettings()
+  const raw = settings.get('dismissedManifestVersions')
+  const existing = Array.isArray(raw) ? raw : []
+  const seen = new Set(existing)
+  for (const e of entries) {
+    seen.add(manifestEntryKey(e.id, e.sha256))
+  }
+  settings.set('dismissedManifestVersions', Array.from(seen))
+}
+
 // ─── checkForUpdates ─────────────────────────────────────────────────────────
 
 const NO_APP_UPDATE: AppUpdateStatus = { available: false, latestVersion: null, checkedAt: null }
@@ -99,6 +123,8 @@ export async function checkForUpdates(): Promise<CheckResult> {
 
     const settings = getSettings()
     const installedVersions = settings.get('installedModelVersions') ?? {}
+    const dismissedRaw = settings.get('dismissedManifestVersions')
+    const dismissed = new Set(Array.isArray(dismissedRaw) ? dismissedRaw : [])
     const definitions = getModelDefinitions()
 
     // ── Model update check ──
@@ -127,6 +153,14 @@ export async function checkForUpdates(): Promise<CheckResult> {
       const installed = installedVersions[manifestModel.id]
       if (installed && installed.sha256 === manifestModel.sha256) {
         continue // Already up to date
+      }
+
+      // Issue #84 / Story F+G — user actively dismissed this exact manifest
+      // entry (UpdateBanner dismiss or ModelUpdateScreen "Diese Version
+      // überspringen"). Re-becomes eligible when the manifest publishes a new
+      // sha256 for the same id.
+      if (dismissed.has(manifestEntryKey(manifestModel.id, manifestModel.sha256))) {
+        continue
       }
 
       // Lazy heal of the legacy '' sentinel from migrateInstalledVersions:

--- a/src/main/services/UpdateCheckService.ts
+++ b/src/main/services/UpdateCheckService.ts
@@ -4,6 +4,7 @@ import { join } from 'path'
 import { get as httpsGet } from 'https'
 import { getSettings } from './SettingsService'
 import { getModelDefinitions, getModelsDir, isModelInstalled } from './ModelDownloadService'
+import { getInstalledVersions, setInstalledVersion } from './InstalledVersionsStore'
 import { downloadFile, verifyFileSha256, extractTarGz } from './DownloadService'
 import {
   ManifestSchema,
@@ -122,7 +123,7 @@ export async function checkForUpdates(): Promise<CheckResult> {
     const manifest = ManifestSchema.parse(raw)
 
     const settings = getSettings()
-    const installedVersions = settings.get('installedModelVersions') ?? {}
+    const installedVersions = getInstalledVersions()
     const dismissedRaw = settings.get('dismissedManifestVersions')
     const dismissed = new Set(Array.isArray(dismissedRaw) ? dismissedRaw : [])
     const definitions = getModelDefinitions()
@@ -176,11 +177,9 @@ export async function checkForUpdates(): Promise<CheckResult> {
         if (existsSync(filePath)) {
           const matches = await verifyFileSha256(filePath, manifestModel.sha256)
           if (matches) {
-            installedVersions[manifestModel.id] = {
-              ...installed,
-              sha256: manifestModel.sha256
-            }
-            settings.set('installedModelVersions', installedVersions)
+            const healed = { ...installed, sha256: manifestModel.sha256 }
+            setInstalledVersion(manifestModel.id, healed)
+            installedVersions[manifestModel.id] = healed
             continue
           }
         }
@@ -408,13 +407,11 @@ export async function executeUpdates(): Promise<void> {
     }
 
     // ── 7. Record installed version ──
-    const installedVersions = settings.get('installedModelVersions') ?? {}
-    installedVersions[update.id] = {
+    setInstalledVersion(update.id, {
       version: update.version,
       sha256: update.sha256,
       installedAt: new Date().toISOString()
-    }
-    settings.set('installedModelVersions', installedVersions)
+    })
 
     overallDownloaded += update.sizeBytes
   }
@@ -501,11 +498,16 @@ export function cleanupIncompleteUpdates(): void {
 
 // ─── migrateInstalledVersions ─────────────────────────────────────────────────
 
+/**
+ * Backfills an empty `installedModelVersions` view for the active channel
+ * with `'pre-update'` sentinel rows whenever a model file exists on disk.
+ *
+ * Story D — the per-channel guard means a freshly switched channel sees
+ * its own (initially empty) view, even when other channels already have
+ * entries; the disk files are reused in-place by the new channel.
+ */
 export function migrateInstalledVersions(): void {
-  const settings = getSettings()
-  const installedVersions = settings.get('installedModelVersions') ?? {}
-
-  // Only migrate if no versions recorded yet
+  const installedVersions = getInstalledVersions()
   if (Object.keys(installedVersions).length > 0) return
 
   const modelsDir = getModelsDir()
@@ -516,17 +518,16 @@ export function migrateInstalledVersions(): void {
   for (const def of definitions) {
     const checkTarget = join(modelsDir, def.checkPath)
     if (existsSync(checkTarget)) {
-      installedVersions[def.id] = {
+      setInstalledVersion(def.id, {
         version: 'pre-update',
         sha256: '', // Unknown — forces update on first manifest check
         installedAt: now
-      }
+      })
       migrated++
     }
   }
 
   if (migrated > 0) {
-    settings.set('installedModelVersions', installedVersions)
     console.log(`UpdateCheckService: ${migrated} bestehende Modelle migriert`)
   }
 }

--- a/src/main/services/UpdateCheckService.ts
+++ b/src/main/services/UpdateCheckService.ts
@@ -129,6 +129,29 @@ export async function checkForUpdates(): Promise<CheckResult> {
         continue // Already up to date
       }
 
+      // Lazy heal of the legacy '' sentinel from migrateInstalledVersions:
+      // for non-archive models we can hash the file on disk and compare against
+      // the manifest. If they match, the install is bit-identical to the
+      // current manifest version — backfill the real hash and skip the update,
+      // closing the upgrade-from-old-build false-positive (Issue #84 / Story B).
+      // Archive models can't be hashed post-extract (the .tar.gz is gone), so
+      // they fall through to the standard update path; one accepted update will
+      // then write the real hash via executeUpdates and the issue resolves.
+      if (installed && installed.sha256 === '' && !definition.archive) {
+        const filePath = join(getModelsDir(), definition.relativePath)
+        if (existsSync(filePath)) {
+          const matches = await verifyFileSha256(filePath, manifestModel.sha256)
+          if (matches) {
+            installedVersions[manifestModel.id] = {
+              ...installed,
+              sha256: manifestModel.sha256
+            }
+            settings.set('installedModelVersions', installedVersions)
+            continue
+          }
+        }
+      }
+
       // Path-traversal guard on relativePath
       if (definition.relativePath.includes('..')) {
         console.warn(

--- a/src/main/services/UpdateCheckService.ts
+++ b/src/main/services/UpdateCheckService.ts
@@ -1,4 +1,4 @@
-import { app } from 'electron'
+import { app, BrowserWindow } from 'electron'
 import { existsSync, mkdirSync, readdirSync, renameSync, rmSync } from 'fs'
 import { join } from 'path'
 import { get as httpsGet } from 'https'
@@ -234,8 +234,31 @@ export async function checkForUpdates(): Promise<CheckResult> {
 
 // ─── triggerUpdateRestart ────────────────────────────────────────────────────
 
+/**
+ * Persists the pending updates and relaunches the app so the next boot picks
+ * them up via `getPending()` and renders ModelUpdateScreen.
+ *
+ * Dev-mode shim (Issue #84 follow-up): in `npm run dev`, `app.relaunch()`
+ * spawns a fresh electron pointed at `localhost:5173`, but the `app.quit()`
+ * that follows kills electron-vite's parent process — the dev server dies
+ * before the new electron can load anything, leaving a white window.
+ *
+ * In dev we instead reload the renderer in place. The renderer remounts,
+ * its startup `getPending()` call sees the freshly-written
+ * `pendingModelUpdates`, and ModelUpdateScreen appears — same observable
+ * UX as the production restart, without trashing the dev server. Main-
+ * process state (TaskQueue, etc.) is not actually reset, but for QA of
+ * the update flow the renderer remount is what's being exercised.
+ */
 export function triggerUpdateRestart(updates: PendingModelUpdate[]): void {
   getSettings().set('pendingModelUpdates', updates)
+
+  if (!app.isPackaged) {
+    const mainWindow = BrowserWindow.getAllWindows()[0]
+    mainWindow?.webContents.reload()
+    return
+  }
+
   app.relaunch()
   app.quit()
 }

--- a/src/main/services/UpdateCheckService.ts
+++ b/src/main/services/UpdateCheckService.ts
@@ -505,8 +505,25 @@ export function cleanupIncompleteUpdates(): void {
  * Story D — the per-channel guard means a freshly switched channel sees
  * its own (initially empty) view, even when other channels already have
  * entries; the disk files are reused in-place by the new channel.
+ *
+ * Boot-phase invariant: this MUST run after `initSettings` has applied the
+ * Story-D channel-tag migration. If we hit untagged keys in the raw record,
+ * the channel-aware adapter would silently filter them out (treating the
+ * channel view as empty) and write fresh `prod:`-prefixed sentinel rows
+ * alongside the legacy untagged ones — producing duplicate entries. Bailing
+ * loudly here surfaces the boot-order regression at the source rather than
+ * a few releases later as a mysterious manifest mismatch.
  */
 export function migrateInstalledVersions(): void {
+  const raw = getSettings().get('installedModelVersions') ?? {}
+  const untaggedKey = Object.keys(raw).find((k) => !k.includes(':'))
+  if (untaggedKey !== undefined) {
+    throw new Error(
+      `migrateInstalledVersions called before initSettings: untagged key "${untaggedKey}" present. ` +
+        'The Story-D channel-tag migration in initSettings must run first.'
+    )
+  }
+
   const installedVersions = getInstalledVersions()
   if (Object.keys(installedVersions).length > 0) return
 

--- a/src/main/services/__tests__/Channel.test.ts
+++ b/src/main/services/__tests__/Channel.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { CHANNELS, getChannel, _resetChannelCacheForTests } from '../Channel'
+
+const ENV_KEY = 'THERASCRIPT_CHANNEL'
+
+describe('Channel — Issue #84 Story D', () => {
+  let originalValue: string | undefined
+
+  beforeEach(() => {
+    originalValue = process.env[ENV_KEY]
+    _resetChannelCacheForTests()
+  })
+
+  afterEach(() => {
+    if (originalValue === undefined) {
+      delete process.env[ENV_KEY]
+    } else {
+      process.env[ENV_KEY] = originalValue
+    }
+    _resetChannelCacheForTests()
+  })
+
+  it('lists prod, staging, local as the supported channels', () => {
+    expect(CHANNELS).toEqual(['prod', 'staging', 'local'])
+  })
+
+  it('defaults to prod when the env var is unset', () => {
+    delete process.env[ENV_KEY]
+    expect(getChannel()).toBe('prod')
+  })
+
+  it('returns the env-supplied channel when valid', () => {
+    process.env[ENV_KEY] = 'staging'
+    expect(getChannel()).toBe('staging')
+
+    _resetChannelCacheForTests()
+    process.env[ENV_KEY] = 'local'
+    expect(getChannel()).toBe('local')
+  })
+
+  it('falls back to prod for unknown values', () => {
+    process.env[ENV_KEY] = 'mainnet'
+    expect(getChannel()).toBe('prod')
+  })
+
+  it('caches the resolved channel (env changes mid-process are ignored)', () => {
+    process.env[ENV_KEY] = 'staging'
+    expect(getChannel()).toBe('staging')
+
+    process.env[ENV_KEY] = 'local'
+    // Without _resetChannelCacheForTests, the cached value sticks.
+    expect(getChannel()).toBe('staging')
+  })
+})

--- a/src/main/services/__tests__/InstalledVersionsStore.test.ts
+++ b/src/main/services/__tests__/InstalledVersionsStore.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+const mockGet = vi.fn()
+const mockSet = vi.fn()
+vi.mock('../SettingsService', () => ({
+  getSettings: () => ({ get: mockGet, set: mockSet })
+}))
+
+const mockGetChannel = vi.fn()
+vi.mock('../Channel', () => ({
+  getChannel: () => mockGetChannel()
+}))
+
+// ─── Import after mocks ───────────────────────────────────────────────────────
+
+import {
+  deleteInstalledVersion,
+  getInstalledVersion,
+  getInstalledVersions,
+  replaceInstalledVersionsForChannel,
+  setInstalledVersion
+} from '../InstalledVersionsStore'
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+const SHA = (c: string): string => c.repeat(64)
+
+const sampleEntry = (sha: string): { version: string; sha256: string; installedAt: string } => ({
+  version: '2025-02-01',
+  sha256: sha,
+  installedAt: '2025-02-01T00:00:00.000Z'
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockGetChannel.mockReturnValue('prod')
+})
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('InstalledVersionsStore — Issue #84 Story D', () => {
+  it('getInstalledVersions returns only the active channel\'s entries', () => {
+    mockGet.mockReturnValue({
+      'prod:whisper-large-v3-turbo': sampleEntry(SHA('a')),
+      'staging:whisper-large-v3-turbo': sampleEntry(SHA('b')),
+      'local:flair-ner-german-large': sampleEntry(SHA('c'))
+    })
+
+    const result = getInstalledVersions()
+    expect(Object.keys(result)).toEqual(['whisper-large-v3-turbo'])
+    expect(result['whisper-large-v3-turbo'].sha256).toBe(SHA('a'))
+  })
+
+  it('getInstalledVersion looks up by plain modelId, scoped to active channel', () => {
+    mockGet.mockReturnValue({
+      'prod:flair-ner-german-large': sampleEntry(SHA('a')),
+      'staging:flair-ner-german-large': sampleEntry(SHA('b'))
+    })
+
+    expect(getInstalledVersion('flair-ner-german-large')?.sha256).toBe(SHA('a'))
+    expect(getInstalledVersion('unknown-id')).toBeNull()
+  })
+
+  it('setInstalledVersion writes the channel-prefixed key without touching other channels', () => {
+    mockGet.mockReturnValue({
+      'staging:whisper-large-v3-turbo': sampleEntry(SHA('b'))
+    })
+
+    setInstalledVersion('whisper-large-v3-turbo', sampleEntry(SHA('a')))
+
+    expect(mockSet).toHaveBeenCalledWith(
+      'installedModelVersions',
+      expect.objectContaining({
+        'prod:whisper-large-v3-turbo': sampleEntry(SHA('a')),
+        'staging:whisper-large-v3-turbo': sampleEntry(SHA('b'))
+      })
+    )
+  })
+
+  it('deleteInstalledVersion removes only the active channel\'s entry', () => {
+    mockGet.mockReturnValue({
+      'prod:flair-ner-german-large': sampleEntry(SHA('a')),
+      'staging:flair-ner-german-large': sampleEntry(SHA('b'))
+    })
+
+    deleteInstalledVersion('flair-ner-german-large')
+
+    const written = mockSet.mock.calls[0][1] as Record<string, unknown>
+    expect(written).toEqual({
+      'staging:flair-ner-german-large': sampleEntry(SHA('b'))
+    })
+  })
+
+  it('respects a non-prod channel for reads and writes', () => {
+    mockGetChannel.mockReturnValue('local')
+    mockGet.mockReturnValue({
+      'prod:whisper-large-v3-turbo': sampleEntry(SHA('a')),
+      'local:whisper-large-v3-turbo': sampleEntry(SHA('z'))
+    })
+
+    expect(getInstalledVersion('whisper-large-v3-turbo')?.sha256).toBe(SHA('z'))
+
+    setInstalledVersion('flair-ner-german-large', sampleEntry(SHA('q')))
+    expect(mockSet).toHaveBeenCalledWith(
+      'installedModelVersions',
+      expect.objectContaining({
+        'local:flair-ner-german-large': sampleEntry(SHA('q'))
+      })
+    )
+  })
+
+  it('coerces a corrupted top-level value to an empty record', () => {
+    mockGet.mockReturnValue(null)
+    expect(getInstalledVersions()).toEqual({})
+
+    mockGet.mockReturnValue('garbage')
+    expect(getInstalledVersions()).toEqual({})
+  })
+
+  it('replaceInstalledVersionsForChannel preserves entries from other channels', () => {
+    mockGet.mockReturnValue({
+      'prod:old-id-a': sampleEntry(SHA('a')),
+      'prod:old-id-b': sampleEntry(SHA('b')),
+      'staging:keep-me': sampleEntry(SHA('s'))
+    })
+
+    replaceInstalledVersionsForChannel({
+      'new-id': sampleEntry(SHA('n'))
+    })
+
+    expect(mockSet).toHaveBeenCalledWith('installedModelVersions', {
+      'staging:keep-me': sampleEntry(SHA('s')),
+      'prod:new-id': sampleEntry(SHA('n'))
+    })
+  })
+})

--- a/src/main/services/__tests__/ModelDownloadService.reconcile.test.ts
+++ b/src/main/services/__tests__/ModelDownloadService.reconcile.test.ts
@@ -1,0 +1,384 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock('electron', () => ({
+  app: { getPath: vi.fn().mockReturnValue('/tmp/therascript-test') },
+  BrowserWindow: { getAllWindows: vi.fn().mockReturnValue([]) }
+}))
+
+vi.mock('../../db/connection', () => ({
+  getDataDir: () => '/tmp/therascript-test'
+}))
+
+interface ActiveModels {
+  transcription: string | null
+  diarization: string | null
+  diarizationPipeline: string
+  ner: string | null
+  ocr: string
+  summarization: string | null
+}
+
+interface ReconcileEventEntry {
+  id: string
+  timestamp: string
+  group: string
+  fromModelId: string | null
+  toModelId: string | null
+  reason: string
+  status: 'pending' | 'seen'
+}
+
+interface InstalledMap {
+  [id: string]: { version: string; sha256: string; installedAt: string }
+}
+
+interface FakeStoreState {
+  activeModels: ActiveModels
+  modelsDownloaded: boolean
+  reconcileEvents: ReconcileEventEntry[]
+  installedModelVersions: InstalledMap
+}
+
+let storeState: FakeStoreState
+
+const mockSettingsStore = {
+  get: vi.fn((key: keyof FakeStoreState) => storeState[key]),
+  set: vi.fn(<K extends keyof FakeStoreState>(key: K, value: FakeStoreState[K]) => {
+    storeState = { ...storeState, [key]: value }
+  })
+}
+vi.mock('../SettingsService', () => ({
+  getSettings: () => mockSettingsStore,
+  initSettings: () => mockSettingsStore
+}))
+
+let installedFiles: Set<string>
+vi.mock('fs', () => {
+  const fsMock = {
+    existsSync: vi.fn((p: string) => installedFiles.has(p)),
+    mkdirSync: vi.fn(),
+    statSync: vi.fn(),
+    unlinkSync: vi.fn(),
+    rmSync: vi.fn()
+  }
+  return { ...fsMock, default: fsMock }
+})
+
+// Import after mocks — the SUT pulls in the catalog and wraps it in
+// `getModelsByGroup` filters; we don't need to stub the catalog because
+// MODEL_DEFINITIONS is already a real import that ships with the app.
+import {
+  reconcileActiveModels,
+  getReconcileEvents,
+  markReconcileEventsSeen,
+  dismissReconcileEvents,
+  recordInstalledVersion
+} from '../ModelDownloadService'
+
+const MODELS_DIR = '/tmp/therascript-test/models'
+
+function freshState(over: Partial<FakeStoreState> = {}): void {
+  storeState = {
+    activeModels: {
+      transcription: 'whisper-large-v3-turbo',
+      diarization: 'pyannote-suite',
+      diarizationPipeline: 'pyannote/speaker-diarization-3.1',
+      ner: 'flair-ner-german-large',
+      ocr: 'apple-vision',
+      summarization: 'gemma-summarization'
+    },
+    modelsDownloaded: true,
+    reconcileEvents: [],
+    installedModelVersions: {},
+    ...over
+  }
+  installedFiles = new Set()
+}
+
+function pretendInstalled(...checkPaths: string[]): void {
+  for (const p of checkPaths) {
+    installedFiles.add(`${MODELS_DIR}/${p}`)
+  }
+}
+
+describe('reconcileActiveModels', () => {
+  beforeEach(() => {
+    freshState()
+    vi.clearAllMocks()
+  })
+
+  it('is a no-op on truly-fresh installs (modelsDownloaded === false)', () => {
+    freshState({ modelsDownloaded: false })
+    pretendInstalled() // nothing installed
+
+    const repairs = reconcileActiveModels()
+
+    expect(repairs).toHaveLength(0)
+    expect(storeState.reconcileEvents).toHaveLength(0)
+    // active slots stay at the defaults — FirstLaunchScreen will gate.
+    expect(storeState.activeModels.transcription).toBe('whisper-large-v3-turbo')
+  })
+
+  it('keeps the steady state when every active model is installed', () => {
+    pretendInstalled(
+      'asr/ggml-large-v3-turbo-q5_0.bin',
+      'diarization/models--pyannote--speaker-diarization-community-1',
+      'ner/models/ner-german-large',
+      'summarization/google_gemma-3-4b-it-Q4_K_M.gguf'
+    )
+
+    const repairs = reconcileActiveModels()
+
+    expect(repairs).toHaveLength(0)
+    expect(storeState.reconcileEvents).toHaveLength(0)
+  })
+
+  it('clears an optional slot when its model file is missing on disk', () => {
+    pretendInstalled(
+      'asr/ggml-large-v3-turbo-q5_0.bin',
+      'diarization/models--pyannote--speaker-diarization-community-1',
+      'ner/models/ner-german-large'
+      // summarization NOT installed
+    )
+
+    const repairs = reconcileActiveModels()
+
+    expect(repairs).toEqual([
+      {
+        group: 'summarization',
+        fromModelId: 'gemma-summarization',
+        toModelId: null,
+        reason: 'group-cleared'
+      }
+    ])
+    expect(storeState.activeModels.summarization).toBeNull()
+    expect(storeState.reconcileEvents).toHaveLength(1)
+    expect(storeState.reconcileEvents[0]).toMatchObject({
+      group: 'summarization',
+      fromModelId: 'gemma-summarization',
+      toModelId: null,
+      reason: 'group-cleared',
+      status: 'pending'
+    })
+  })
+
+  it('emits no event when an optional slot was already null and stays null', () => {
+    freshState({
+      activeModels: {
+        transcription: 'whisper-large-v3-turbo',
+        diarization: 'pyannote-suite',
+        diarizationPipeline: 'pyannote/speaker-diarization-3.1',
+        ner: 'flair-ner-german-large',
+        ocr: 'apple-vision',
+        summarization: null
+      }
+    })
+    pretendInstalled(
+      'asr/ggml-large-v3-turbo-q5_0.bin',
+      'diarization/models--pyannote--speaker-diarization-community-1',
+      'ner/models/ner-german-large'
+    )
+
+    const repairs = reconcileActiveModels()
+
+    expect(repairs).toHaveLength(0)
+    expect(storeState.reconcileEvents).toHaveLength(0)
+  })
+
+  it('promotes the catalog default when an installed required slot points at a missing file', () => {
+    // ASR slot points at the swiss variant which is NOT installed; the
+    // multilingual default IS installed → promote it.
+    freshState({
+      activeModels: {
+        transcription: 'whisper-large-v3-turbo-swiss',
+        diarization: 'pyannote-suite',
+        diarizationPipeline: 'pyannote/speaker-diarization-3.1',
+        ner: 'flair-ner-german-large',
+        ocr: 'apple-vision',
+        summarization: null
+      }
+    })
+    pretendInstalled(
+      'asr/ggml-large-v3-turbo-q5_0.bin', // multi-lingual default
+      'diarization/models--pyannote--speaker-diarization-community-1',
+      'ner/models/ner-german-large'
+    )
+
+    const repairs = reconcileActiveModels()
+
+    expect(repairs).toEqual([
+      {
+        group: 'asr',
+        fromModelId: 'whisper-large-v3-turbo-swiss',
+        toModelId: 'whisper-large-v3-turbo',
+        reason: 'default-promoted'
+      }
+    ])
+    expect(storeState.activeModels.transcription).toBe('whisper-large-v3-turbo')
+  })
+
+  it('falls back to any installed group member when the catalog default itself is missing', () => {
+    // Only the swiss variant is installed; ASR slot points at the missing default.
+    freshState({
+      activeModels: {
+        transcription: 'whisper-large-v3-turbo',
+        diarization: 'pyannote-suite',
+        diarizationPipeline: 'pyannote/speaker-diarization-3.1',
+        ner: 'flair-ner-german-large',
+        ocr: 'apple-vision',
+        summarization: null
+      }
+    })
+    pretendInstalled(
+      'asr/ggml-large-v3-turbo-swiss-q5_0.bin', // only the swiss variant
+      'diarization/models--pyannote--speaker-diarization-community-1',
+      'ner/models/ner-german-large'
+    )
+
+    const repairs = reconcileActiveModels()
+
+    const asrRepair = repairs.find((r) => r.group === 'asr')
+    expect(asrRepair).toBeDefined()
+    expect(asrRepair?.toModelId).toBe('whisper-large-v3-turbo-swiss')
+    expect(asrRepair?.reason).toBe('default-promoted')
+    expect(storeState.activeModels.transcription).toBe('whisper-large-v3-turbo-swiss')
+  })
+
+  it('emits model-removed when no installed alternative exists for a required group', () => {
+    // ASR slot points at a model that is not installed and no other ASR is installed either.
+    freshState({
+      activeModels: {
+        transcription: 'whisper-large-v3-turbo',
+        diarization: 'pyannote-suite',
+        diarizationPipeline: 'pyannote/speaker-diarization-3.1',
+        ner: 'flair-ner-german-large',
+        ocr: 'apple-vision',
+        summarization: null
+      }
+    })
+    pretendInstalled(
+      'diarization/models--pyannote--speaker-diarization-community-1',
+      'ner/models/ner-german-large'
+    )
+
+    const repairs = reconcileActiveModels()
+
+    expect(repairs).toEqual([
+      {
+        group: 'asr',
+        fromModelId: 'whisper-large-v3-turbo',
+        toModelId: null,
+        reason: 'model-removed'
+      }
+    ])
+    expect(storeState.activeModels.transcription).toBeNull()
+  })
+})
+
+describe('reconcile event lifecycle', () => {
+  beforeEach(() => {
+    freshState()
+    vi.clearAllMocks()
+  })
+
+  it('markReconcileEventsSeen transitions all pending entries to seen', () => {
+    storeState.reconcileEvents = [
+      {
+        id: 'a',
+        timestamp: '2026-04-30T10:00:00Z',
+        group: 'asr',
+        fromModelId: 'old',
+        toModelId: null,
+        reason: 'model-removed',
+        status: 'pending'
+      },
+      {
+        id: 'b',
+        timestamp: '2026-04-30T10:00:01Z',
+        group: 'summarization',
+        fromModelId: 'gemma-summarization',
+        toModelId: null,
+        reason: 'group-cleared',
+        status: 'pending'
+      }
+    ]
+
+    const next = markReconcileEventsSeen()
+
+    expect(next.every((e) => e.status === 'seen')).toBe(true)
+    expect(storeState.reconcileEvents.every((e) => e.status === 'seen')).toBe(true)
+  })
+
+  it('markReconcileEventsSeen is a no-op when nothing is pending', () => {
+    storeState.reconcileEvents = [
+      {
+        id: 'a',
+        timestamp: '2026-04-30T10:00:00Z',
+        group: 'asr',
+        fromModelId: 'old',
+        toModelId: null,
+        reason: 'model-removed',
+        status: 'seen'
+      }
+    ]
+    const setBefore = mockSettingsStore.set.mock.calls.length
+    markReconcileEventsSeen()
+    expect(mockSettingsStore.set.mock.calls.length).toBe(setBefore)
+  })
+
+  it('dismissReconcileEvents wipes all events permanently', () => {
+    storeState.reconcileEvents = [
+      {
+        id: 'a',
+        timestamp: '2026-04-30T10:00:00Z',
+        group: 'asr',
+        fromModelId: 'old',
+        toModelId: null,
+        reason: 'model-removed',
+        status: 'seen'
+      }
+    ]
+
+    dismissReconcileEvents()
+
+    expect(storeState.reconcileEvents).toEqual([])
+    expect(getReconcileEvents()).toEqual([])
+  })
+})
+
+describe('recordInstalledVersion', () => {
+  beforeEach(() => {
+    freshState()
+    vi.clearAllMocks()
+  })
+
+  it('writes {version: installed, sha256, installedAt} for the given id', () => {
+    recordInstalledVersion('whisper-large-v3-turbo', 'abc123')
+
+    expect(storeState.installedModelVersions['whisper-large-v3-turbo']).toBeDefined()
+    expect(storeState.installedModelVersions['whisper-large-v3-turbo'].version).toBe('installed')
+    expect(storeState.installedModelVersions['whisper-large-v3-turbo'].sha256).toBe('abc123')
+    expect(storeState.installedModelVersions['whisper-large-v3-turbo'].installedAt).toMatch(
+      /\d{4}-\d{2}-\d{2}T/
+    )
+  })
+
+  it('preserves existing entries for other ids', () => {
+    storeState.installedModelVersions['flair-ner-german-large'] = {
+      version: 'pre-update',
+      sha256: 'def456',
+      installedAt: '2026-01-01T00:00:00Z'
+    }
+
+    recordInstalledVersion('whisper-large-v3-turbo', 'abc123')
+
+    expect(storeState.installedModelVersions['flair-ner-german-large']).toEqual({
+      version: 'pre-update',
+      sha256: 'def456',
+      installedAt: '2026-01-01T00:00:00Z'
+    })
+    expect(storeState.installedModelVersions['whisper-large-v3-turbo'].sha256).toBe('abc123')
+  })
+})

--- a/src/main/services/__tests__/ModelDownloadService.reconcile.test.ts
+++ b/src/main/services/__tests__/ModelDownloadService.reconcile.test.ts
@@ -354,19 +354,21 @@ describe('recordInstalledVersion', () => {
     vi.clearAllMocks()
   })
 
+  // Issue #84 Story D — keys are now `${channel}:${modelId}` so the
+  // active-channel adapter can isolate per-channel install records.
+  // Tests run with the default `prod` channel (no env override).
   it('writes {version: installed, sha256, installedAt} for the given id', () => {
     recordInstalledVersion('whisper-large-v3-turbo', 'abc123')
 
-    expect(storeState.installedModelVersions['whisper-large-v3-turbo']).toBeDefined()
-    expect(storeState.installedModelVersions['whisper-large-v3-turbo'].version).toBe('installed')
-    expect(storeState.installedModelVersions['whisper-large-v3-turbo'].sha256).toBe('abc123')
-    expect(storeState.installedModelVersions['whisper-large-v3-turbo'].installedAt).toMatch(
-      /\d{4}-\d{2}-\d{2}T/
-    )
+    const entry = storeState.installedModelVersions['prod:whisper-large-v3-turbo']
+    expect(entry).toBeDefined()
+    expect(entry.version).toBe('installed')
+    expect(entry.sha256).toBe('abc123')
+    expect(entry.installedAt).toMatch(/\d{4}-\d{2}-\d{2}T/)
   })
 
   it('preserves existing entries for other ids', () => {
-    storeState.installedModelVersions['flair-ner-german-large'] = {
+    storeState.installedModelVersions['prod:flair-ner-german-large'] = {
       version: 'pre-update',
       sha256: 'def456',
       installedAt: '2026-01-01T00:00:00Z'
@@ -374,11 +376,11 @@ describe('recordInstalledVersion', () => {
 
     recordInstalledVersion('whisper-large-v3-turbo', 'abc123')
 
-    expect(storeState.installedModelVersions['flair-ner-german-large']).toEqual({
+    expect(storeState.installedModelVersions['prod:flair-ner-german-large']).toEqual({
       version: 'pre-update',
       sha256: 'def456',
       installedAt: '2026-01-01T00:00:00Z'
     })
-    expect(storeState.installedModelVersions['whisper-large-v3-turbo'].sha256).toBe('abc123')
+    expect(storeState.installedModelVersions['prod:whisper-large-v3-turbo'].sha256).toBe('abc123')
   })
 })

--- a/src/main/services/__tests__/ModelDownloadService.reconcile.test.ts
+++ b/src/main/services/__tests__/ModelDownloadService.reconcile.test.ts
@@ -74,7 +74,9 @@ import {
   getReconcileEvents,
   markReconcileEventsSeen,
   dismissReconcileEvents,
-  recordInstalledVersion
+  recordInstalledVersion,
+  getActiveModelId,
+  getActiveModelIdBelief
 } from '../ModelDownloadService'
 
 const MODELS_DIR = '/tmp/therascript-test/models'
@@ -382,5 +384,41 @@ describe('recordInstalledVersion', () => {
       installedAt: '2026-01-01T00:00:00Z'
     })
     expect(storeState.installedModelVersions['prod:whisper-large-v3-turbo'].sha256).toBe('abc123')
+  })
+})
+
+// Issue #84 Story E follow-up — getActiveModelIdBelief returns the raw
+// settings value without the disk-presence check, so the Settings catalog
+// can expose the inconsistent state (active=true, installed=false) via the
+// <ModelStatusBadge>. Executors keep using getActiveModelId (the filtered
+// variant) — verified here too.
+describe('getActiveModelIdBelief vs getActiveModelId', () => {
+  beforeEach(() => {
+    freshState()
+    vi.clearAllMocks()
+  })
+
+  it('belief returns the raw settings value even when the file is missing', () => {
+    // No pretendInstalled() — every checkPath misses on disk.
+    expect(getActiveModelIdBelief('asr')).toBe('whisper-large-v3-turbo')
+    expect(getActiveModelIdBelief('diarization')).toBe('pyannote-suite')
+    expect(getActiveModelIdBelief('ner')).toBe('flair-ner-german-large')
+  })
+
+  it('the disk-checked variant masks the same state as null', () => {
+    expect(getActiveModelId('asr')).toBeNull()
+    expect(getActiveModelId('diarization')).toBeNull()
+    expect(getActiveModelId('ner')).toBeNull()
+  })
+
+  it('belief returns null when the slot is null (post-reconciler steady state)', () => {
+    storeState.activeModels.summarization = null
+    expect(getActiveModelIdBelief('summarization')).toBeNull()
+  })
+
+  it('both return the same id when the file is on disk', () => {
+    pretendInstalled('asr/ggml-large-v3-turbo-q5_0.bin')
+    expect(getActiveModelIdBelief('asr')).toBe('whisper-large-v3-turbo')
+    expect(getActiveModelId('asr')).toBe('whisper-large-v3-turbo')
   })
 })

--- a/src/main/services/__tests__/ModelDownloadService.test.ts
+++ b/src/main/services/__tests__/ModelDownloadService.test.ts
@@ -31,16 +31,25 @@ vi.mock('../SettingsService', () => ({
   initSettings: () => mockSettingsStore
 }))
 
+const mockMkdirSync = vi.fn()
 vi.mock('fs', () => {
   const fsMock = {
     existsSync: vi.fn().mockReturnValue(false),
-    mkdirSync: vi.fn(),
+    mkdirSync: (...a: unknown[]) => mockMkdirSync(...a),
     statSync: vi.fn(),
     unlinkSync: vi.fn(),
     rmSync: vi.fn()
   }
   return { ...fsMock, default: fsMock }
 })
+
+const mockDownloadFile = vi.fn()
+const mockVerifyFileSha256 = vi.fn()
+vi.mock('../DownloadService', () => ({
+  downloadFile: (...a: unknown[]) => mockDownloadFile(...a),
+  verifyFileSha256: (...a: unknown[]) => mockVerifyFileSha256(...a),
+  extractTarGz: vi.fn()
+}))
 
 // Import after mocks
 import {
@@ -107,6 +116,30 @@ describe('downloadSingleModel', () => {
     await expect(downloadSingleModel('flair-ner-german-large')).rejects.toThrow(
       /Pflicht-Modell/i
     )
+  })
+
+  // Issue #84 follow-up — required-group dirs (asr/diarization/ner) are
+  // bootstrapped at startup by initDatabase, but optional groups
+  // (summarization, …) are not. The first download for an optional group
+  // lands in a parent that does not exist yet; the entry point owns the
+  // parent. This test pins the contract: mkdirSync(parent) must run before
+  // downloadFile() opens the .partial file for write.
+  it('creates the target parent directory before invoking downloadFile (optional group)', async () => {
+    mockMkdirSync.mockClear()
+    mockDownloadFile.mockClear()
+    mockDownloadFile.mockResolvedValue({ success: true })
+    mockVerifyFileSha256.mockResolvedValue(true)
+
+    await downloadSingleModel('gemma-summarization')
+
+    expect(mockMkdirSync).toHaveBeenCalledWith(
+      expect.stringContaining('/models/summarization'),
+      { recursive: true }
+    )
+    // Order: mkdirSync ran before downloadFile.
+    const mkdirInvocation = mockMkdirSync.mock.invocationCallOrder[0]
+    const downloadInvocation = mockDownloadFile.mock.invocationCallOrder[0]
+    expect(mkdirInvocation).toBeLessThan(downloadInvocation)
   })
 })
 

--- a/src/main/services/__tests__/ProvenanceCapture.test.ts
+++ b/src/main/services/__tests__/ProvenanceCapture.test.ts
@@ -44,11 +44,12 @@ describe('captureProcessedModels', () => {
       sha256: SHA('a'),
       sizeBytes: 100
     }))
+    // Issue #84 Story D — keys are channel-prefixed; default test env = prod.
     mockSettingsGet.mockReturnValue({
-      'whisper-large-v3-turbo': { version: '2025-02-01', sha256: SHA('a'), installedAt: '' },
-      'pyannote-suite': { version: '2025-03-12', sha256: SHA('a'), installedAt: '' },
-      'flair-ner-german-large': { version: '2025-02-08', sha256: SHA('a'), installedAt: '' },
-      'gemma-summarization': { version: '2025-04-01', sha256: SHA('a'), installedAt: '' }
+      'prod:whisper-large-v3-turbo': { version: '2025-02-01', sha256: SHA('a'), installedAt: '' },
+      'prod:pyannote-suite': { version: '2025-03-12', sha256: SHA('a'), installedAt: '' },
+      'prod:flair-ner-german-large': { version: '2025-02-08', sha256: SHA('a'), installedAt: '' },
+      'prod:gemma-summarization': { version: '2025-04-01', sha256: SHA('a'), installedAt: '' }
     })
 
     const snap = captureProcessedModels([

--- a/src/main/services/__tests__/ProvenanceCapture.test.ts
+++ b/src/main/services/__tests__/ProvenanceCapture.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+const mockGetActiveModelId = vi.fn()
+const mockGetModelById = vi.fn()
+vi.mock('../ModelDownloadService', () => ({
+  getActiveModelId: (...a: unknown[]) => mockGetActiveModelId(...a),
+  getModelById: (...a: unknown[]) => mockGetModelById(...a)
+}))
+
+const mockSettingsGet = vi.fn()
+vi.mock('../SettingsService', () => ({
+  getSettings: () => ({ get: (...a: unknown[]) => mockSettingsGet(...a) })
+}))
+
+// ─── Import after mocks ───────────────────────────────────────────────────────
+
+import { captureProcessedModels } from '../ProvenanceCapture'
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const SHA = (c: string): string => c.repeat(64)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  // By default, settings has no installedModelVersions yet — every snapshot
+  // falls back to version='unknown'. Tests override per case.
+  mockSettingsGet.mockReturnValue({})
+})
+
+describe('captureProcessedModels', () => {
+  it('snapshots active models for every step in plannedSteps', () => {
+    mockGetActiveModelId.mockImplementation((group: string) => {
+      if (group === 'asr') return 'whisper-large-v3-turbo'
+      if (group === 'diarization') return 'pyannote-suite'
+      if (group === 'ner') return 'flair-ner-german-large'
+      if (group === 'summarization') return 'gemma-summarization'
+      return null
+    })
+    mockGetModelById.mockImplementation((id: string) => ({
+      id,
+      label: `Label ${id}`,
+      sha256: SHA('a'),
+      sizeBytes: 100
+    }))
+    mockSettingsGet.mockReturnValue({
+      'whisper-large-v3-turbo': { version: '2025-02-01', sha256: SHA('a'), installedAt: '' },
+      'pyannote-suite': { version: '2025-03-12', sha256: SHA('a'), installedAt: '' },
+      'flair-ner-german-large': { version: '2025-02-08', sha256: SHA('a'), installedAt: '' },
+      'gemma-summarization': { version: '2025-04-01', sha256: SHA('a'), installedAt: '' }
+    })
+
+    const snap = captureProcessedModels([
+      'diarization',
+      'transcription',
+      'alignment',
+      'anonymization',
+      'summarization'
+    ])
+
+    expect(snap.asr?.id).toBe('whisper-large-v3-turbo')
+    expect(snap.asr?.version).toBe('2025-02-01')
+    expect(snap.asr?.sizeBytes).toBe(100)
+    expect(snap.diarization?.id).toBe('pyannote-suite')
+    expect(snap.ner?.id).toBe('flair-ner-german-large')
+    expect(snap.summarization?.id).toBe('gemma-summarization')
+    expect(snap.capturedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+  })
+
+  it('returns null per group when the step is not in plannedSteps', () => {
+    // PDF pipeline: only extraction → ocr → anonymization → summarization;
+    // no transcription, no diarization.
+    mockGetActiveModelId.mockReturnValue('flair-ner-german-large')
+    mockGetModelById.mockReturnValue({
+      id: 'flair-ner-german-large',
+      label: 'flair NER',
+      sha256: SHA('b'),
+      sizeBytes: 200
+    })
+
+    const snap = captureProcessedModels(['extraction', 'ocr', 'anonymization'])
+
+    expect(snap.asr).toBeNull()
+    expect(snap.diarization).toBeNull()
+    expect(snap.summarization).toBeNull()
+    expect(snap.ner?.id).toBe('flair-ner-german-large')
+  })
+
+  it('returns null for a group whose active model id is null (defensive)', () => {
+    // Reconciler may have cleared the slot mid-flight; capture gracefully.
+    mockGetActiveModelId.mockReturnValue(null)
+    const snap = captureProcessedModels([
+      'diarization',
+      'transcription',
+      'anonymization',
+      'summarization'
+    ])
+    expect(snap.asr).toBeNull()
+    expect(snap.diarization).toBeNull()
+    expect(snap.ner).toBeNull()
+    expect(snap.summarization).toBeNull()
+  })
+
+  it('falls back to version="unknown" when installedModelVersions has no entry', () => {
+    mockGetActiveModelId.mockReturnValue('whisper-large-v3-turbo')
+    mockGetModelById.mockReturnValue({
+      id: 'whisper-large-v3-turbo',
+      label: 'Whisper',
+      sha256: SHA('a'),
+      sizeBytes: 100
+    })
+    mockSettingsGet.mockReturnValue({}) // no record
+
+    const snap = captureProcessedModels(['transcription'])
+    expect(snap.asr?.version).toBe('unknown')
+  })
+})

--- a/src/main/services/__tests__/SettingsService.test.ts
+++ b/src/main/services/__tests__/SettingsService.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+interface ActiveModels {
+  transcription: string | null
+  diarization: string | null
+  diarizationPipeline: string
+  ner: string | null
+  ocr: string
+  summarization: string | null
+}
+
+interface FakeStoreState {
+  activeModels: ActiveModels
+  reconcileEvents: unknown[]
+  dismissedManifestVersions: unknown[]
+  installedModelVersions: Record<string, unknown>
+}
+
+let storeState: FakeStoreState
+
+// electron-store constructor is called inside initSettings; mock it to read
+// from / write to the fake state above so the test can introspect post-init.
+vi.mock('electron-store', () => {
+  return {
+    default: class MockStore {
+      get<K extends keyof FakeStoreState>(key: K): FakeStoreState[K] {
+        return storeState[key]
+      }
+      set<K extends keyof FakeStoreState>(key: K, value: FakeStoreState[K]): void {
+        storeState = { ...storeState, [key]: value }
+      }
+    }
+  }
+})
+
+// initSettings reads getModelDefinitions for the known-id sets; let it use
+// the real catalog (deterministic, no env required).
+
+// ─── Import after mocks ───────────────────────────────────────────────────────
+
+import { initSettings, _resetSettingsForTests } from '../SettingsService'
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function freshState(over: Partial<FakeStoreState> = {}): void {
+  storeState = {
+    activeModels: {
+      transcription: 'whisper-large-v3-turbo',
+      diarization: 'pyannote-suite',
+      diarizationPipeline: 'pyannote/speaker-diarization-3.1',
+      ner: 'flair-ner-german-large',
+      ocr: 'apple-vision',
+      summarization: 'gemma-summarization'
+    },
+    reconcileEvents: [],
+    dismissedManifestVersions: [],
+    installedModelVersions: {},
+    ...over
+  }
+}
+
+beforeEach(() => {
+  freshState()
+  _resetSettingsForTests()
+  vi.clearAllMocks()
+})
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('initSettings — Issue #84 boot-loop regression guard', () => {
+  it('preserves a null ner slot (post-reconciler state) instead of resetting it', () => {
+    // Reconciler from the previous boot cleared ner because the model file
+    // was missing. A naive "unknown value → reset" guard would now overwrite
+    // null with the catalog default, only to have the reconciler clear it
+    // again on the next launch — emitting a fresh ReconcileEvent every boot.
+    freshState({
+      activeModels: {
+        transcription: 'whisper-large-v3-turbo',
+        diarization: 'pyannote-suite',
+        diarizationPipeline: 'pyannote/speaker-diarization-3.1',
+        ner: null,
+        ocr: 'apple-vision',
+        summarization: 'gemma-summarization'
+      }
+    })
+
+    initSettings()
+
+    expect(storeState.activeModels.ner).toBeNull()
+  })
+
+  it('preserves a null diarization slot (Story C invariant, regression guard)', () => {
+    freshState({
+      activeModels: {
+        transcription: 'whisper-large-v3-turbo',
+        diarization: null,
+        diarizationPipeline: 'pyannote/speaker-diarization-3.1',
+        ner: 'flair-ner-german-large',
+        ocr: 'apple-vision',
+        summarization: 'gemma-summarization'
+      }
+    })
+
+    initSettings()
+
+    expect(storeState.activeModels.diarization).toBeNull()
+  })
+
+  it('still resets a truly unknown ner string back to the catalog default', () => {
+    freshState({
+      activeModels: {
+        transcription: 'whisper-large-v3-turbo',
+        diarization: 'pyannote-suite',
+        diarizationPipeline: 'pyannote/speaker-diarization-3.1',
+        // Legacy ID from a reverted multi-backend iteration; the migration
+        // SHOULD reset this so AnonymizationService does not abort.
+        ner: 'ai4privacy/gliner',
+        ocr: 'apple-vision',
+        summarization: 'gemma-summarization'
+      }
+    })
+
+    initSettings()
+
+    expect(storeState.activeModels.ner).toBe('flair-ner-german-large')
+  })
+})

--- a/src/main/services/__tests__/TaskQueueService.deletePath.test.ts
+++ b/src/main/services/__tests__/TaskQueueService.deletePath.test.ts
@@ -10,6 +10,13 @@ vi.mock('../../utils/ipc-helpers', () => ({
   sendToRenderer: vi.fn()
 }))
 
+// Issue #84 / Story C — computePlannedSteps reads getActiveModelId which
+// reaches into electron-store; mock it so this test doesn't have to init
+// the real settings layer.
+vi.mock('../ModelDownloadService', () => ({
+  getActiveModelId: vi.fn().mockReturnValue(null)
+}))
+
 /**
  * Issue #80 DR-6: deletePath verification.
  * Four contracts:

--- a/src/main/services/__tests__/TaskQueueService.enqueueInvariant.test.ts
+++ b/src/main/services/__tests__/TaskQueueService.enqueueInvariant.test.ts
@@ -10,7 +10,22 @@ vi.mock('../../utils/ipc-helpers', () => ({
 }))
 
 vi.mock('../ModelDownloadService', () => ({
-  getActiveModelId: vi.fn()
+  getActiveModelId: vi.fn(),
+  // Issue #84 Story I — ProvenanceCapture (called from enqueuePipeline)
+  // resolves the active id to a catalog entry. Stub a minimal shape so the
+  // capture path doesn't NPE; provenance content is not asserted here.
+  getModelById: vi.fn().mockReturnValue({
+    id: 'stub',
+    label: 'Stub',
+    sha256: '0'.repeat(64),
+    sizeBytes: 0
+  })
+}))
+
+// ProvenanceCapture also reads installedModelVersions from electron-store;
+// tests don't init settings, so stub the module entirely.
+vi.mock('../SettingsService', () => ({
+  getSettings: () => ({ get: () => ({}) })
 }))
 
 import { getActiveModelId } from '../ModelDownloadService'

--- a/src/main/services/__tests__/TaskQueueService.enqueueInvariant.test.ts
+++ b/src/main/services/__tests__/TaskQueueService.enqueueInvariant.test.ts
@@ -94,21 +94,20 @@ describe('TaskQueueService — enqueue + plannedSteps invariant', () => {
       expect(sessionRepo.findById(session.id)?.plannedSteps).toContain('summarization')
     })
 
-    it('omits ocr when pdfHasScannedPages is false (text-only PDF)', () => {
+    it('always includes ocr for PDF — executor self-skips when no scanned pages', () => {
       const session = sessionRepo.create({ title: 'T', type: 'pdf', status: 'queued' })
       sessionRepo.update(session.id, { pdfHasScannedPages: false })
       queue.enqueuePipeline(session.id, 'pdf')
 
       const tasks = taskRepo.findBySession(session.id)
       const types = tasks.map((t) => t.type)
-      expect(types).toEqual(['extraction', 'anonymization'])
-      expect(types).not.toContain('ocr')
+      expect(types).toEqual(['extraction', 'ocr', 'anonymization'])
 
       const reloaded = sessionRepo.findById(session.id)
-      expect(reloaded?.plannedSteps).toEqual(['extraction', 'anonymization'])
+      expect(reloaded?.plannedSteps).toEqual(['extraction', 'ocr', 'anonymization'])
     })
 
-    it('includes ocr when pdfHasScannedPages is true', () => {
+    it('includes ocr regardless of pdfHasScannedPages flag', () => {
       const session = sessionRepo.create({ title: 'T', type: 'pdf', status: 'queued' })
       sessionRepo.update(session.id, { pdfHasScannedPages: true })
       queue.enqueuePipeline(session.id, 'pdf')
@@ -132,9 +131,10 @@ describe('TaskQueueService — enqueue + plannedSteps invariant', () => {
   })
 
   describe('retrySession', () => {
-    it('honours frozen plannedSteps — text-only PDF does not re-add ocr on retry', () => {
-      // Arrange: simulate original run's frozen state. Text-only PDF without
-      // summarization → plannedSteps = [extraction, anonymization].
+    it('honours frozen plannedSteps on retry — even legacy plans without ocr', () => {
+      // Arrange: simulate a pre-fix session whose frozen plan omitted ocr.
+      // Retry must replay exactly what was frozen, not the new always-include-ocr
+      // default — that's the whole point of freezing plannedSteps.
       const session = sessionRepo.create({ title: 'T', type: 'pdf', status: 'queued' })
       sessionRepo.update(session.id, {
         pdfHasScannedPages: false,
@@ -148,9 +148,8 @@ describe('TaskQueueService — enqueue + plannedSteps invariant', () => {
       // Act
       queue.retrySession(session.id)
 
-      // Assert: no ocr / summarization re-introduced.
+      // Assert: frozen plan is replayed verbatim.
       const types = taskRepo.findBySession(session.id).map((t) => t.type)
-      expect(types).not.toContain('ocr')
       expect(types).not.toContain('summarization')
       expect(types).toEqual(['extraction', 'anonymization'])
     })

--- a/src/main/services/__tests__/TaskQueueService.enqueueInvariant.test.ts
+++ b/src/main/services/__tests__/TaskQueueService.enqueueInvariant.test.ts
@@ -10,11 +10,10 @@ vi.mock('../../utils/ipc-helpers', () => ({
 }))
 
 vi.mock('../ModelDownloadService', () => ({
-  getActiveModelId: vi.fn(),
-  isModelInstalled: vi.fn()
+  getActiveModelId: vi.fn()
 }))
 
-import { getActiveModelId, isModelInstalled } from '../ModelDownloadService'
+import { getActiveModelId } from '../ModelDownloadService'
 
 /**
  * Issue #80 invariant: enqueuePipeline + retrySession must enqueue exactly
@@ -31,9 +30,11 @@ describe('TaskQueueService — enqueue + plannedSteps invariant', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-    // Default: no summarization model active. Tests opt in by overriding mocks.
-    vi.mocked(getActiveModelId).mockReturnValue('')
-    vi.mocked(isModelInstalled).mockReturnValue(false)
+    // Default: no summarization model active. Issue #84 / Story C — getActiveModelId
+    // does the disk-presence check internally and returns null on
+    // missing-or-not-installed; tests opt into "model active" by returning a
+    // non-null id from the mock.
+    vi.mocked(getActiveModelId).mockReturnValue(null)
     db = new Database(':memory:')
     db.pragma('foreign_keys = ON')
     applyTestSchema(db)
@@ -69,7 +70,6 @@ describe('TaskQueueService — enqueue + plannedSteps invariant', () => {
 
     it('includes summarization when an LLM model is active AND installed', () => {
       vi.mocked(getActiveModelId).mockReturnValue('gemma-3-4b')
-      vi.mocked(isModelInstalled).mockReturnValue(true)
       const session = sessionRepo.create({ title: 'T', type: 'audio', status: 'queued' })
       queue.enqueuePipeline(session.id, 'audio')
 

--- a/src/main/services/__tests__/TaskQueueService.plannedSteps.test.ts
+++ b/src/main/services/__tests__/TaskQueueService.plannedSteps.test.ts
@@ -78,22 +78,20 @@ describe('computePlannedSteps — Issue #80 Phase H', () => {
   })
 
   describe('pdf sessions', () => {
-    it('returns extraction → anonymization without OCR or summarization by default', () => {
+    it('always includes OCR — independent of pdfHasScannedPages (executor self-skips)', () => {
       const session = makeSession({ type: 'pdf' })
-      expect(computePlannedSteps(session)).toEqual(['extraction', 'anonymization'])
+      expect(computePlannedSteps(session)).toEqual(['extraction', 'ocr', 'anonymization'])
     })
 
-    it('includes OCR when pdfHasScannedPages === true', () => {
-      // pdfHasScannedPages is added by Phase G's migration 013; cast for now.
+    it('still includes OCR when pdfHasScannedPages === true', () => {
       const session = makeSession({ type: 'pdf' }) as Session & { pdfHasScannedPages?: boolean }
       session.pdfHasScannedPages = true
       expect(computePlannedSteps(session)).toEqual(['extraction', 'ocr', 'anonymization'])
     })
 
-    it('includes both OCR and summarization when conditions are met', () => {
+    it('includes summarization when an LLM model is active', () => {
       vi.mocked(getActiveModelId).mockReturnValue('gemma-3-4b')
-      const session = makeSession({ type: 'pdf' }) as Session & { pdfHasScannedPages?: boolean }
-      session.pdfHasScannedPages = true
+      const session = makeSession({ type: 'pdf' })
       expect(computePlannedSteps(session)).toEqual([
         'extraction',
         'ocr',

--- a/src/main/services/__tests__/TaskQueueService.plannedSteps.test.ts
+++ b/src/main/services/__tests__/TaskQueueService.plannedSteps.test.ts
@@ -33,6 +33,7 @@ function makeSession(overrides: Partial<Session> = {}): Session {
     plannedSteps: null,
     retryCount: 0,
     pdfHasScannedPages: null,
+    processedWithModels: null,
     ...overrides
   }
 }

--- a/src/main/services/__tests__/TaskQueueService.plannedSteps.test.ts
+++ b/src/main/services/__tests__/TaskQueueService.plannedSteps.test.ts
@@ -3,11 +3,10 @@ import { computePlannedSteps } from '../TaskQueueService'
 import type { Session } from '../../../shared/types'
 
 vi.mock('../ModelDownloadService', () => ({
-  getActiveModelId: vi.fn(),
-  isModelInstalled: vi.fn()
+  getActiveModelId: vi.fn()
 }))
 
-import { getActiveModelId, isModelInstalled } from '../ModelDownloadService'
+import { getActiveModelId } from '../ModelDownloadService'
 
 function makeSession(overrides: Partial<Session> = {}): Session {
   return {
@@ -38,10 +37,13 @@ function makeSession(overrides: Partial<Session> = {}): Session {
   }
 }
 
+// Issue #84 / Story C — getActiveModelId now does the disk-presence check
+// internally and returns null on missing-or-unknown-or-not-installed. The
+// computePlannedSteps test bed therefore only needs to mock
+// getActiveModelId; isModelInstalled no longer participates in the decision.
 describe('computePlannedSteps — Issue #80 Phase H', () => {
   beforeEach(() => {
-    vi.mocked(getActiveModelId).mockReturnValue('')
-    vi.mocked(isModelInstalled).mockReturnValue(false)
+    vi.mocked(getActiveModelId).mockReturnValue(null)
   })
 
   describe('audio sessions', () => {
@@ -57,7 +59,6 @@ describe('computePlannedSteps — Issue #80 Phase H', () => {
 
     it('includes summarization when a model is active AND installed', () => {
       vi.mocked(getActiveModelId).mockReturnValue('gemma-3-4b')
-      vi.mocked(isModelInstalled).mockReturnValue(true)
       const session = makeSession({ type: 'audio' })
       expect(computePlannedSteps(session)).toEqual([
         'diarization',
@@ -68,17 +69,8 @@ describe('computePlannedSteps — Issue #80 Phase H', () => {
       ])
     })
 
-    it('omits summarization when configured id points to a non-installed model', () => {
-      vi.mocked(getActiveModelId).mockReturnValue('gemma-3-4b')
-      vi.mocked(isModelInstalled).mockReturnValue(false)
-      const session = makeSession({ type: 'audio' })
-      expect(computePlannedSteps(session)).not.toContain('summarization')
-    })
-
-    it('omits summarization when getActiveModelId throws', () => {
-      vi.mocked(getActiveModelId).mockImplementation(() => {
-        throw new Error('settings store unavailable')
-      })
+    it('omits summarization when getActiveModelId returns null (slot empty or file missing)', () => {
+      vi.mocked(getActiveModelId).mockReturnValue(null)
       const session = makeSession({ type: 'audio' })
       expect(computePlannedSteps(session)).not.toContain('summarization')
     })
@@ -99,7 +91,6 @@ describe('computePlannedSteps — Issue #80 Phase H', () => {
 
     it('includes both OCR and summarization when conditions are met', () => {
       vi.mocked(getActiveModelId).mockReturnValue('gemma-3-4b')
-      vi.mocked(isModelInstalled).mockReturnValue(true)
       const session = makeSession({ type: 'pdf' }) as Session & { pdfHasScannedPages?: boolean }
       session.pdfHasScannedPages = true
       expect(computePlannedSteps(session)).toEqual([

--- a/src/main/services/__tests__/TaskQueueService.test.ts
+++ b/src/main/services/__tests__/TaskQueueService.test.ts
@@ -90,8 +90,6 @@ describe('TaskQueueService', () => {
         title: 'PDF Test',
         type: 'pdf'
       })
-      // Force OCR into plannedSteps; default pdfHasScannedPages is null/false.
-      sessionRepo.update(pdfSession.id, { pdfHasScannedPages: true })
 
       const tasks = queue.enqueuePipeline(pdfSession.id, 'pdf')
 

--- a/src/main/services/__tests__/TaskQueueService.test.ts
+++ b/src/main/services/__tests__/TaskQueueService.test.ts
@@ -16,8 +16,7 @@ vi.mock('../../utils/ipc-helpers', () => ({
 // 4 PDF steps); mock ModelDownloadService so the summarization step survives
 // the filter. PDF sessions also need pdfHasScannedPages=true to include ocr.
 vi.mock('../ModelDownloadService', () => ({
-  getActiveModelId: vi.fn().mockReturnValue('gemma-3-4b'),
-  isModelInstalled: vi.fn().mockReturnValue(true)
+  getActiveModelId: vi.fn().mockReturnValue('gemma-3-4b')
 }))
 
 describe('TaskQueueService', () => {

--- a/src/main/services/__tests__/TaskQueueService.test.ts
+++ b/src/main/services/__tests__/TaskQueueService.test.ts
@@ -16,7 +16,23 @@ vi.mock('../../utils/ipc-helpers', () => ({
 // 4 PDF steps); mock ModelDownloadService so the summarization step survives
 // the filter. PDF sessions also need pdfHasScannedPages=true to include ocr.
 vi.mock('../ModelDownloadService', () => ({
-  getActiveModelId: vi.fn().mockReturnValue('gemma-3-4b')
+  getActiveModelId: vi.fn().mockReturnValue('gemma-3-4b'),
+  // Issue #84 Story I — ProvenanceCapture (called from enqueuePipeline)
+  // resolves the active id to a catalog entry. Stub a minimal shape so the
+  // capture path doesn't NPE in tests; the snapshot itself is irrelevant
+  // for the assertions below.
+  getModelById: vi.fn().mockReturnValue({
+    id: 'stub',
+    label: 'Stub',
+    sha256: '0'.repeat(64),
+    sizeBytes: 0
+  })
+}))
+
+// ProvenanceCapture also reads installedModelVersions from electron-store;
+// tests don't init settings, so stub the module entirely.
+vi.mock('../SettingsService', () => ({
+  getSettings: () => ({ get: () => ({}) })
 }))
 
 describe('TaskQueueService', () => {

--- a/src/main/services/__tests__/UpdateCheckService.test.ts
+++ b/src/main/services/__tests__/UpdateCheckService.test.ts
@@ -657,6 +657,26 @@ describe('migrateInstalledVersions', () => {
 
     expect(mockSettingsStore.set).not.toHaveBeenCalled()
   })
+
+  it('throws clearly if untagged keys are still present (boot-order invariant)', () => {
+    // Simulates initSettings's channel-tag migration not having run yet —
+    // for example because someone reordered main/index.ts and called
+    // migrateInstalledVersions before initSettings. Without this guard the
+    // function would silently filter the untagged keys out via the
+    // channel-aware adapter, see an empty channel view, and write fresh
+    // prod: sentinel rows alongside the legacy ones.
+    storedInstalled = {
+      'whisper-large-v3-turbo': {
+        version: 'pre-update',
+        sha256: '',
+        installedAt: ''
+      }
+    }
+
+    expect(() => migrateInstalledVersions()).toThrow(
+      /channel-tag migration in initSettings must run first/i
+    )
+  })
 })
 
 describe('executeUpdates', () => {

--- a/src/main/services/__tests__/UpdateCheckService.test.ts
+++ b/src/main/services/__tests__/UpdateCheckService.test.ts
@@ -154,14 +154,16 @@ describe('checkForUpdates', () => {
     vi.clearAllMocks()
   })
 
+  // Issue #84 Story D — installedModelVersions keys are now `${channel}:${id}`;
+  // default test env yields the `prod` channel.
   it('returns updates when manifest sha256 differs from installed', async () => {
     mockSettingsStore.get.mockReturnValue({
-      'whisper-large-v3-turbo': {
+      'prod:whisper-large-v3-turbo': {
         version: '2025-01-15',
         sha256: 'aaaa' + 'a'.repeat(60),
         installedAt: ''
       },
-      'pyannote-suite': {
+      'prod:pyannote-suite': {
         version: '2025-01-15',
         sha256: 'bbbb' + 'b'.repeat(60),
         installedAt: ''
@@ -180,12 +182,12 @@ describe('checkForUpdates', () => {
 
   it('returns no updates when all sha256 match', async () => {
     mockSettingsStore.get.mockReturnValue({
-      'whisper-large-v3-turbo': {
+      'prod:whisper-large-v3-turbo': {
         version: '2025-01-15',
         sha256: 'cccc' + 'c'.repeat(60),
         installedAt: ''
       },
-      'pyannote-suite': {
+      'prod:pyannote-suite': {
         version: '2025-01-15',
         sha256: 'bbbb' + 'b'.repeat(60),
         installedAt: ''
@@ -287,12 +289,19 @@ describe('checkForUpdates — dismissed manifest versions (Story F+G)', () => {
 
   // The settings store is mocked with a single mockReturnValue; for the dismiss
   // filter we need different return values per key, so route by key.
+  // Issue #84 Story D — installed entries are passed in plain modelId form
+  // for readability; this helper applies the `prod:` channel prefix the
+  // adapter expects.
   function setupMockSettings(opts: {
     installed?: Record<string, { version: string; sha256: string; installedAt: string }>
     dismissed?: string[]
   }): void {
+    const prefixed: Record<string, { version: string; sha256: string; installedAt: string }> = {}
+    for (const [id, val] of Object.entries(opts.installed ?? {})) {
+      prefixed[`prod:${id}`] = val
+    }
     mockSettingsStore.get.mockImplementation((key: string) => {
-      if (key === 'installedModelVersions') return opts.installed ?? {}
+      if (key === 'installedModelVersions') return prefixed
       if (key === 'dismissedManifestVersions') return opts.dismissed ?? []
       return null
     })
@@ -350,12 +359,12 @@ describe('checkForUpdates — dismissed manifest versions (Story F+G)', () => {
     mockSettingsStore.get.mockImplementation((key: string) => {
       if (key === 'installedModelVersions') {
         return {
-          'whisper-large-v3-turbo': {
+          'prod:whisper-large-v3-turbo': {
             version: '2025-01-15',
             sha256: 'aaaa' + 'a'.repeat(60),
             installedAt: ''
           },
-          'pyannote-suite': {
+          'prod:pyannote-suite': {
             version: '2025-01-15',
             sha256: 'bbbb' + 'b'.repeat(60),
             installedAt: ''
@@ -583,33 +592,47 @@ describe('cleanupIncompleteUpdates', () => {
 })
 
 describe('migrateInstalledVersions', () => {
+  // Issue #84 Story D — migrateInstalledVersions now writes via the
+  // channel-aware adapter. Use a stateful mock that round-trips writes back
+  // through reads, so the per-model setInstalledVersion calls accumulate
+  // observably (the first call's read sees an empty record, the second
+  // sees the first entry, …).
+  let storedInstalled: Record<string, unknown> = {}
   beforeEach(() => {
     vi.clearAllMocks()
+    storedInstalled = {}
+    mockSettingsStore.get.mockImplementation((key: string) => {
+      if (key === 'installedModelVersions') return storedInstalled
+      return null
+    })
+    mockSettingsStore.set.mockImplementation((key: string, value: unknown) => {
+      if (key === 'installedModelVersions') {
+        storedInstalled = value as Record<string, unknown>
+      }
+    })
   })
 
   it('populates installed versions for existing models', () => {
-    mockSettingsStore.get.mockReturnValue({})
     mockExistsSync.mockReturnValue(true) // all models exist
 
     migrateInstalledVersions()
 
-    expect(mockSettingsStore.set).toHaveBeenCalledWith(
-      'installedModelVersions',
+    // Final state contains both models, channel-prefixed (`prod` default).
+    expect(storedInstalled).toEqual(
       expect.objectContaining({
-        'whisper-large-v3-turbo': expect.objectContaining({
+        'prod:whisper-large-v3-turbo': expect.objectContaining({
           version: 'pre-update',
           sha256: '' // empty — forces update on first manifest check
         }),
-        'pyannote-suite': expect.objectContaining({
+        'prod:pyannote-suite': expect.objectContaining({
           version: 'pre-update',
-          sha256: '' // empty — forces update on first manifest check
+          sha256: ''
         })
       })
     )
   })
 
   it('skips models that are not installed on disk', () => {
-    mockSettingsStore.get.mockReturnValue({})
     // whisper not installed, pyannote installed
     mockExistsSync.mockImplementation(
       (p: string) => p.includes('diarization') || p.includes('speaker-diarization')
@@ -617,20 +640,18 @@ describe('migrateInstalledVersions', () => {
 
     migrateInstalledVersions()
 
-    const call = mockSettingsStore.set.mock.calls[0]
-    const versions = call[1] as Record<string, unknown>
-    expect(versions['pyannote-suite']).toBeDefined()
-    expect(versions['whisper-large-v3-turbo']).toBeUndefined()
+    expect(storedInstalled['prod:pyannote-suite']).toBeDefined()
+    expect(storedInstalled['prod:whisper-large-v3-turbo']).toBeUndefined()
   })
 
   it('does nothing if installedModelVersions already has entries', () => {
-    mockSettingsStore.get.mockReturnValue({
-      'whisper-large-v3-turbo': {
+    storedInstalled = {
+      'prod:whisper-large-v3-turbo': {
         version: '2025-01-15',
         sha256: 'aaaa' + 'a'.repeat(60),
         installedAt: ''
       }
-    })
+    }
 
     migrateInstalledVersions()
 
@@ -686,11 +707,11 @@ describe('executeUpdates', () => {
       expect.stringContaining('.staging'),
       expect.stringContaining('ggml-large-v3-turbo')
     )
-    // Record new version
+    // Record new version (channel-prefixed key per Story D)
     expect(mockSettingsStore.set).toHaveBeenCalledWith(
       'installedModelVersions',
       expect.objectContaining({
-        'whisper-large-v3-turbo': expect.objectContaining({ sha256: pendingUpdate.sha256 })
+        'prod:whisper-large-v3-turbo': expect.objectContaining({ sha256: pendingUpdate.sha256 })
       })
     )
     // Clear pending

--- a/src/main/services/__tests__/UpdateCheckService.test.ts
+++ b/src/main/services/__tests__/UpdateCheckService.test.ts
@@ -2,9 +2,21 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 // ─── Mocks ────────────────────────────────────────────────────────────────────
 
+const mockReloadFn = vi.fn()
+const mockSendFn = vi.fn()
 vi.mock('electron', () => ({
-  app: { relaunch: vi.fn(), quit: vi.fn(), getVersion: vi.fn().mockReturnValue('0.3.3') },
-  BrowserWindow: { getAllWindows: vi.fn().mockReturnValue([]) }
+  app: {
+    relaunch: vi.fn(),
+    quit: vi.fn(),
+    getVersion: vi.fn().mockReturnValue('0.3.3'),
+    // Default to packaged for tests; the dev-shim test overrides this.
+    isPackaged: true
+  },
+  BrowserWindow: {
+    getAllWindows: vi.fn(() => [
+      { webContents: { reload: mockReloadFn, send: mockSendFn } }
+    ])
+  }
 }))
 
 const mockExistsSync = vi.fn()
@@ -503,27 +515,54 @@ describe('checkForUpdates — app update', () => {
 })
 
 describe('triggerUpdateRestart', () => {
-  it('saves pending updates and triggers relaunch', async () => {
+  const updates = [
+    {
+      id: 'whisper-large-v3-turbo',
+      version: '2025-02-01',
+      label: 'Spracherkennung',
+      url: 'https://example.com/whisper.bin',
+      sha256: 'cccc' + 'c'.repeat(60),
+      sizeBytes: 100,
+      relativePath: 'asr/ggml-large-v3-turbo-q5_0.bin',
+      archive: false,
+      checkPath: 'asr/ggml-large-v3-turbo-q5_0.bin'
+    }
+  ]
+
+  beforeEach(async () => {
+    mockReloadFn.mockClear()
     const { app } = await import('electron')
-    const updates = [
-      {
-        id: 'whisper-large-v3-turbo',
-        version: '2025-02-01',
-        label: 'Spracherkennung',
-        url: 'https://example.com/whisper.bin',
-        sha256: 'cccc' + 'c'.repeat(60),
-        sizeBytes: 100,
-        relativePath: 'asr/ggml-large-v3-turbo-q5_0.bin',
-        archive: false,
-        checkPath: 'asr/ggml-large-v3-turbo-q5_0.bin'
-      }
-    ]
+    vi.mocked(app.relaunch).mockClear()
+    vi.mocked(app.quit).mockClear()
+  })
+
+  it('saves pending updates and triggers relaunch in packaged builds', async () => {
+    const { app } = await import('electron')
+    ;(app as { isPackaged: boolean }).isPackaged = true
 
     triggerUpdateRestart(updates)
 
     expect(mockSettingsStore.set).toHaveBeenCalledWith('pendingModelUpdates', updates)
     expect(app.relaunch).toHaveBeenCalled()
     expect(app.quit).toHaveBeenCalled()
+    expect(mockReloadFn).not.toHaveBeenCalled()
+  })
+
+  it('reloads the renderer in dev mode without quitting (Issue #84 dev-shim)', async () => {
+    // Dev-mode: app.relaunch() + app.quit() would kill electron-vite's
+    // parent process and orphan a window pointed at a dead localhost:5173.
+    // The shim writes pendingModelUpdates and reloads the renderer instead;
+    // the next mount of App.tsx reads the pending state and shows
+    // ModelUpdateScreen — same observable UX, without the white screen.
+    const { app } = await import('electron')
+    ;(app as { isPackaged: boolean }).isPackaged = false
+
+    triggerUpdateRestart(updates)
+
+    expect(mockSettingsStore.set).toHaveBeenCalledWith('pendingModelUpdates', updates)
+    expect(mockReloadFn).toHaveBeenCalledOnce()
+    expect(app.relaunch).not.toHaveBeenCalled()
+    expect(app.quit).not.toHaveBeenCalled()
   })
 })
 

--- a/src/main/services/__tests__/UpdateCheckService.test.ts
+++ b/src/main/services/__tests__/UpdateCheckService.test.ts
@@ -85,7 +85,9 @@ import {
   cleanupIncompleteUpdates,
   migrateInstalledVersions,
   executeUpdates,
-  isNewerVersion
+  isNewerVersion,
+  dismissManifestVersions,
+  manifestEntryKey
 } from '../UpdateCheckService'
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -275,6 +277,131 @@ describe('checkForUpdates', () => {
 
     const { modelUpdates } = await checkForUpdates()
     expect(modelUpdates).toHaveLength(0)
+  })
+})
+
+describe('checkForUpdates — dismissed manifest versions (Story F+G)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // The settings store is mocked with a single mockReturnValue; for the dismiss
+  // filter we need different return values per key, so route by key.
+  function setupMockSettings(opts: {
+    installed?: Record<string, { version: string; sha256: string; installedAt: string }>
+    dismissed?: string[]
+  }): void {
+    mockSettingsStore.get.mockImplementation((key: string) => {
+      if (key === 'installedModelVersions') return opts.installed ?? {}
+      if (key === 'dismissedManifestVersions') return opts.dismissed ?? []
+      return null
+    })
+  }
+
+  it('skips a manifest entry whose id+sha256 is in the dismiss list', async () => {
+    setupMockSettings({
+      installed: {
+        'whisper-large-v3-turbo': {
+          version: '2025-01-15',
+          sha256: 'aaaa' + 'a'.repeat(60),
+          installedAt: ''
+        },
+        'pyannote-suite': {
+          version: '2025-01-15',
+          sha256: 'bbbb' + 'b'.repeat(60),
+          installedAt: ''
+        }
+      },
+      dismissed: [manifestEntryKey('whisper-large-v3-turbo', 'cccc' + 'c'.repeat(60))]
+    })
+    makeHttpsResponse(200, validManifest)
+
+    const { modelUpdates } = await checkForUpdates()
+    // whisper would normally be flagged (sha differs) but is dismissed.
+    expect(modelUpdates).toHaveLength(0)
+  })
+
+  it('still flags a different sha256 for the same id (new manifest revision)', async () => {
+    setupMockSettings({
+      installed: {
+        'whisper-large-v3-turbo': {
+          version: '2025-01-15',
+          sha256: 'aaaa' + 'a'.repeat(60),
+          installedAt: ''
+        },
+        'pyannote-suite': {
+          version: '2025-01-15',
+          sha256: 'bbbb' + 'b'.repeat(60),
+          installedAt: ''
+        }
+      },
+      // Stale dismiss entry for an older sha256 — manifest now ships 'cccc...'
+      // for whisper, so this entry must NOT silence the new update.
+      dismissed: [manifestEntryKey('whisper-large-v3-turbo', 'eeee' + 'e'.repeat(60))]
+    })
+    makeHttpsResponse(200, validManifest)
+
+    const { modelUpdates } = await checkForUpdates()
+    expect(modelUpdates).toHaveLength(1)
+    expect(modelUpdates[0].id).toBe('whisper-large-v3-turbo')
+  })
+
+  it('tolerates a non-array dismissed value (corrupted setting)', async () => {
+    mockSettingsStore.get.mockImplementation((key: string) => {
+      if (key === 'installedModelVersions') {
+        return {
+          'whisper-large-v3-turbo': {
+            version: '2025-01-15',
+            sha256: 'aaaa' + 'a'.repeat(60),
+            installedAt: ''
+          },
+          'pyannote-suite': {
+            version: '2025-01-15',
+            sha256: 'bbbb' + 'b'.repeat(60),
+            installedAt: ''
+          }
+        }
+      }
+      if (key === 'dismissedManifestVersions') return null
+      return null
+    })
+    makeHttpsResponse(200, validManifest)
+
+    const { modelUpdates } = await checkForUpdates()
+    // Filter must default to empty set and behave like the baseline check.
+    expect(modelUpdates).toHaveLength(1)
+  })
+})
+
+describe('dismissManifestVersions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('appends entries and de-duplicates', () => {
+    mockSettingsStore.get.mockReturnValue([
+      manifestEntryKey('a', '1'.repeat(64))
+    ])
+
+    dismissManifestVersions([
+      { id: 'a', sha256: '1'.repeat(64) }, // duplicate
+      { id: 'b', sha256: '2'.repeat(64) }
+    ])
+
+    expect(mockSettingsStore.set).toHaveBeenCalledWith(
+      'dismissedManifestVersions',
+      [manifestEntryKey('a', '1'.repeat(64)), manifestEntryKey('b', '2'.repeat(64))]
+    )
+  })
+
+  it('initializes the list when the existing value is not an array', () => {
+    mockSettingsStore.get.mockReturnValue(null)
+
+    dismissManifestVersions([{ id: 'a', sha256: '1'.repeat(64) }])
+
+    expect(mockSettingsStore.set).toHaveBeenCalledWith('dismissedManifestVersions', [
+      manifestEntryKey('a', '1'.repeat(64))
+    ])
   })
 })
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -168,6 +168,11 @@ const api: IpcApi = {
       ipcRenderer.invoke('pipeline:setDiarization', { pipeline }),
     listDiarization: () => ipcRenderer.invoke('pipeline:listDiarization')
   },
+  modelReconcile: {
+    getEvents: () => ipcRenderer.invoke('modelReconcile:getEvents'),
+    markSeen: () => ipcRenderer.invoke('modelReconcile:markSeen'),
+    dismiss: () => ipcRenderer.invoke('modelReconcile:dismiss')
+  },
   modelUpdate: {
     check: () => ipcRenderer.invoke('modelUpdate:check'),
     restart: (updates: PendingModelUpdate[]) =>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -180,6 +180,8 @@ const api: IpcApi = {
     startDownload: () => ipcRenderer.invoke('modelUpdate:startDownload'),
     getPending: () => ipcRenderer.invoke('modelUpdate:getPending'),
     clearPending: () => ipcRenderer.invoke('modelUpdate:clearPending'),
+    dismissVersions: (updates: PendingModelUpdate[]) =>
+      ipcRenderer.invoke('modelUpdate:dismissVersions', { updates }),
     onAvailable: (callback) => {
       const handler = (_event: Electron.IpcRendererEvent, updates: PendingModelUpdate[]): void =>
         callback(updates)

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -105,6 +105,12 @@ export default function App(): React.JSX.Element {
     // If allowed, the app will relaunch — no further action needed
   }, [availableUpdates])
 
+  const handleDismissUpdates = useCallback(async () => {
+    if (!availableUpdates || availableUpdates.length === 0) return
+    await window.api.modelUpdate.dismissVersions(availableUpdates)
+    clearUpdates()
+  }, [availableUpdates, clearUpdates])
+
   const isInReview = currentView === 'review'
   const navHidden = isRecording || isInReview
 
@@ -156,7 +162,11 @@ export default function App(): React.JSX.Element {
 
       {/* Update banner — shown when updates are available (non-blocking) */}
       {availableUpdates && availableUpdates.length > 0 && (
-        <UpdateBanner updates={availableUpdates} onRestart={handleRestartForUpdate} />
+        <UpdateBanner
+          updates={availableUpdates}
+          onRestart={handleRestartForUpdate}
+          onDismiss={handleDismissUpdates}
+        />
       )}
 
       {/* Main content */}

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -80,6 +80,14 @@ export default function App(): React.JSX.Element {
     clearUpdates()
   }, [clearUpdates])
 
+  // Issue #84 / Story G — "Später" + Error-Continue exits leave the
+  // pending entry in electron-store intact (next-launch retry promise) and
+  // must not clear the live banner state — the user did not dismiss the
+  // update, only the current screen.
+  const handleUpdateLater = useCallback(() => {
+    setPendingUpdates(null)
+  }, [])
+
   const handleCloseReview = useCallback(() => {
     scrollToSessionId.current = reviewSessionId
     setReviewSessionId(null)
@@ -150,7 +158,11 @@ export default function App(): React.JSX.Element {
       <div className="flex h-screen flex-col bg-surface-0">
         <TitleBar />
         <div className="min-h-0 flex-1">
-          <ModelUpdateScreen updates={pendingUpdates} onComplete={handleUpdateComplete} />
+          <ModelUpdateScreen
+            updates={pendingUpdates}
+            onComplete={handleUpdateComplete}
+            onLater={handleUpdateLater}
+          />
         </div>
       </div>
     )

--- a/src/renderer/src/__tests__/App.test.tsx
+++ b/src/renderer/src/__tests__/App.test.tsx
@@ -16,6 +16,7 @@ const mockModelUpdate = {
   startDownload: vi.fn(),
   getPending: vi.fn().mockResolvedValue(null),
   clearPending: vi.fn().mockResolvedValue(undefined),
+  dismissVersions: vi.fn().mockResolvedValue(undefined),
   onAvailable: vi.fn().mockReturnValue(() => {}),
   onDownloadProgress: vi.fn().mockReturnValue(() => {}),
   onDownloadComplete: vi.fn().mockReturnValue(() => {}),

--- a/src/renderer/src/__tests__/App.test.tsx
+++ b/src/renderer/src/__tests__/App.test.tsx
@@ -111,6 +111,11 @@ beforeEach(() => {
     },
     feedback: {
       send: vi.fn().mockResolvedValue(undefined)
+    },
+    modelReconcile: {
+      getEvents: vi.fn().mockResolvedValue([]),
+      markSeen: vi.fn().mockResolvedValue([]),
+      dismiss: vi.fn().mockResolvedValue(undefined)
     }
   } as typeof window.api
 })

--- a/src/renderer/src/components/AboutPage.tsx
+++ b/src/renderer/src/components/AboutPage.tsx
@@ -21,7 +21,7 @@ const ACKNOWLEDGMENTS = [
   },
   {
     name: 'TipTap',
-    description: 'Review-Editor — ermöglicht die Bearbeitung des anonymisierten Textes'
+    description: 'Review-Editor — ermöglicht die Bearbeitung des pseudonymisierten Textes'
   },
   {
     name: 'Electron',
@@ -96,6 +96,31 @@ export default function AboutPage(): React.JSX.Element {
         <p className="text-sm text-text-secondary">
           Alle Verarbeitung findet komplett lokal auf Ihrem Mac statt.
         </p>
+
+        {/* Pseudonymisierung — Erklärung der DSGVO-Terminologie (Issue #84 / Story H) */}
+        <section
+          id="pseudonymisierung"
+          className="rounded-lg border border-border bg-surface-1 p-4"
+        >
+          <h4 className="mb-2 text-sm font-medium text-text-primary">
+            Wie TheraScript Daten schützt
+          </h4>
+          <p className="mb-2 text-sm text-text-secondary">
+            Erkannte personenbezogene Angaben werden durch typisierte Platzhalter ersetzt:{' '}
+            <span className="whitespace-nowrap">[PERSON 1]</span>,{' '}
+            <span className="whitespace-nowrap">[ORT 1]</span>,{' '}
+            <span className="whitespace-nowrap">[DATUM 1]</span>.
+          </p>
+          <p className="mb-2 text-sm text-text-secondary">
+            DSGVO-rechtlich heisst das <span className="font-medium">Pseudonymisierung</span> —
+            die Originaldaten bleiben in Ihrem lokalen Backup vorhanden, sind aber im
+            exportierten Text nicht mehr enthalten.
+          </p>
+          <p className="text-sm text-text-secondary">
+            Echte Anonymisierung wäre, die Originale zu löschen — das machen wir bewusst nicht,
+            damit Sie Korrekturen rückgängig machen können.
+          </p>
+        </section>
 
         {/* Quellcode */}
         <div>

--- a/src/renderer/src/components/BlocklistManager.tsx
+++ b/src/renderer/src/components/BlocklistManager.tsx
@@ -122,7 +122,7 @@ const BlocklistManager = forwardRef<BlocklistManagerHandle>(function BlocklistMa
       <div className="p-6">
         <div className="mb-4 flex items-baseline justify-between gap-4">
           <p className="text-sm text-text-secondary">
-            Begriffe, die immer automatisch anonymisiert werden.
+            Begriffe, die immer automatisch pseudonymisiert werden.
           </p>
           {entries.length > 0 && (
             <span className="shrink-0 text-xs text-text-tertiary">

--- a/src/renderer/src/components/ModelUpdateScreen.tsx
+++ b/src/renderer/src/components/ModelUpdateScreen.tsx
@@ -60,8 +60,28 @@ export default function ModelUpdateScreen({
     await window.api.modelUpdate.startDownload()
   }, [updates])
 
-  const handleSkip = useCallback(async () => {
-    // Clear pending updates in settings so the screen doesn't reappear next launch
+  // Story G — three distinct exits from the pre-download state:
+  //
+  // 1. handleLater: keep `pendingModelUpdates` intact → screen reappears on
+  //    next start. Used by the "Später" button.
+  // 2. handleSkipVersion: clear pending AND dismiss this manifest entry so the
+  //    UpdateBanner won't bring it back this manifest revision. Used by the
+  //    "Diese Version überspringen" button.
+  // 3. handleErrorContinue: error path — clear pending and dismiss the screen
+  //    without dismissing the manifest entry (executeUpdates kept pending on
+  //    failure; the user explicitly dropping out of the screen should release
+  //    that hold without permanently silencing the banner).
+  const handleLater = useCallback(() => {
+    onComplete()
+  }, [onComplete])
+
+  const handleSkipVersion = useCallback(async () => {
+    await window.api.modelUpdate.dismissVersions(updates)
+    await window.api.modelUpdate.clearPending()
+    onComplete()
+  }, [onComplete, updates])
+
+  const handleErrorContinue = useCallback(async () => {
     await window.api.modelUpdate.clearPending()
     onComplete()
   }, [onComplete])
@@ -99,12 +119,20 @@ export default function ModelUpdateScreen({
               {updates.length} {updates.length === 1 ? 'Modell wird' : 'Modelle werden'}{' '}
               aktualisiert (~{formatBytes(updates.reduce((s, u) => s + u.sizeBytes, 0))}).
             </p>
-            <div className="flex justify-center gap-3">
+            <div className="flex flex-wrap justify-center gap-3">
               <button
                 className="rounded-lg border border-border-strong bg-surface-0 px-4 py-2.5 text-sm font-semibold text-text-secondary transition-colors hover:bg-surface-1"
-                onClick={handleSkip}
+                onClick={handleSkipVersion}
+                title="Diese Version überspringen — wird erst beim nächsten Modell-Update wieder gezeigt"
               >
-                Überspringen
+                Diese Version überspringen
+              </button>
+              <button
+                className="rounded-lg border border-border-strong bg-surface-0 px-4 py-2.5 text-sm font-semibold text-text-secondary transition-colors hover:bg-surface-1"
+                onClick={handleLater}
+                title="Das Update wird beim nächsten Start vorgeschlagen"
+              >
+                Später
               </button>
               <button
                 className="rounded-lg bg-primary px-6 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-primary-hover"
@@ -113,6 +141,10 @@ export default function ModelUpdateScreen({
                 Update starten
               </button>
             </div>
+            <p className="mt-4 text-xs text-text-tertiary">
+              Später: erscheint beim nächsten Start erneut. Überspringen: erst beim nächsten
+              Modell-Update wieder gezeigt.
+            </p>
           </div>
         )}
 
@@ -194,7 +226,7 @@ export default function ModelUpdateScreen({
             </p>
             <button
               className="rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-primary-hover"
-              onClick={handleSkip}
+              onClick={handleErrorContinue}
             >
               Weiter
             </button>

--- a/src/renderer/src/components/ModelUpdateScreen.tsx
+++ b/src/renderer/src/components/ModelUpdateScreen.tsx
@@ -7,12 +7,19 @@ import AppLogo from './AppLogo'
 
 interface ModelUpdateScreenProps {
   updates: PendingModelUpdate[]
+  /** Download finished or user actively skipped this version — wipe both
+   *  the pending entry in electron-store and any live banner state. */
   onComplete: () => void
+  /** "Später" + error-state "Weiter" — close the screen but keep the pending
+   *  entry intact so the next launch can retry, matching the in-screen
+   *  promise "Das Update wird beim nächsten Start erneut versucht." */
+  onLater: () => void
 }
 
 export default function ModelUpdateScreen({
   updates,
-  onComplete
+  onComplete,
+  onLater
 }: ModelUpdateScreenProps): React.JSX.Element {
   const [status, setStatus] = useState<ModelDownloadStatus>({ state: 'idle' })
   const [started, setStarted] = useState(false)
@@ -60,31 +67,25 @@ export default function ModelUpdateScreen({
     await window.api.modelUpdate.startDownload()
   }, [updates])
 
-  // Story G — three distinct exits from the pre-download state:
+  // Story G — exits from the pre-download / error states:
   //
   // 1. handleLater: keep `pendingModelUpdates` intact → screen reappears on
-  //    next start. Used by the "Später" button.
-  // 2. handleSkipVersion: clear pending AND dismiss this manifest entry so the
-  //    UpdateBanner won't bring it back this manifest revision. Used by the
-  //    "Diese Version überspringen" button.
-  // 3. handleErrorContinue: error path — clear pending and dismiss the screen
-  //    without dismissing the manifest entry (executeUpdates kept pending on
-  //    failure; the user explicitly dropping out of the screen should release
-  //    that hold without permanently silencing the banner).
+  //    next start (executeUpdates retries automatically). Used by both the
+  //    "Später" button (pre-download) and the "Weiter" button (error state),
+  //    matching the existing "wird beim nächsten Start erneut versucht"
+  //    promise rendered inside the error panel.
+  // 2. handleSkipVersion: clear pending AND dismiss this manifest entry so
+  //    the UpdateBanner won't bring it back this manifest revision. Used by
+  //    the "Diese Version überspringen" button.
   const handleLater = useCallback(() => {
-    onComplete()
-  }, [onComplete])
+    onLater()
+  }, [onLater])
 
   const handleSkipVersion = useCallback(async () => {
     await window.api.modelUpdate.dismissVersions(updates)
     await window.api.modelUpdate.clearPending()
     onComplete()
   }, [onComplete, updates])
-
-  const handleErrorContinue = useCallback(async () => {
-    await window.api.modelUpdate.clearPending()
-    onComplete()
-  }, [onComplete])
 
   const isDownloading = status.state === 'downloading'
   const isExtracting = status.state === 'extracting'
@@ -226,7 +227,7 @@ export default function ModelUpdateScreen({
             </p>
             <button
               className="rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-primary-hover"
-              onClick={handleErrorContinue}
+              onClick={handleLater}
             >
               Weiter
             </button>

--- a/src/renderer/src/components/SessionDashboard.tsx
+++ b/src/renderer/src/components/SessionDashboard.tsx
@@ -224,7 +224,7 @@ export default function SessionDashboard({
         <ConfirmDialog
           title="Transkription löschen"
           message={`„${deleteTarget.title}“ und alle zugehörigen Daten unwiderruflich löschen?`}
-          details={['Audiodatei', 'Originaltext', 'Anonymisierter Text', 'Platzhalter-Mapping']}
+          details={['Audiodatei', 'Originaltext', 'Pseudonymisierter Text', 'Platzhalter-Mapping']}
           confirmLabel="Löschen"
           destructive
           onConfirm={handleDelete}

--- a/src/renderer/src/components/UpdateBanner.tsx
+++ b/src/renderer/src/components/UpdateBanner.tsx
@@ -1,12 +1,18 @@
+import { X } from 'lucide-react'
 import type { PendingModelUpdate } from '../../../shared/types/ModelUpdate'
 import { formatBytes } from '../utils/formatBytes'
 
 interface UpdateBannerProps {
   updates: PendingModelUpdate[]
   onRestart: () => void
+  onDismiss: () => void
 }
 
-export default function UpdateBanner({ updates, onRestart }: UpdateBannerProps): React.JSX.Element {
+export default function UpdateBanner({
+  updates,
+  onRestart,
+  onDismiss
+}: UpdateBannerProps): React.JSX.Element {
   const totalBytes = updates.reduce((sum, u) => sum + u.sizeBytes, 0)
   const count = updates.length
 
@@ -19,12 +25,22 @@ export default function UpdateBanner({ updates, onRestart }: UpdateBannerProps):
           ~{formatBytes(totalBytes)})
         </span>
       </div>
-      <button
-        className="titlebar-no-drag rounded-md bg-blue-600 px-3 py-1.5 text-xs font-semibold text-white transition-colors hover:bg-primary-hover"
-        onClick={onRestart}
-      >
-        Jetzt neu starten
-      </button>
+      <div className="flex items-center gap-2">
+        <button
+          className="titlebar-no-drag rounded-md bg-blue-600 px-3 py-1.5 text-xs font-semibold text-white transition-colors hover:bg-primary-hover"
+          onClick={onRestart}
+        >
+          Jetzt neu starten
+        </button>
+        <button
+          aria-label="Update-Hinweis ausblenden"
+          title="Diese Version überspringen — Banner erscheint erst beim nächsten Modell-Update wieder"
+          className="titlebar-no-drag flex h-7 w-7 items-center justify-center rounded-md text-info-text transition-colors hover:bg-info-border/40"
+          onClick={onDismiss}
+        >
+          <X className="h-4 w-4" strokeWidth={2} aria-hidden="true" />
+        </button>
+      </div>
     </div>
   )
 }

--- a/src/renderer/src/components/__tests__/ModelUpdateScreen.test.tsx
+++ b/src/renderer/src/components/__tests__/ModelUpdateScreen.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import ModelUpdateScreen from '../ModelUpdateScreen'
+import type { PendingModelUpdate } from '../../../../shared/types/ModelUpdate'
+
+const update: PendingModelUpdate = {
+  id: 'whisper-large-v3-turbo',
+  version: '2025-02-01',
+  label: 'Whisper Large V3 Turbo',
+  url: 'https://example.com/model.bin',
+  sha256: 'a'.repeat(64),
+  sizeBytes: 1024 * 1024,
+  relativePath: 'asr/model.bin',
+  archive: false,
+  checkPath: 'asr/model.bin'
+}
+
+const mockModelUpdate = {
+  startDownload: vi.fn().mockResolvedValue(undefined),
+  clearPending: vi.fn().mockResolvedValue(undefined),
+  dismissVersions: vi.fn().mockResolvedValue(undefined),
+  onDownloadProgress: vi.fn().mockReturnValue(() => {}),
+  onDownloadComplete: vi.fn().mockReturnValue(() => {}),
+  onDownloadError: vi.fn().mockReturnValue(() => {})
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  // @ts-expect-error — partial test stub for window.api
+  window.api = { modelUpdate: mockModelUpdate }
+})
+
+describe('ModelUpdateScreen — pre-download exits (Story G)', () => {
+  it('"Später" calls onComplete without clearing or dismissing', async () => {
+    const user = userEvent.setup()
+    const onComplete = vi.fn()
+    render(<ModelUpdateScreen updates={[update]} onComplete={onComplete} />)
+
+    await user.click(screen.getByRole('button', { name: /^Später$/i }))
+
+    expect(onComplete).toHaveBeenCalledOnce()
+    expect(mockModelUpdate.clearPending).not.toHaveBeenCalled()
+    expect(mockModelUpdate.dismissVersions).not.toHaveBeenCalled()
+  })
+
+  it('"Diese Version überspringen" dismisses the manifest entry and clears pending', async () => {
+    const user = userEvent.setup()
+    const onComplete = vi.fn()
+    render(<ModelUpdateScreen updates={[update]} onComplete={onComplete} />)
+
+    await user.click(screen.getByRole('button', { name: /Diese Version überspringen/i }))
+
+    expect(mockModelUpdate.dismissVersions).toHaveBeenCalledWith([update])
+    expect(mockModelUpdate.clearPending).toHaveBeenCalledOnce()
+    expect(onComplete).toHaveBeenCalledOnce()
+  })
+
+  it('"Update starten" begins the download', async () => {
+    const user = userEvent.setup()
+    render(<ModelUpdateScreen updates={[update]} onComplete={vi.fn()} />)
+
+    await user.click(screen.getByRole('button', { name: /Update starten/i }))
+
+    expect(mockModelUpdate.startDownload).toHaveBeenCalledOnce()
+    // Pre-download dismiss/skip controls are no longer rendered once started.
+    expect(screen.queryByRole('button', { name: /^Später$/i })).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: /Diese Version überspringen/i })
+    ).not.toBeInTheDocument()
+  })
+})

--- a/src/renderer/src/components/__tests__/ModelUpdateScreen.test.tsx
+++ b/src/renderer/src/components/__tests__/ModelUpdateScreen.test.tsx
@@ -32,14 +32,25 @@ beforeEach(() => {
 })
 
 describe('ModelUpdateScreen — pre-download exits (Story G)', () => {
-  it('"Später" calls onComplete without clearing or dismissing', async () => {
+  it('"Später" calls onLater without clearing or dismissing — and does NOT call onComplete', async () => {
     const user = userEvent.setup()
     const onComplete = vi.fn()
-    render(<ModelUpdateScreen updates={[update]} onComplete={onComplete} />)
+    const onLater = vi.fn()
+    render(
+      <ModelUpdateScreen
+        updates={[update]}
+        onComplete={onComplete}
+        onLater={onLater}
+      />
+    )
 
     await user.click(screen.getByRole('button', { name: /^Später$/i }))
 
-    expect(onComplete).toHaveBeenCalledOnce()
+    expect(onLater).toHaveBeenCalledOnce()
+    // onComplete must not fire — that path also clears the live banner state
+    // in App.tsx via clearUpdates(), which "Später" must not do (Issue #84
+    // architect review #3).
+    expect(onComplete).not.toHaveBeenCalled()
     expect(mockModelUpdate.clearPending).not.toHaveBeenCalled()
     expect(mockModelUpdate.dismissVersions).not.toHaveBeenCalled()
   })
@@ -47,18 +58,28 @@ describe('ModelUpdateScreen — pre-download exits (Story G)', () => {
   it('"Diese Version überspringen" dismisses the manifest entry and clears pending', async () => {
     const user = userEvent.setup()
     const onComplete = vi.fn()
-    render(<ModelUpdateScreen updates={[update]} onComplete={onComplete} />)
+    const onLater = vi.fn()
+    render(
+      <ModelUpdateScreen
+        updates={[update]}
+        onComplete={onComplete}
+        onLater={onLater}
+      />
+    )
 
     await user.click(screen.getByRole('button', { name: /Diese Version überspringen/i }))
 
     expect(mockModelUpdate.dismissVersions).toHaveBeenCalledWith([update])
     expect(mockModelUpdate.clearPending).toHaveBeenCalledOnce()
     expect(onComplete).toHaveBeenCalledOnce()
+    expect(onLater).not.toHaveBeenCalled()
   })
 
   it('"Update starten" begins the download', async () => {
     const user = userEvent.setup()
-    render(<ModelUpdateScreen updates={[update]} onComplete={vi.fn()} />)
+    render(
+      <ModelUpdateScreen updates={[update]} onComplete={vi.fn()} onLater={vi.fn()} />
+    )
 
     await user.click(screen.getByRole('button', { name: /Update starten/i }))
 

--- a/src/renderer/src/components/__tests__/SessionCard.test.tsx
+++ b/src/renderer/src/components/__tests__/SessionCard.test.tsx
@@ -33,6 +33,7 @@ function makeSession(overrides: Partial<Session> = {}): Session {
     plannedSteps: null,
     retryCount: 0,
     pdfHasScannedPages: null,
+    processedWithModels: null,
     ...overrides
   }
 }

--- a/src/renderer/src/components/__tests__/SessionDashboard.test.tsx
+++ b/src/renderer/src/components/__tests__/SessionDashboard.test.tsx
@@ -183,6 +183,11 @@ beforeEach(() => {
     },
     feedback: {
       send: vi.fn().mockResolvedValue(undefined)
+    },
+    modelReconcile: {
+      getEvents: vi.fn().mockResolvedValue([]),
+      markSeen: vi.fn().mockResolvedValue([]),
+      dismiss: vi.fn().mockResolvedValue(undefined)
     }
   } as typeof window.api
   vi.clearAllMocks()

--- a/src/renderer/src/components/__tests__/SessionDashboard.test.tsx
+++ b/src/renderer/src/components/__tests__/SessionDashboard.test.tsx
@@ -30,6 +30,7 @@ function makeSession(overrides: Partial<Session> = {}): Session {
     plannedSteps: null,
     retryCount: 0,
     pdfHasScannedPages: null,
+    processedWithModels: null,
     ...overrides
   }
 }

--- a/src/renderer/src/components/__tests__/SessionDashboard.test.tsx
+++ b/src/renderer/src/components/__tests__/SessionDashboard.test.tsx
@@ -92,6 +92,7 @@ const mockModelUpdate = {
   startDownload: vi.fn(),
   getPending: vi.fn().mockResolvedValue(null),
   clearPending: vi.fn().mockResolvedValue(undefined),
+  dismissVersions: vi.fn().mockResolvedValue(undefined),
   onAvailable: vi.fn().mockReturnValue(() => {}),
   onDownloadProgress: vi.fn().mockReturnValue(() => {}),
   onDownloadComplete: vi.fn().mockReturnValue(() => {}),

--- a/src/renderer/src/components/__tests__/UpdateBanner.test.tsx
+++ b/src/renderer/src/components/__tests__/UpdateBanner.test.tsx
@@ -18,11 +18,11 @@ const makeUpdate = (id: string, sizeBytes: number): PendingModelUpdate => ({
 
 describe('UpdateBanner', () => {
   it('displays update count and size for a single update', () => {
-    const onRestart = vi.fn()
     render(
       <UpdateBanner
         updates={[makeUpdate('whisper-large-v3-turbo', 100 * 1024 * 1024)]}
-        onRestart={onRestart}
+        onRestart={vi.fn()}
+        onDismiss={vi.fn()}
       />
     )
 
@@ -38,21 +38,41 @@ describe('UpdateBanner', () => {
           makeUpdate('pyannote-suite', 30 * 1024 * 1024)
         ]}
         onRestart={vi.fn()}
+        onDismiss={vi.fn()}
       />
     )
 
     expect(screen.getByText(/2 Modelle/)).toBeInTheDocument()
   })
 
-  it('calls onRestart when button is clicked', async () => {
+  it('calls onRestart when restart button is clicked', async () => {
     const user = userEvent.setup()
     const onRestart = vi.fn()
     render(
-      <UpdateBanner updates={[makeUpdate('whisper-large-v3-turbo', 100)]} onRestart={onRestart} />
+      <UpdateBanner
+        updates={[makeUpdate('whisper-large-v3-turbo', 100)]}
+        onRestart={onRestart}
+        onDismiss={vi.fn()}
+      />
     )
 
     await user.click(screen.getByRole('button', { name: /neu starten/i }))
     expect(onRestart).toHaveBeenCalledOnce()
+  })
+
+  it('calls onDismiss when the close button is clicked', async () => {
+    const user = userEvent.setup()
+    const onDismiss = vi.fn()
+    render(
+      <UpdateBanner
+        updates={[makeUpdate('whisper-large-v3-turbo', 100)]}
+        onRestart={vi.fn()}
+        onDismiss={onDismiss}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: /ausblenden/i }))
+    expect(onDismiss).toHaveBeenCalledOnce()
   })
 
   it('shows size in GB for large updates', () => {
@@ -60,14 +80,22 @@ describe('UpdateBanner', () => {
       <UpdateBanner
         updates={[makeUpdate('flair-ner-german-large', 2 * 1024 * 1024 * 1024)]}
         onRestart={vi.fn()}
+        onDismiss={vi.fn()}
       />
     )
 
     expect(screen.getByText(/2\.0 GB/)).toBeInTheDocument()
   })
 
-  it('renders the restart button', () => {
-    render(<UpdateBanner updates={[makeUpdate('test', 1000)]} onRestart={vi.fn()} />)
+  it('renders both restart and dismiss buttons', () => {
+    render(
+      <UpdateBanner
+        updates={[makeUpdate('test', 1000)]}
+        onRestart={vi.fn()}
+        onDismiss={vi.fn()}
+      />
+    )
     expect(screen.getByRole('button', { name: /neu starten/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /ausblenden/i })).toBeInTheDocument()
   })
 })

--- a/src/renderer/src/components/editor/AnonymizationPanel.tsx
+++ b/src/renderer/src/components/editor/AnonymizationPanel.tsx
@@ -28,7 +28,7 @@ export function AnonymizationPanel({
       <div className="flex h-full w-[300px] flex-col border-l border-border bg-surface-1">
         <div className="flex items-center justify-between border-b border-border px-4 py-3">
           <div className="flex items-center gap-2">
-            <h3 className="text-sm font-semibold text-text-primary">Anonymisierungen</h3>
+            <h3 className="text-sm font-semibold text-text-primary">Pseudonymisierungen</h3>
             {data.totalChips > 0 && (
               <span className="rounded-full bg-surface-3 px-1.5 py-0.5 text-[11px] font-medium text-text-secondary">
                 {data.totalChips}
@@ -40,7 +40,7 @@ export function AnonymizationPanel({
         <div className="flex-1 overflow-y-auto px-3 py-3">
           {data.totalIdentities === 0 ? (
             <p className="py-8 text-center text-sm text-text-tertiary">
-              Keine Anonymisierungen
+              Keine Pseudonymisierungen
             </p>
           ) : (
             <div className="flex flex-col gap-4">

--- a/src/renderer/src/components/editor/BlocklistConfirmDialog.tsx
+++ b/src/renderer/src/components/editor/BlocklistConfirmDialog.tsx
@@ -56,8 +56,8 @@ export function BlocklistConfirmDialog({
           Sperrliste hinzufügen?
         </p>
         <p className="mb-4 text-xs text-text-tertiary">
-          Der Begriff wird in zukünftigen Transkriptionen automatisch anonymisiert und retroaktiv
-          im aktuellen Dokument ersetzt.
+          Der Begriff wird in zukünftigen Transkriptionen automatisch pseudonymisiert und
+          retroaktiv im aktuellen Dokument ersetzt.
         </p>
 
         <div className="flex justify-end gap-2">

--- a/src/renderer/src/components/editor/EditorContextMenu.tsx
+++ b/src/renderer/src/components/editor/EditorContextMenu.tsx
@@ -31,12 +31,12 @@ export interface ContextMenuState {
     number: number
     count: number
   }
-  /** If true, text is selected — show "Anonymisieren als..." */
+  /** If true, text is selected — show "Pseudonymisieren als..." */
   hasSelection: boolean
   /**
    * If true, the selection consists exclusively of two or more chips with no
    * neutral text outside them — re-flagging would be ambiguous, so the
-   * "Anonymisieren als..." block is hidden (AK 12).
+   * "Pseudonymisieren als..." block is hidden (AK 12).
    */
   selectionSpansMultipleChipsOnly: boolean
 }
@@ -113,11 +113,11 @@ export function EditorContextMenu({
       {/* Separator when both chip and selection options present */}
       {state.chip && state.hasSelection && <div className="my-1 border-t border-border" />}
 
-      {/* Selection context: "Anonymisieren als..." — hidden when selection is multiple chips only */}
+      {/* Selection context: "Pseudonymisieren als..." — hidden when selection is multiple chips only */}
       {state.hasSelection && !state.selectionSpansMultipleChipsOnly && (
         <>
           <div className="px-3 py-1.5 text-xs font-medium text-text-tertiary">
-            Anonymisieren als...
+            Pseudonymisieren als...
           </div>
           {ANONYMIZE_TYPES.map((type) => (
             <button

--- a/src/renderer/src/components/review/EditableSessionTitle.tsx
+++ b/src/renderer/src/components/review/EditableSessionTitle.tsx
@@ -58,7 +58,17 @@ export function EditableSessionTitle({
       })
   }
 
-  const onBlur = (e: FocusEvent<HTMLHeadingElement>): void => commit(e.currentTarget)
+  const onBlur = (e: FocusEvent<HTMLHeadingElement>): void => {
+    // Focused state had `overflow-x: auto` (so the user could edit past the
+    // visible width); contentEditable auto-scrolls to keep the caret visible.
+    // On blur the CSS reverts to `truncate` (= overflow: hidden), but the
+    // browser preserves scrollLeft through that transition — without this
+    // reset the filled state would render the middle of the title with
+    // ellipsis on the right, looking like a rendering bug. Resetting here
+    // restores the expected "start of title + …" view.
+    e.currentTarget.scrollLeft = 0
+    commit(e.currentTarget)
+  }
   const onKeyDown = (e: KeyboardEvent<HTMLHeadingElement>): void => {
     if (e.key === 'Escape') {
       e.currentTarget.textContent = originalRef.current
@@ -79,7 +89,20 @@ export function EditableSessionTitle({
       // receives focus. A contentEditable element must always pass clicks
       // through, so the class belongs on the component itself, not the call
       // site.
-      className={`titlebar-no-drag session-title outline-none focus:ring-1 focus:ring-primary rounded-sm ${className ?? ''}`}
+      //
+      // Standard inline-edit-title pattern (Linear/Notion/Figma):
+      // - Filled (default): looks like a plain bold heading. truncate +
+      //   transparent border that reserves space so focus does not shift
+      //   the layout.
+      // - Focused: same dimensions, border becomes primary (the only
+      //   visual change), overflow-x-auto + text-clip replaces truncate
+      //   so the user edits without ellipsis. text-clip is required —
+      //   overflow-x-auto alone does not suppress text-overflow:ellipsis,
+      //   the dots keep rendering.
+      // The contentEditable element shows a text caret on hover by
+      // default — that is the discoverability hint, no extra hover chrome
+      // needed.
+      className={`titlebar-no-drag session-title h-9 rounded-lg border border-transparent px-4 leading-9 outline-none transition-colors truncate focus:border-primary focus:overflow-x-auto focus:text-clip ${className ?? ''}`}
       contentEditable
       suppressContentEditableWarning
       onBlur={onBlur}

--- a/src/renderer/src/components/review/EditableSessionTitle.tsx
+++ b/src/renderer/src/components/review/EditableSessionTitle.tsx
@@ -73,7 +73,13 @@ export function EditableSessionTitle({
   return (
     <h2
       ref={setRef}
-      className={`session-title outline-none focus:ring-1 focus:ring-primary rounded-sm ${className ?? ''}`}
+      // `titlebar-no-drag` is mandatory: the parent ReviewEditor header is a
+      // macOS hiddenInset drag region (`titlebar-drag`); without this opt-out
+      // the OS treats clicks as window-drags and the contentEditable never
+      // receives focus. A contentEditable element must always pass clicks
+      // through, so the class belongs on the component itself, not the call
+      // site.
+      className={`titlebar-no-drag session-title outline-none focus:ring-1 focus:ring-primary rounded-sm ${className ?? ''}`}
       contentEditable
       suppressContentEditableWarning
       onBlur={onBlur}

--- a/src/renderer/src/components/review/ProvenancePanel.tsx
+++ b/src/renderer/src/components/review/ProvenancePanel.tsx
@@ -1,0 +1,134 @@
+import { ChevronDown } from 'lucide-react'
+import { formatBytes } from '../../utils/formatBytes'
+import type { ModelSnapshot, ProcessedModelsSnapshot } from '../../../../shared/types'
+
+interface Props {
+  data: ProcessedModelsSnapshot | null
+  reviewAt: string | null
+}
+
+type GroupKey = 'asr' | 'diarization' | 'ner' | 'summarization'
+
+const GROUP_LABELS: Record<GroupKey, string> = {
+  asr: 'Spracherkennung',
+  diarization: 'Sprechererkennung',
+  ner: 'Pseudonymisierung',
+  summarization: 'Zusammenfassung'
+}
+
+const GROUP_ORDER: GroupKey[] = ['asr', 'diarization', 'ner', 'summarization']
+
+const LEGACY_HINT =
+  'Diese Sitzung wurde vor Einführung der detaillierten Modell-Protokollierung verarbeitet.'
+
+function formatProcessedAt(iso: string | null): string | null {
+  if (!iso) return null
+  const date = new Date(iso)
+  if (Number.isNaN(date.getTime())) return null
+  return date.toLocaleString('de-CH', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit'
+  })
+}
+
+/**
+ * Issue #84 Story I — Modell-Provenienz pro Sitzung. Default-collapsed
+ * disclosure showing which model identity (id + version + sha256 + size)
+ * produced each pipeline group's output. Uses native `<details>` so the
+ * default-closed state and a11y come for free.
+ *
+ * Legacy sessions (processed_with_models == null) render the neutral hint
+ * instead of fake/missing model rows.
+ */
+export function ProvenancePanel({ data, reviewAt }: Props): React.JSX.Element {
+  const processedAt = formatProcessedAt(reviewAt)
+
+  return (
+    <details className="group rounded-lg border border-border bg-surface-1">
+      <summary className="flex cursor-pointer list-none items-center justify-between px-4 py-2.5 text-sm font-medium text-text-secondary hover:bg-surface-2">
+        <span>Verarbeitungs-Information</span>
+        <ChevronDown
+          className="h-4 w-4 transition-transform group-open:rotate-180"
+          strokeWidth={2}
+          aria-hidden="true"
+        />
+      </summary>
+
+      <div className="border-t border-border px-4 py-3 text-sm">
+        {data === null ? (
+          <p className="text-text-tertiary">{LEGACY_HINT}</p>
+        ) : (
+          <div className="space-y-3">
+            {processedAt && (
+              <Row label="Verarbeitet am" value={processedAt} />
+            )}
+            <div className="space-y-2">
+              {GROUP_ORDER.map((group) => (
+                <GroupRow
+                  key={group}
+                  label={GROUP_LABELS[group]}
+                  snapshot={data[group]}
+                />
+              ))}
+            </div>
+
+            <details className="pt-1 text-xs">
+              <summary className="cursor-pointer list-none text-text-tertiary hover:text-text-secondary">
+                ▸ Technische Details (Hash, IDs)
+              </summary>
+              <div className="mt-2 space-y-2 rounded-md border border-border bg-surface-0 px-3 py-2 font-mono text-[11px] leading-relaxed text-text-tertiary">
+                {GROUP_ORDER.map((group) => {
+                  const snap = data[group]
+                  if (!snap) return null
+                  return (
+                    <div key={group}>
+                      <div className="text-text-secondary">{GROUP_LABELS[group]}</div>
+                      <div>id: {snap.id}</div>
+                      <div className="break-all">sha256: {snap.sha256}</div>
+                    </div>
+                  )
+                })}
+              </div>
+            </details>
+          </div>
+        )}
+      </div>
+    </details>
+  )
+}
+
+function Row({ label, value }: { label: string; value: string }): React.JSX.Element {
+  return (
+    <div className="flex items-baseline gap-3">
+      <span className="w-44 shrink-0 text-text-tertiary">{label}</span>
+      <span className="text-text-primary">{value}</span>
+    </div>
+  )
+}
+
+function GroupRow({
+  label,
+  snapshot
+}: {
+  label: string
+  snapshot: ModelSnapshot | null
+}): React.JSX.Element {
+  return (
+    <div className="flex items-baseline gap-3">
+      <span className="w-44 shrink-0 text-text-tertiary">{label}</span>
+      {snapshot === null ? (
+        <span className="text-text-tertiary">nicht erstellt</span>
+      ) : (
+        <span className="min-w-0 flex-1 text-text-primary">
+          {snapshot.label}
+          <span className="ml-2 text-text-tertiary">
+            Version {snapshot.version} · {formatBytes(snapshot.sizeBytes)}
+          </span>
+        </span>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/src/components/review/__tests__/ProvenancePanel.test.tsx
+++ b/src/renderer/src/components/review/__tests__/ProvenancePanel.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ProvenancePanel } from '../ProvenancePanel'
+import type { ProcessedModelsSnapshot } from '../../../../../shared/types'
+
+const SHA = (c: string): string => c.repeat(64)
+
+const fullSnapshot: ProcessedModelsSnapshot = {
+  capturedAt: '2026-04-15T14:32:00Z',
+  asr: {
+    id: 'whisper-large-v3-turbo',
+    label: 'Whisper Large V3 Turbo',
+    version: '2026-04-01',
+    sha256: SHA('a'),
+    sizeBytes: 1_700_000_000
+  },
+  diarization: {
+    id: 'pyannote-suite',
+    label: 'pyannote 3.1',
+    version: '2026-03-12',
+    sha256: SHA('b'),
+    sizeBytes: 200_000_000
+  },
+  ner: {
+    id: 'flair-ner-german-large',
+    label: 'flair NER German Large',
+    version: '2026-02-08',
+    sha256: SHA('c'),
+    sizeBytes: 1_100_000_000
+  },
+  summarization: null
+}
+
+describe('ProvenancePanel', () => {
+  it('renders the legacy hint when data is null', async () => {
+    const user = userEvent.setup()
+    render(<ProvenancePanel data={null} reviewAt={null} />)
+
+    await user.click(screen.getByText('Verarbeitungs-Information'))
+    expect(
+      screen.getByText(/vor Einführung der detaillierten Modell-Protokollierung/i)
+    ).toBeInTheDocument()
+  })
+
+  it('renders model rows with label, version and size on open', async () => {
+    const user = userEvent.setup()
+    render(<ProvenancePanel data={fullSnapshot} reviewAt="2026-04-15T14:32:00Z" />)
+
+    await user.click(screen.getByText('Verarbeitungs-Information'))
+
+    // Group labels appear twice (main row + Technische Details key) — both
+    // are intentional. We just assert presence and the model-specific values.
+    expect(screen.getByText('Whisper Large V3 Turbo')).toBeInTheDocument()
+    expect(screen.getByText(/Version 2026-04-01/)).toBeInTheDocument()
+    expect(screen.getAllByText('Spracherkennung').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('Sprechererkennung').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('Pseudonymisierung').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('Zusammenfassung').length).toBeGreaterThan(0)
+  })
+
+  it('shows "nicht erstellt" for skipped optional groups (e.g. summarization)', async () => {
+    const user = userEvent.setup()
+    render(<ProvenancePanel data={fullSnapshot} reviewAt={null} />)
+
+    await user.click(screen.getByText('Verarbeitungs-Information'))
+    // summarization is null in the snapshot
+    expect(screen.getByText('nicht erstellt')).toBeInTheDocument()
+  })
+
+  it('exposes id + sha256 inside the "Technische Details" sub-disclosure', async () => {
+    const user = userEvent.setup()
+    render(<ProvenancePanel data={fullSnapshot} reviewAt={null} />)
+
+    await user.click(screen.getByText('Verarbeitungs-Information'))
+    await user.click(screen.getByText(/Technische Details/i))
+
+    expect(screen.getByText('id: whisper-large-v3-turbo')).toBeInTheDocument()
+    expect(screen.getByText(`sha256: ${SHA('a')}`)).toBeInTheDocument()
+    expect(screen.getByText(`sha256: ${SHA('b')}`)).toBeInTheDocument()
+  })
+
+  it('omits the "Verarbeitet am" row when reviewAt is null', async () => {
+    const user = userEvent.setup()
+    render(<ProvenancePanel data={fullSnapshot} reviewAt={null} />)
+    await user.click(screen.getByText('Verarbeitungs-Information'))
+    expect(screen.queryByText('Verarbeitet am')).not.toBeInTheDocument()
+  })
+})

--- a/src/renderer/src/components/settings/DiarizationPipelineSection.tsx
+++ b/src/renderer/src/components/settings/DiarizationPipelineSection.tsx
@@ -27,7 +27,12 @@ const PIPELINE_INFOS: PipelineInfo[] = [
   }
 ]
 
-/** Baut einen Pseudo-ModelCatalogEntry, damit die Pipeline im ModelCard gerendert werden kann. */
+/**
+ * Build a pseudo-ModelCatalogEntry so the pipeline choices render as
+ * ModelCards. Both pipelines piggyback on the installed pyannote-suite —
+ * this section is only mounted when the suite is on disk (gated by
+ * ModelsSettings, Story E), so `isInstalled: true` is accurate here.
+ */
 function toCatalogEntry(info: PipelineInfo, isActive: boolean): ModelCatalogEntry {
   return {
     id: info.id,
@@ -66,34 +71,28 @@ export default function DiarizationPipelineSection(): React.JSX.Element {
   }
 
   return (
-    <section className="space-y-3">
-      <div>
-        <h2 className="mb-1 text-lg font-semibold">Sprechererkennungs-Pipeline</h2>
-        <p className="text-sm text-text-secondary">
-          Das pyannote-Paket enthält zwei Pipelines. Wähle, welche für neue Transkriptionen
-          verwendet werden soll.
-        </p>
-      </div>
+    <div className="space-y-3">
+      <p className="text-sm text-text-secondary">
+        Das pyannote-Paket enthält zwei Pipelines. Wähle, welche für neue Transkriptionen
+        verwendet werden soll.
+      </p>
 
-      <div>
-        <h3 className="mb-2 text-sm font-medium text-text-tertiary">Installiert</h3>
-        <div className="space-y-3">
-          {PIPELINE_INFOS.map((info) => (
-            <ModelCard
-              key={info.id}
-              model={toCatalogEntry(info, active === info.id)}
-              downloading={false}
-              anyBusy={false}
-              deletable={false}
-              showChips={false}
-              onDownload={noop}
-              onCancelDownload={noop}
-              onDelete={noop}
-              onActivate={() => handleActivate(info.id)}
-            />
-          ))}
-        </div>
+      <div className="space-y-3">
+        {PIPELINE_INFOS.map((info) => (
+          <ModelCard
+            key={info.id}
+            model={toCatalogEntry(info, active === info.id)}
+            downloading={false}
+            anyBusy={false}
+            deletable={false}
+            showChips={false}
+            onDownload={noop}
+            onCancelDownload={noop}
+            onDelete={noop}
+            onActivate={() => handleActivate(info.id)}
+          />
+        ))}
       </div>
-    </section>
+    </div>
   )
 }

--- a/src/renderer/src/components/settings/ModelCard.tsx
+++ b/src/renderer/src/components/settings/ModelCard.tsx
@@ -2,6 +2,7 @@ import { Download, ExternalLink, Power, PowerOff, Trash2, X } from 'lucide-react
 import type { LucideIcon } from 'lucide-react'
 import type { ModelCatalogEntry } from '../../../../shared/validation/model-catalog-schemas'
 import { formatBytes } from '../../utils/formatBytes'
+import ModelStatusBadge, { deriveModelStatus } from './ModelStatusBadge'
 
 interface Props {
   model: ModelCatalogEntry
@@ -162,11 +163,7 @@ export default function ModelCard({
                 <ExternalLink className="h-3.5 w-3.5" strokeWidth={1.75} aria-hidden="true" />
               </a>
             )}
-            {model.isActive && (
-              <span className="rounded-full bg-primary px-2 py-0.5 text-xs font-medium text-white">
-                Aktiv
-              </span>
-            )}
+            <ModelStatusBadge status={deriveModelStatus(model)} />
           </div>
 
           {showChips && (

--- a/src/renderer/src/components/settings/ModelStatusBadge.tsx
+++ b/src/renderer/src/components/settings/ModelStatusBadge.tsx
@@ -1,0 +1,95 @@
+import { AlertTriangle, Check, CircleDot, Download } from 'lucide-react'
+import type { LucideIcon } from 'lucide-react'
+
+/**
+ * Issue #84 / Story E — single source of truth for the disk-vs-active
+ * status of a model card.
+ *
+ * - `active`       — currently the active model AND installed on disk.
+ * - `installed`    — on disk, ready to be activated, but not currently active.
+ * - `missing`      — not yet downloaded.
+ * - `inconsistent` — defense-in-depth: settings believe the model is active
+ *                    but its file is missing on disk. The bootstrap reconciler
+ *                    (Story C) clears such states at startup; the badge
+ *                    surfaces it for the rare in-session case (e.g. user
+ *                    deleted the file in Finder while the app is running).
+ */
+export type ModelStatus = 'active' | 'installed' | 'missing' | 'inconsistent'
+
+export function deriveModelStatus(entry: {
+  isActive: boolean
+  isInstalled: boolean
+}): ModelStatus {
+  if (entry.isActive && !entry.isInstalled) return 'inconsistent'
+  if (entry.isActive) return 'active'
+  if (entry.isInstalled) return 'installed'
+  return 'missing'
+}
+
+interface BadgeStyle {
+  Icon: LucideIcon
+  /** Visible micro-text label. */
+  label: string
+  /** Tooltip / aria-label expansion of the label for screen readers. */
+  description: string
+  /** Tailwind classes for the pill wrapper (border + background + text colour). */
+  pillClassName: string
+  /** Tailwind classes for the icon — kept separate so the icon can pop in
+   *  the green/orange semantic colour while the pill stays calm. */
+  iconClassName: string
+}
+
+const STYLES: Record<ModelStatus, BadgeStyle> = {
+  active: {
+    Icon: CircleDot,
+    label: 'Aktiv',
+    description: 'Aktiv — wird für neue Verarbeitungen verwendet',
+    pillClassName: 'border-border bg-surface-2 text-text-primary',
+    iconClassName: 'text-success'
+  },
+  installed: {
+    Icon: Check,
+    label: 'Installiert',
+    description: 'Installiert — kann aktiviert werden',
+    pillClassName: 'border-border bg-surface-2 text-text-secondary',
+    iconClassName: 'text-text-tertiary'
+  },
+  missing: {
+    Icon: Download,
+    label: 'Nicht installiert',
+    description: 'Nicht installiert — noch nicht heruntergeladen',
+    pillClassName: 'border-border bg-surface-1 text-text-tertiary',
+    iconClassName: 'text-text-tertiary'
+  },
+  inconsistent: {
+    Icon: AlertTriangle,
+    label: 'Aktiv, aber fehlt',
+    description:
+      'Aktiv markiert, aber nicht auf Disk gefunden — wird beim nächsten Start automatisch repariert',
+    pillClassName: 'border-warning-border bg-warning-bg text-warning-text',
+    iconClassName: 'text-warning'
+  }
+}
+
+interface Props {
+  status: ModelStatus
+}
+
+export default function ModelStatusBadge({ status }: Props): React.JSX.Element {
+  const style = STYLES[status]
+  return (
+    <span
+      role="status"
+      title={style.description}
+      aria-label={style.description}
+      className={`inline-flex shrink-0 items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] font-medium ${style.pillClassName}`}
+    >
+      <style.Icon
+        className={`h-3 w-3 ${style.iconClassName}`}
+        strokeWidth={2}
+        aria-hidden="true"
+      />
+      {style.label}
+    </span>
+  )
+}

--- a/src/renderer/src/components/settings/ModelStatusBadge.tsx
+++ b/src/renderer/src/components/settings/ModelStatusBadge.tsx
@@ -63,7 +63,10 @@ const STYLES: Record<ModelStatus, BadgeStyle> = {
   },
   inconsistent: {
     Icon: AlertTriangle,
-    label: 'Aktiv, aber fehlt',
+    // Locked spec text from Issue #84 UX update — pill carries the full
+    // sentence (not truncated to a tooltip) so the self-heal promise is
+    // visible without hover.
+    label: 'Aktiv, aber fehlt — wird repariert',
     description:
       'Aktiv markiert, aber nicht auf Disk gefunden — wird beim nächsten Start automatisch repariert',
     pillClassName: 'border-warning-border bg-warning-bg text-warning-text',

--- a/src/renderer/src/components/settings/ModelsSettings.tsx
+++ b/src/renderer/src/components/settings/ModelsSettings.tsx
@@ -1,20 +1,37 @@
 import { useEffect, useState } from 'react'
 import type { ModelCatalogEntry } from '../../../../shared/validation/model-catalog-schemas'
 import type { ModelDownloadStatus } from '../../../../shared/types/IpcApi'
+import { useReconcileEvents } from '../../hooks/useReconcileEvents'
 import { useToast } from '../../hooks/useToast'
 import { ConfirmDialog } from '../ConfirmDialog'
 import { formatBytes } from '../../utils/formatBytes'
 import ModelCard from './ModelCard'
 import DiarizationPipelineSection from './DiarizationPipelineSection'
+import ReconcileEventsBanner from './ReconcileEventsBanner'
 
 export default function ModelsSettings(): React.JSX.Element {
   const toast = useToast()
+  const reconcile = useReconcileEvents()
   const [asrModels, setAsrModels] = useState<ModelCatalogEntry[]>([])
   const [nerModels, setNerModels] = useState<ModelCatalogEntry[]>([])
   const [summarizationModels, setSummarizationModels] = useState<ModelCatalogEntry[]>([])
   const [downloadingId, setDownloadingId] = useState<string | null>(null)
   const [progress, setProgress] = useState<number | undefined>(undefined)
   const [deleteCandidate, setDeleteCandidate] = useState<ModelCatalogEntry | null>(null)
+
+  // Mark reconcile events as seen on mount — the banner stays visible until
+  // the user clicks "Verstanden", but the BottomNav dot disappears immediately
+  // because the user has now reached the surface that explains the change.
+  // Dep is the events array (changes when the hook refreshes) + the stable
+  // markSeen callback. The `.some` guard short-circuits subsequent runs once
+  // every event has transitioned to `seen`.
+  const reconcileEvents = reconcile.events
+  const reconcileMarkSeen = reconcile.markSeen
+  useEffect(() => {
+    if (reconcileEvents.some((e) => e.status === 'pending')) {
+      reconcileMarkSeen()
+    }
+  }, [reconcileEvents, reconcileMarkSeen])
 
   const reload = async (): Promise<void> => {
     const [asr, ner, summarization] = await Promise.all([
@@ -109,6 +126,10 @@ export default function ModelsSettings(): React.JSX.Element {
 
   return (
     <div className="space-y-8 p-6">
+      {reconcile.events.length > 0 && (
+        <ReconcileEventsBanner events={reconcile.events} onDismiss={reconcile.dismiss} />
+      )}
+
       <section className="space-y-3">
         <div>
           <h2 className="mb-1 text-lg font-semibold">Transkriptions-Modelle</h2>

--- a/src/renderer/src/components/settings/ModelsSettings.tsx
+++ b/src/renderer/src/components/settings/ModelsSettings.tsx
@@ -16,10 +16,27 @@ interface ModelsSettingsProps {
   onOpenAbout: () => void
 }
 
+/**
+ * Issue #84 / Story E — sort by status (active first, then installed, then
+ * missing). Within each bucket, preserve the catalog order. This replaces
+ * the previous "Installiert" / "Zum Download verfügbar" sub-headers, which
+ * fragmented a small list and hid the disk-reality behind two clicks.
+ */
+function statusOrder(entry: ModelCatalogEntry): number {
+  if (entry.isActive) return 0
+  if (entry.isInstalled) return 1
+  return 2
+}
+
+function sortByStatus(entries: ModelCatalogEntry[]): ModelCatalogEntry[] {
+  return [...entries].sort((a, b) => statusOrder(a) - statusOrder(b))
+}
+
 export default function ModelsSettings({ onOpenAbout }: ModelsSettingsProps): React.JSX.Element {
   const toast = useToast()
   const reconcile = useReconcileEvents()
   const [asrModels, setAsrModels] = useState<ModelCatalogEntry[]>([])
+  const [diarizationModels, setDiarizationModels] = useState<ModelCatalogEntry[]>([])
   const [nerModels, setNerModels] = useState<ModelCatalogEntry[]>([])
   const [summarizationModels, setSummarizationModels] = useState<ModelCatalogEntry[]>([])
   const [downloadingId, setDownloadingId] = useState<string | null>(null)
@@ -41,12 +58,14 @@ export default function ModelsSettings({ onOpenAbout }: ModelsSettingsProps): Re
   }, [reconcileEvents, reconcileMarkSeen])
 
   const reload = async (): Promise<void> => {
-    const [asr, ner, summarization] = await Promise.all([
+    const [asr, diarization, ner, summarization] = await Promise.all([
       window.api.modelCatalog.list('asr'),
+      window.api.modelCatalog.list('diarization'),
       window.api.modelCatalog.list('ner'),
       window.api.modelCatalog.list('summarization')
     ])
     setAsrModels(asr)
+    setDiarizationModels(diarization)
     setNerModels(ner)
     setSummarizationModels(summarization)
   }
@@ -73,9 +92,9 @@ export default function ModelsSettings({ onOpenAbout }: ModelsSettingsProps): Re
     setDownloadingId(id)
     try {
       await window.api.modelCatalog.download(id)
-      // download returns the catalog for the model's group only — reload both
-      // to keep ASR + summarization grids in sync regardless of which one
-      // triggered the download.
+      // download returns the catalog for the model's group only — reload all
+      // groups to keep grids in sync regardless of which one triggered the
+      // download.
       await reload()
       toast.success('Modell erfolgreich heruntergeladen.')
     } catch (err) {
@@ -127,9 +146,17 @@ export default function ModelsSettings({ onOpenAbout }: ModelsSettingsProps): Re
     }
   }
 
-  const installed = asrModels.filter((m) => m.isInstalled)
-  const available = asrModels.filter((m) => !m.isInstalled)
   const anyBusy = downloadingId !== null
+  const sharedActions = {
+    onCancelDownload: handleCancelDownload,
+    onDelete: (m: ModelCatalogEntry) => setDeleteCandidate(m)
+  }
+
+  // Diarization is shipped as a single bundled suite (pyannote-suite). The
+  // pipeline picker (3.1 vs community-1) only makes sense when the suite is
+  // installed; otherwise the whole pyannote step is unavailable.
+  const diarizationSuite = diarizationModels[0] ?? null
+  const diarizationInstalled = diarizationSuite?.isInstalled === true
 
   return (
     <div className="space-y-8 p-6">
@@ -137,62 +164,62 @@ export default function ModelsSettings({ onOpenAbout }: ModelsSettingsProps): Re
         <ReconcileEventsBanner events={reconcile.events} onDismiss={reconcile.dismiss} />
       )}
 
+      {/* ── Spracherkennung ───────────────────────────────────────────── */}
       <section className="space-y-3">
         <div>
-          <h2 className="mb-1 text-lg font-semibold">Transkriptions-Modelle</h2>
+          <h2 className="mb-1 text-lg font-semibold">Spracherkennung</h2>
           <p className="text-sm text-text-secondary">
-            Wähle das Modell, das für die Transkription verwendet werden soll. Ein
-            Modellwechsel wirkt sich nur auf neue Transkriptionen aus.
+            Wandelt Audio in Text um. Ein Modellwechsel wirkt sich nur auf neue
+            Transkriptionen aus.
           </p>
         </div>
 
-        {installed.length > 0 && (
-          <div>
-            <h3 className="mb-2 text-sm font-medium text-text-tertiary">Installiert</h3>
-            <div className="space-y-3">
-              {installed.map((m) => (
-                <ModelCard
-                  key={m.id}
-                  model={m}
-                  downloading={downloadingId === m.id}
-                  progress={downloadingId === m.id ? progress : undefined}
-                  anyBusy={anyBusy}
-                  onDownload={() => handleDownload(m.id)}
-                  onCancelDownload={handleCancelDownload}
-                  onDelete={() => setDeleteCandidate(m)}
-                  onActivate={() => handleActivate(m)}
-                />
-              ))}
-            </div>
-          </div>
-        )}
-
-        {available.length > 0 && (
-          <div>
-            <h3 className="mb-2 text-sm font-medium text-text-tertiary">
-              Zum Download verfügbar
-            </h3>
-            <div className="space-y-3">
-              {available.map((m) => (
-                <ModelCard
-                  key={m.id}
-                  model={m}
-                  downloading={downloadingId === m.id}
-                  progress={downloadingId === m.id ? progress : undefined}
-                  anyBusy={anyBusy}
-                  onDownload={() => handleDownload(m.id)}
-                  onCancelDownload={handleCancelDownload}
-                  onDelete={() => setDeleteCandidate(m)}
-                  onActivate={() => handleActivate(m)}
-                />
-              ))}
-            </div>
-          </div>
-        )}
+        <div className="space-y-3">
+          {sortByStatus(asrModels).map((m) => (
+            <ModelCard
+              key={m.id}
+              model={m}
+              downloading={downloadingId === m.id}
+              progress={downloadingId === m.id ? progress : undefined}
+              anyBusy={anyBusy}
+              onDownload={() => handleDownload(m.id)}
+              onCancelDownload={sharedActions.onCancelDownload}
+              onDelete={() => sharedActions.onDelete(m)}
+              onActivate={() => handleActivate(m)}
+            />
+          ))}
+        </div>
       </section>
 
-      <DiarizationPipelineSection />
+      {/* ── Sprechererkennung ─────────────────────────────────────────── */}
+      <section className="space-y-3">
+        <div>
+          <h2 className="mb-1 text-lg font-semibold">Sprechererkennung</h2>
+          <p className="text-sm text-text-secondary">
+            Trennt verschiedene Gesprächspersonen anhand der Stimmenmerkmale.
+          </p>
+        </div>
 
+        {diarizationSuite && (
+          <ModelCard
+            model={diarizationSuite}
+            downloading={downloadingId === diarizationSuite.id}
+            progress={downloadingId === diarizationSuite.id ? progress : undefined}
+            anyBusy={anyBusy}
+            deletable={false}
+            onDownload={() => handleDownload(diarizationSuite.id)}
+            onCancelDownload={sharedActions.onCancelDownload}
+            onDelete={() => sharedActions.onDelete(diarizationSuite)}
+            onActivate={() => handleActivate(diarizationSuite)}
+          />
+        )}
+
+        {/* Pipeline-Picker erscheint nur, wenn das pyannote-Bundle installiert ist —
+            Wahl-Affordances existieren nicht, wo nichts wählbar ist. */}
+        {diarizationInstalled && <DiarizationPipelineSection />}
+      </section>
+
+      {/* ── Pseudonymisierung ─────────────────────────────────────────── */}
       <section className="space-y-3">
         <div>
           <h2 className="mb-1 text-lg font-semibold">Pseudonymisierung</h2>
@@ -208,118 +235,51 @@ export default function ModelsSettings({ onOpenAbout }: ModelsSettingsProps): Re
           </p>
         </div>
 
-        {nerModels.filter((m) => m.isInstalled).length > 0 && (
-          <div>
-            <h3 className="mb-2 text-sm font-medium text-text-tertiary">Installiert</h3>
-            <div className="space-y-3">
-              {nerModels
-                .filter((m) => m.isInstalled)
-                .map((m) => (
-                  <ModelCard
-                    key={m.id}
-                    model={m}
-                    downloading={downloadingId === m.id}
-                    progress={downloadingId === m.id ? progress : undefined}
-                    anyBusy={anyBusy}
-                    deletable={false}
-                    onDownload={() => handleDownload(m.id)}
-                    onCancelDownload={handleCancelDownload}
-                    onDelete={() => setDeleteCandidate(m)}
-                    onActivate={() => handleActivate(m)}
-                  />
-                ))}
-            </div>
-          </div>
-        )}
-
-        {nerModels.filter((m) => !m.isInstalled).length > 0 && (
-          <div>
-            <h3 className="mb-2 text-sm font-medium text-text-tertiary">
-              Zum Download verfügbar
-            </h3>
-            <div className="space-y-3">
-              {nerModels
-                .filter((m) => !m.isInstalled)
-                .map((m) => (
-                  <ModelCard
-                    key={m.id}
-                    model={m}
-                    downloading={downloadingId === m.id}
-                    progress={downloadingId === m.id ? progress : undefined}
-                    anyBusy={anyBusy}
-                    deletable={false}
-                    onDownload={() => handleDownload(m.id)}
-                    onCancelDownload={handleCancelDownload}
-                    onDelete={() => setDeleteCandidate(m)}
-                    onActivate={() => handleActivate(m)}
-                  />
-                ))}
-            </div>
-          </div>
-        )}
+        <div className="space-y-3">
+          {sortByStatus(nerModels).map((m) => (
+            <ModelCard
+              key={m.id}
+              model={m}
+              downloading={downloadingId === m.id}
+              progress={downloadingId === m.id ? progress : undefined}
+              anyBusy={anyBusy}
+              deletable={false}
+              onDownload={() => handleDownload(m.id)}
+              onCancelDownload={sharedActions.onCancelDownload}
+              onDelete={() => sharedActions.onDelete(m)}
+              onActivate={() => handleActivate(m)}
+            />
+          ))}
+        </div>
       </section>
 
+      {/* ── Zusammenfassung ───────────────────────────────────────────── */}
       <section className="space-y-3">
         <div>
           <h2 className="mb-1 text-lg font-semibold">Zusammenfassung (optional)</h2>
           <p className="text-sm text-text-secondary">
             Lokales Sprachmodell für 2-Satz-Zusammenfassungen am Ende der Verarbeitung.
-            Optional — ohne installiertes Modell wird der Schritt geräuschlos
-            übersprungen.
+            Ohne installiertes Modell wird der Schritt geräuschlos übersprungen.
           </p>
         </div>
 
-        {summarizationModels.filter((m) => m.isInstalled).length > 0 && (
-          <div>
-            <h3 className="mb-2 text-sm font-medium text-text-tertiary">Installiert</h3>
-            <div className="space-y-3">
-              {summarizationModels
-                .filter((m) => m.isInstalled)
-                .map((m) => (
-                  <ModelCard
-                    key={m.id}
-                    model={m}
-                    downloading={downloadingId === m.id}
-                    progress={downloadingId === m.id ? progress : undefined}
-                    anyBusy={anyBusy}
-                    optional
-                    onDownload={() => handleDownload(m.id)}
-                    onCancelDownload={handleCancelDownload}
-                    onDelete={() => setDeleteCandidate(m)}
-                    onActivate={() => handleActivate(m)}
-                    onDeactivate={() => handleDeactivate(m)}
-                  />
-                ))}
-            </div>
-          </div>
-        )}
-
-        {summarizationModels.filter((m) => !m.isInstalled).length > 0 && (
-          <div>
-            <h3 className="mb-2 text-sm font-medium text-text-tertiary">
-              Zum Download verfügbar
-            </h3>
-            <div className="space-y-3">
-              {summarizationModels
-                .filter((m) => !m.isInstalled)
-                .map((m) => (
-                  <ModelCard
-                    key={m.id}
-                    model={m}
-                    downloading={downloadingId === m.id}
-                    progress={downloadingId === m.id ? progress : undefined}
-                    anyBusy={anyBusy}
-                    optional
-                    onDownload={() => handleDownload(m.id)}
-                    onCancelDownload={handleCancelDownload}
-                    onDelete={() => setDeleteCandidate(m)}
-                    onActivate={() => handleActivate(m)}
-                    onDeactivate={() => handleDeactivate(m)}
-                  />
-                ))}
-            </div>
-          </div>
-        )}
+        <div className="space-y-3">
+          {sortByStatus(summarizationModels).map((m) => (
+            <ModelCard
+              key={m.id}
+              model={m}
+              downloading={downloadingId === m.id}
+              progress={downloadingId === m.id ? progress : undefined}
+              anyBusy={anyBusy}
+              optional
+              onDownload={() => handleDownload(m.id)}
+              onCancelDownload={sharedActions.onCancelDownload}
+              onDelete={() => sharedActions.onDelete(m)}
+              onActivate={() => handleActivate(m)}
+              onDeactivate={() => handleDeactivate(m)}
+            />
+          ))}
+        </div>
       </section>
 
       {deleteCandidate && (
@@ -335,3 +295,6 @@ export default function ModelsSettings({ onOpenAbout }: ModelsSettingsProps): Re
     </div>
   )
 }
+
+/** Issue #84 / Story E — exported for unit tests. */
+export { sortByStatus }

--- a/src/renderer/src/components/settings/ModelsSettings.tsx
+++ b/src/renderer/src/components/settings/ModelsSettings.tsx
@@ -9,13 +9,6 @@ import ModelCard from './ModelCard'
 import DiarizationPipelineSection from './DiarizationPipelineSection'
 import ReconcileEventsBanner from './ReconcileEventsBanner'
 
-interface ModelsSettingsProps {
-  /** Issue #84 / Story H — open the About sub-page so the user can read the
-   *  Pseudonymisierung explainer. Triggered by the "Was ist Pseudonymisierung?"
-   *  link below the group header. */
-  onOpenAbout: () => void
-}
-
 /**
  * Issue #84 / Story E — sort by status (active first, then installed, then
  * missing). Within each bucket, preserve the catalog order. This replaces
@@ -32,7 +25,7 @@ function sortByStatus(entries: ModelCatalogEntry[]): ModelCatalogEntry[] {
   return [...entries].sort((a, b) => statusOrder(a) - statusOrder(b))
 }
 
-export default function ModelsSettings({ onOpenAbout }: ModelsSettingsProps): React.JSX.Element {
+export default function ModelsSettings(): React.JSX.Element {
   const toast = useToast()
   const reconcile = useReconcileEvents()
   const [asrModels, setAsrModels] = useState<ModelCatalogEntry[]>([])
@@ -224,14 +217,10 @@ export default function ModelsSettings({ onOpenAbout }: ModelsSettingsProps): Re
         <div>
           <h2 className="mb-1 text-lg font-semibold">Pseudonymisierung</h2>
           <p className="text-sm text-text-secondary">
-            Erkennt Personen, Orte und andere sensible Entitäten.{' '}
-            <button
-              type="button"
-              className="titlebar-no-drag font-medium text-primary transition-colors hover:text-primary-hover"
-              onClick={onOpenAbout}
-            >
-              Was ist Pseudonymisierung? →
-            </button>
+            Erkennt Personen, Orte und andere sensible Entitäten und ersetzt sie durch
+            typisierte Platzhalter (z.&nbsp;B. [PERSON&nbsp;1]). DSGVO-rechtlich
+            Pseudonymisierung — die Originale bleiben lokal und werden nach 30&nbsp;Tagen
+            automatisch gelöscht.
           </p>
         </div>
 

--- a/src/renderer/src/components/settings/ModelsSettings.tsx
+++ b/src/renderer/src/components/settings/ModelsSettings.tsx
@@ -9,7 +9,14 @@ import ModelCard from './ModelCard'
 import DiarizationPipelineSection from './DiarizationPipelineSection'
 import ReconcileEventsBanner from './ReconcileEventsBanner'
 
-export default function ModelsSettings(): React.JSX.Element {
+interface ModelsSettingsProps {
+  /** Issue #84 / Story H — open the About sub-page so the user can read the
+   *  Pseudonymisierung explainer. Triggered by the "Was ist Pseudonymisierung?"
+   *  link below the group header. */
+  onOpenAbout: () => void
+}
+
+export default function ModelsSettings({ onOpenAbout }: ModelsSettingsProps): React.JSX.Element {
   const toast = useToast()
   const reconcile = useReconcileEvents()
   const [asrModels, setAsrModels] = useState<ModelCatalogEntry[]>([])
@@ -188,9 +195,16 @@ export default function ModelsSettings(): React.JSX.Element {
 
       <section className="space-y-3">
         <div>
-          <h2 className="mb-1 text-lg font-semibold">Anonymisierung</h2>
+          <h2 className="mb-1 text-lg font-semibold">Pseudonymisierung</h2>
           <p className="text-sm text-text-secondary">
-            Erkennt Personen, Orte und andere sensible Entitäten.
+            Erkennt Personen, Orte und andere sensible Entitäten.{' '}
+            <button
+              type="button"
+              className="titlebar-no-drag font-medium text-primary transition-colors hover:text-primary-hover"
+              onClick={onOpenAbout}
+            >
+              Was ist Pseudonymisierung? →
+            </button>
           </p>
         </div>
 

--- a/src/renderer/src/components/settings/ReconcileEventsBanner.tsx
+++ b/src/renderer/src/components/settings/ReconcileEventsBanner.tsx
@@ -1,0 +1,104 @@
+import { Info } from 'lucide-react'
+import type {
+  ReconcileEvent,
+  ReconcileReason
+} from '../../../../shared/types/ReconcileEvent'
+import type { ModelGroup } from '../../../../shared/validation/model-catalog-schemas'
+
+interface Props {
+  events: ReconcileEvent[]
+  onDismiss: () => void
+}
+
+const GROUP_LABEL: Record<ModelGroup, string> = {
+  asr: 'Spracherkennung',
+  diarization: 'Sprechererkennung',
+  ner: 'Pseudonymisierung',
+  summarization: 'Zusammenfassung'
+}
+
+const REASON_LABEL: Record<ReconcileReason, string> = {
+  'model-removed': 'Vorheriges Modell nicht mehr gefunden — kein Ersatz installiert',
+  'default-promoted': 'Vorheriges Modell nicht mehr gefunden — Standard wurde aktiviert',
+  'group-cleared': 'Vorheriges Modell nicht mehr gefunden — Schritt wird übersprungen'
+}
+
+function formatTimestamp(iso: string): string {
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return iso
+  const date = d.toLocaleDateString('de-CH', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric'
+  })
+  const time = d.toLocaleTimeString('de-CH', { hour: '2-digit', minute: '2-digit' })
+  return `${date} um ${time}`
+}
+
+/**
+ * Issue #84 / Story C — surfaces invariant repairs the bootstrap reconciler
+ * made (active model deleted from disk → promoted to default / cleared). The
+ * BottomNav dot routed the user here; this banner explains *what* was changed
+ * and lets them dismiss the notice. Persisted reconcile events are deleted
+ * server-side when the user clicks "Verstanden".
+ */
+export default function ReconcileEventsBanner({ events, onDismiss }: Props): React.JSX.Element {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="rounded-lg border border-primary/30 bg-primary-light/20 p-4"
+    >
+      <div className="flex items-start gap-3">
+        <Info
+          className="mt-0.5 h-5 w-5 shrink-0 text-primary"
+          strokeWidth={1.75}
+          aria-hidden="true"
+        />
+        <div className="min-w-0 flex-1">
+          <h3 className="text-sm font-semibold text-text-primary">Automatische Anpassung</h3>
+          <p className="mt-1 text-sm text-text-secondary">
+            Beim Start der App wurden Inkonsistenzen zwischen aktiver
+            Modell-Auswahl und tatsächlich installierten Dateien gefunden und
+            korrigiert.
+          </p>
+
+          <ul className="mt-3 space-y-2 text-sm">
+            {events.map((e) => (
+              <li
+                key={e.id}
+                className="rounded-md border border-border bg-surface-0 p-3"
+              >
+                <p className="font-medium text-text-primary">{GROUP_LABEL[e.group]}</p>
+                <dl className="mt-1.5 grid grid-cols-[max-content_1fr] gap-x-3 gap-y-0.5 text-text-secondary">
+                  <dt>Bisher aktiv:</dt>
+                  <dd>{e.fromModelId ?? '— (kein Modell)'}</dd>
+                  <dt>Jetzt aktiv:</dt>
+                  <dd>{e.toModelId ?? '— (kein Modell)'}</dd>
+                  <dt>Grund:</dt>
+                  <dd>{REASON_LABEL[e.reason]}</dd>
+                  <dt>Geändert am:</dt>
+                  <dd>{formatTimestamp(e.timestamp)}</dd>
+                </dl>
+              </li>
+            ))}
+          </ul>
+
+          <p className="mt-3 text-sm text-text-secondary">
+            Du kannst die Auswahl unten jederzeit anpassen.
+          </p>
+
+          <div className="mt-3 flex justify-end">
+            <button
+              type="button"
+              onClick={onDismiss}
+              className="titlebar-no-drag rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-primary-hover"
+            >
+              Verstanden
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/settings/__tests__/ModelStatusBadge.test.tsx
+++ b/src/renderer/src/components/settings/__tests__/ModelStatusBadge.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import ModelStatusBadge, { deriveModelStatus } from '../ModelStatusBadge'
+
+describe('deriveModelStatus', () => {
+  it('returns "active" when active and installed', () => {
+    expect(deriveModelStatus({ isActive: true, isInstalled: true })).toBe('active')
+  })
+
+  it('returns "installed" when installed but not active', () => {
+    expect(deriveModelStatus({ isActive: false, isInstalled: true })).toBe('installed')
+  })
+
+  it('returns "missing" when neither active nor installed', () => {
+    expect(deriveModelStatus({ isActive: false, isInstalled: false })).toBe('missing')
+  })
+
+  it('returns "inconsistent" when active but not installed (defense in depth)', () => {
+    // Story C's reconciler clears this state at app start; the badge surfaces
+    // it for the rare in-session case (e.g. user deletes the file in Finder
+    // while the app is running).
+    expect(deriveModelStatus({ isActive: true, isInstalled: false })).toBe('inconsistent')
+  })
+})
+
+describe('<ModelStatusBadge>', () => {
+  it('renders the label "Aktiv" for active status', () => {
+    render(<ModelStatusBadge status="active" />)
+    expect(screen.getByText('Aktiv')).toBeInTheDocument()
+    expect(screen.getByRole('status')).toHaveAttribute(
+      'aria-label',
+      expect.stringContaining('wird für neue Verarbeitungen verwendet')
+    )
+  })
+
+  it('renders the label "Installiert" for installed status', () => {
+    render(<ModelStatusBadge status="installed" />)
+    expect(screen.getByText('Installiert')).toBeInTheDocument()
+  })
+
+  it('renders the label "Nicht installiert" for missing status', () => {
+    render(<ModelStatusBadge status="missing" />)
+    expect(screen.getByText('Nicht installiert')).toBeInTheDocument()
+  })
+
+  it('renders the label "Aktiv, aber fehlt" with a self-heal hint for inconsistent status', () => {
+    render(<ModelStatusBadge status="inconsistent" />)
+    expect(screen.getByText('Aktiv, aber fehlt')).toBeInTheDocument()
+    expect(screen.getByRole('status')).toHaveAttribute(
+      'aria-label',
+      expect.stringContaining('wird beim nächsten Start automatisch repariert')
+    )
+  })
+})

--- a/src/renderer/src/components/settings/__tests__/ModelStatusBadge.test.tsx
+++ b/src/renderer/src/components/settings/__tests__/ModelStatusBadge.test.tsx
@@ -43,9 +43,9 @@ describe('<ModelStatusBadge>', () => {
     expect(screen.getByText('Nicht installiert')).toBeInTheDocument()
   })
 
-  it('renders the label "Aktiv, aber fehlt" with a self-heal hint for inconsistent status', () => {
+  it('renders the locked label including the self-heal promise for inconsistent status', () => {
     render(<ModelStatusBadge status="inconsistent" />)
-    expect(screen.getByText('Aktiv, aber fehlt')).toBeInTheDocument()
+    expect(screen.getByText('Aktiv, aber fehlt — wird repariert')).toBeInTheDocument()
     expect(screen.getByRole('status')).toHaveAttribute(
       'aria-label',
       expect.stringContaining('wird beim nächsten Start automatisch repariert')

--- a/src/renderer/src/components/settings/__tests__/ModelsSettings.sort.test.ts
+++ b/src/renderer/src/components/settings/__tests__/ModelsSettings.sort.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest'
+import { sortByStatus } from '../ModelsSettings'
+import type { ModelCatalogEntry } from '../../../../../shared/validation/model-catalog-schemas'
+
+function entry(
+  id: string,
+  status: { isActive: boolean; isInstalled: boolean }
+): ModelCatalogEntry {
+  return {
+    id,
+    label: id,
+    sizeBytes: 0,
+    group: 'asr',
+    isRequired: false,
+    isActive: status.isActive,
+    isInstalled: status.isInstalled
+  }
+}
+
+describe('sortByStatus — Issue #84 Story E', () => {
+  it('places the active model first, then installed, then missing', () => {
+    const sorted = sortByStatus([
+      entry('m-missing', { isActive: false, isInstalled: false }),
+      entry('m-installed-1', { isActive: false, isInstalled: true }),
+      entry('m-active', { isActive: true, isInstalled: true }),
+      entry('m-installed-2', { isActive: false, isInstalled: true }),
+      entry('m-missing-2', { isActive: false, isInstalled: false })
+    ]).map((e) => e.id)
+
+    expect(sorted).toEqual([
+      'm-active',
+      'm-installed-1',
+      'm-installed-2',
+      'm-missing',
+      'm-missing-2'
+    ])
+  })
+
+  it('preserves catalog order within each bucket (stable)', () => {
+    const sorted = sortByStatus([
+      entry('a-installed', { isActive: false, isInstalled: true }),
+      entry('b-installed', { isActive: false, isInstalled: true }),
+      entry('c-installed', { isActive: false, isInstalled: true })
+    ]).map((e) => e.id)
+
+    expect(sorted).toEqual(['a-installed', 'b-installed', 'c-installed'])
+  })
+
+  it('returns a new array (does not mutate input)', () => {
+    const input = [
+      entry('m-missing', { isActive: false, isInstalled: false }),
+      entry('m-active', { isActive: true, isInstalled: true })
+    ]
+    const sorted = sortByStatus(input)
+    expect(input.map((e) => e.id)).toEqual(['m-missing', 'm-active'])
+    expect(sorted.map((e) => e.id)).toEqual(['m-active', 'm-missing'])
+  })
+
+  it('handles an empty list', () => {
+    expect(sortByStatus([])).toEqual([])
+  })
+})

--- a/src/renderer/src/components/shell/BottomNav.tsx
+++ b/src/renderer/src/components/shell/BottomNav.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { Files, MessageSquare, Settings } from 'lucide-react'
 import { useAppUpdate } from '../../hooks/useAppUpdate'
+import { useReconcileEvents } from '../../hooks/useReconcileEvents'
 import { useToast } from '../../hooks/useToast'
 
 type View = 'sessions' | 'settings'
@@ -24,6 +25,7 @@ export default function BottomNav({ current, onChange }: BottomNavProps): React.
   const [pill, setPill] = useState<{ x: number; w: number } | null>(null)
   const [appVersion, setAppVersion] = useState<string | null>(null)
   const { status: appUpdateStatus, openReleasePage } = useAppUpdate()
+  const { pendingCount: reconcilePending } = useReconcileEvents()
   const toast = useToast()
 
   const handleSendFeedback = async (): Promise<void> => {
@@ -74,6 +76,10 @@ export default function BottomNav({ current, onChange }: BottomNavProps): React.
         {ITEMS.map((item) => {
           const isActive = current === item.id
           const Icon = item.icon
+          // Issue #84 / Story C — passive awareness that the reconciler made
+          // an invariant repair the user hasn't yet acknowledged. Cleared
+          // when Settings → Modelle is mounted (markReconcileEventsSeen).
+          const showReconcileDot = item.id === 'settings' && reconcilePending > 0
 
           return (
             <button
@@ -92,13 +98,20 @@ export default function BottomNav({ current, onChange }: BottomNavProps): React.
             >
               <span
                 key={`icon-${item.id}-${isActive}`}
-                className="bottom-nav-icon inline-flex"
+                className="bottom-nav-icon relative inline-flex"
               >
                 <Icon
                   className="h-4 w-4"
                   strokeWidth={isActive ? 2 : 1.75}
                   aria-hidden="true"
                 />
+                {showReconcileDot && (
+                  <span
+                    aria-label="Automatische Anpassung — Hinweis in Modelle"
+                    title="Automatische Anpassung — Hinweis in Modelle"
+                    className="absolute -right-0.5 -top-0.5 h-1.5 w-1.5 rounded-full bg-primary"
+                  />
+                )}
               </span>
               <span>{item.label}</span>
             </button>

--- a/src/renderer/src/hooks/useReconcileEvents.ts
+++ b/src/renderer/src/hooks/useReconcileEvents.ts
@@ -1,0 +1,52 @@
+import { useCallback, useEffect, useState } from 'react'
+import type { ReconcileEvent } from '../../../shared/types/ReconcileEvent'
+
+// Cross-component synchronisation: the BottomNav dot and the Settings →
+// Modelle banner both render reconcile events. When one component mutates
+// the events (markSeen on settings mount, dismiss on "Verstanden"), the
+// other needs to re-read. A window-level CustomEvent keeps the two views
+// in sync without standing up a full IPC push channel for what is a
+// renderer-only state-fanout problem.
+const RECONCILE_CHANGED = 'therascript:reconcileEventsChanged'
+
+interface UseReconcileEvents {
+  events: ReconcileEvent[]
+  pendingCount: number
+  refresh: () => Promise<void>
+  markSeen: () => Promise<void>
+  dismiss: () => Promise<void>
+}
+
+export function useReconcileEvents(): UseReconcileEvents {
+  const [events, setEvents] = useState<ReconcileEvent[]>([])
+
+  const refresh = useCallback(async () => {
+    const fresh = await window.api.modelReconcile.getEvents()
+    setEvents(fresh)
+  }, [])
+
+  useEffect(() => {
+    refresh()
+    const handler = (): void => {
+      refresh()
+    }
+    window.addEventListener(RECONCILE_CHANGED, handler)
+    return () => {
+      window.removeEventListener(RECONCILE_CHANGED, handler)
+    }
+  }, [refresh])
+
+  const markSeen = useCallback(async () => {
+    await window.api.modelReconcile.markSeen()
+    window.dispatchEvent(new Event(RECONCILE_CHANGED))
+  }, [])
+
+  const dismiss = useCallback(async () => {
+    await window.api.modelReconcile.dismiss()
+    window.dispatchEvent(new Event(RECONCILE_CHANGED))
+  }, [])
+
+  const pendingCount = events.reduce((n, e) => (e.status === 'pending' ? n + 1 : n), 0)
+
+  return { events, pendingCount, refresh, markSeen, dismiss }
+}

--- a/src/renderer/src/views/ReviewEditor.tsx
+++ b/src/renderer/src/views/ReviewEditor.tsx
@@ -13,6 +13,7 @@ import { BlocklistConfirmDialog } from '../components/editor/BlocklistConfirmDia
 import { ConfirmDialog } from '../components/ConfirmDialog'
 import { EditableSessionTitle } from '../components/review/EditableSessionTitle'
 import { SummaryPanel } from '../components/review/SummaryPanel'
+import { ProvenancePanel } from '../components/review/ProvenancePanel'
 import {
   batchRemovePlaceholder,
   anonymizeSelectionWithPropagation,
@@ -28,6 +29,7 @@ import { AnonymizationPanel } from '../components/editor/AnonymizationPanel'
 import type {
   EntityMap,
   PlaceholderType,
+  ProcessedModelsSnapshot,
   ReviewData,
   SessionType
 } from '../../../shared/types'
@@ -53,6 +55,8 @@ export default function ReviewEditor({ sessionId, onBack }: ReviewEditorProps): 
   const [loadError, setLoadError] = useState<string | null>(null)
   const [sessionTitle, setSessionTitle] = useState('')
   const [sessionType, setSessionType] = useState<SessionType>('audio')
+  const [provenance, setProvenance] = useState<ProcessedModelsSnapshot | null>(null)
+  const [reviewAt, setReviewAt] = useState<string | null>(null)
   const [_entityMap, setEntityMap] = useState<EntityMap>({})
   const [updateCounter, setUpdateCounter] = useState(0)
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null)
@@ -242,6 +246,8 @@ export default function ReviewEditor({ sessionId, onBack }: ReviewEditorProps): 
         setSessionTitle(data.sessionTitle)
         setSessionType(data.sessionType)
         setEntityMap(data.entityMap)
+        setProvenance(data.processedWithModels)
+        setReviewAt(data.reviewAt)
         entityMapRef.current = data.entityMap
 
         editor?.commands.setContent(data.document)
@@ -605,6 +611,10 @@ export default function ReviewEditor({ sessionId, onBack }: ReviewEditorProps): 
           {/* Optional LLM-generated summary scrolls with the transcript */}
           <div className="px-6 pt-4 [&:empty]:p-0">
             <SummaryPanel sessionId={sessionId} />
+          </div>
+          {/* Issue #84 Story I — collapsible Modell-Provenienz, default closed */}
+          <div className="px-6 pt-4">
+            <ProvenancePanel data={provenance} reviewAt={reviewAt} />
           </div>
           <EditorContent editor={editor} />
         </div>

--- a/src/renderer/src/views/ReviewEditor.tsx
+++ b/src/renderer/src/views/ReviewEditor.tsx
@@ -557,7 +557,7 @@ export default function ReviewEditor({ sessionId, onBack }: ReviewEditorProps): 
             title={sessionTitle}
             fallback="Transkription ohne Titel"
             onSaved={setSessionTitle}
-            className="min-w-0 flex-1 truncate text-lg font-semibold text-text-primary"
+            className="min-w-0 flex-1 text-base font-semibold text-text-primary"
           />
         </div>
         <div className="flex shrink-0 items-center gap-2">

--- a/src/renderer/src/views/ReviewEditor.tsx
+++ b/src/renderer/src/views/ReviewEditor.tsx
@@ -573,9 +573,9 @@ export default function ReviewEditor({ sessionId, onBack }: ReviewEditorProps): 
           <button
             className={`titlebar-no-drag flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-border-strong transition-colors hover:bg-surface-1 ${panelOpen ? 'bg-surface-2 text-text-primary' : 'bg-surface-0 text-text-secondary'}`}
             onClick={togglePanel}
-            aria-label="Anonymisierungen anzeigen"
+            aria-label="Pseudonymisierungen anzeigen"
             aria-pressed={panelOpen}
-            title="Anonymisierungen"
+            title="Pseudonymisierungen"
           >
             <PanelRight className="h-4 w-4" strokeWidth={1.75} aria-hidden />
           </button>
@@ -641,7 +641,7 @@ export default function ReviewEditor({ sessionId, onBack }: ReviewEditorProps): 
         <ConfirmDialog
           title="Transkription löschen"
           message={`„${sessionTitle}" und alle zugehörigen Daten unwiderruflich löschen?`}
-          details={['Audiodatei', 'Originaltext', 'Anonymisierter Text', 'Platzhalter-Mapping']}
+          details={['Audiodatei', 'Originaltext', 'Pseudonymisierter Text', 'Platzhalter-Mapping']}
           confirmLabel="Löschen"
           destructive
           onConfirm={handleDeleteConfirm}

--- a/src/renderer/src/views/Settings.tsx
+++ b/src/renderer/src/views/Settings.tsx
@@ -49,7 +49,9 @@ export default function Settings(): React.JSX.Element {
         <div className="min-h-0 flex-1 overflow-y-auto">
           {subpage === 'sperrliste' && <BlocklistManager ref={blocklistRef} />}
           {subpage === 'darstellung' && <AppearanceSettings />}
-          {subpage === 'modelle' && <ModelsSettings />}
+          {subpage === 'modelle' && (
+            <ModelsSettings onOpenAbout={() => setSubpage('ueber')} />
+          )}
           {subpage === 'ueber' && <AboutPage />}
         </div>
       )}

--- a/src/renderer/src/views/Settings.tsx
+++ b/src/renderer/src/views/Settings.tsx
@@ -49,9 +49,7 @@ export default function Settings(): React.JSX.Element {
         <div className="min-h-0 flex-1 overflow-y-auto">
           {subpage === 'sperrliste' && <BlocklistManager ref={blocklistRef} />}
           {subpage === 'darstellung' && <AppearanceSettings />}
-          {subpage === 'modelle' && (
-            <ModelsSettings onOpenAbout={() => setSubpage('ueber')} />
-          )}
+          {subpage === 'modelle' && <ModelsSettings />}
           {subpage === 'ueber' && <AboutPage />}
         </div>
       )}

--- a/src/shared/constants/__tests__/pipelineWording.snapshot.test.ts
+++ b/src/shared/constants/__tests__/pipelineWording.snapshot.test.ts
@@ -14,7 +14,7 @@ describe('pipelineWording snapshot — Issue #80 Story 9 / AC#2 final lock', () 
       diarization: 'Sprecher unterscheiden',
       transcription: 'Gespräch transkribieren',
       alignment: 'Audio aufbereiten',
-      anonymization: 'Persönliche Angaben anonymisieren',
+      anonymization: 'Persönliche Angaben pseudonymisieren',
       summarization: 'Zusammenfassung erstellen',
       extraction: 'Text auslesen',
       ocr: 'Schrift erkennen'

--- a/src/shared/constants/pipelineWording.ts
+++ b/src/shared/constants/pipelineWording.ts
@@ -14,7 +14,7 @@ export const STEP_LABELS_DE: Record<TaskType, string> = {
   diarization: 'Sprecher unterscheiden',
   transcription: 'Gespräch transkribieren',
   alignment: 'Audio aufbereiten',
-  anonymization: 'Persönliche Angaben anonymisieren',
+  anonymization: 'Persönliche Angaben pseudonymisieren',
   summarization: 'Zusammenfassung erstellen',
   extraction: 'Text auslesen',
   ocr: 'Schrift erkennen'

--- a/src/shared/types/IpcApi.ts
+++ b/src/shared/types/IpcApi.ts
@@ -5,6 +5,7 @@ import type { EntityMap, PlaceholderType } from './EntityMap'
 import type { TipTapDocument } from './TipTapDocument'
 import type { PendingModelUpdate, AppUpdateStatus, CheckResult } from './ModelUpdate'
 import type { ReconcileEvent } from './ReconcileEvent'
+import type { ProcessedModelsSnapshot } from './Provenance'
 import type {
   ModelCatalogEntry,
   ModelGroup,
@@ -91,6 +92,19 @@ export interface ReviewData {
   entityMap: EntityMap
   sessionType: SessionType
   sessionTitle: string
+  /**
+   * Issue #84 Story I — captured at pipeline-start. NULL for sessions that
+   * reached 'review' before this column was introduced; the renderer surfaces
+   * the legacy hint in that case.
+   */
+  processedWithModels: ProcessedModelsSnapshot | null
+  /**
+   * Issue #84 Story I — when the session transitioned to 'review' (≈ when the
+   * pipeline finished). Used as "Verarbeitet am" in the provenance panel.
+   * NULL only if the row pre-dates Migration 003 which is unlikely in
+   * practice; the panel falls back to omitting the timestamp.
+   */
+  reviewAt: string | null
 }
 
 export interface ReviewApi {

--- a/src/shared/types/IpcApi.ts
+++ b/src/shared/types/IpcApi.ts
@@ -165,6 +165,12 @@ export interface ModelUpdateApi {
   startDownload(): Promise<void>
   getPending(): Promise<PendingModelUpdate[] | null>
   clearPending(): Promise<void>
+  /**
+   * Issue #84 / Story F+G — record that the user actively dismissed these
+   * manifest entries. Future update checks filter them out until the manifest
+   * publishes a new sha256 for the same id.
+   */
+  dismissVersions(updates: PendingModelUpdate[]): Promise<void>
   onAvailable(callback: (updates: PendingModelUpdate[]) => void): () => void
   onDownloadProgress(callback: (status: ModelDownloadStatus) => void): () => void
   onDownloadComplete(callback: () => void): () => void

--- a/src/shared/types/IpcApi.ts
+++ b/src/shared/types/IpcApi.ts
@@ -4,6 +4,7 @@ import type { BlocklistEntry } from './NerTypes'
 import type { EntityMap, PlaceholderType } from './EntityMap'
 import type { TipTapDocument } from './TipTapDocument'
 import type { PendingModelUpdate, AppUpdateStatus, CheckResult } from './ModelUpdate'
+import type { ReconcileEvent } from './ReconcileEvent'
 import type {
   ModelCatalogEntry,
   ModelGroup,
@@ -214,6 +215,15 @@ export interface PipelineApi {
   listDiarization(): Promise<readonly DiarizationPipeline[]>
 }
 
+export interface ModelReconcileApi {
+  /** Read all reconcile events (pending + seen). */
+  getEvents(): Promise<ReconcileEvent[]>
+  /** Mark every pending event as seen — call when Settings → Modelle mounts. */
+  markSeen(): Promise<ReconcileEvent[]>
+  /** Permanently dismiss all reconcile events — call from the "Verstanden" button. */
+  dismiss(): Promise<void>
+}
+
 export interface IpcApi {
   sessions: SessionApi
   recording: RecordingApi
@@ -226,6 +236,7 @@ export interface IpcApi {
   modelDownload: ModelDownloadApi
   modelCatalog: ModelCatalogApi
   modelUpdate: ModelUpdateApi
+  modelReconcile: ModelReconcileApi
   pipeline: PipelineApi
   appUpdate: AppUpdateApi
   summary: SummaryApi

--- a/src/shared/types/Provenance.ts
+++ b/src/shared/types/Provenance.ts
@@ -1,0 +1,32 @@
+/**
+ * Issue #84 / Story I — Modell-Provenienz pro Sitzung.
+ *
+ * Snapshot der pro Pipeline-Gruppe aktiven Modelle, captured-at-source bei
+ * Pipeline-Start. Wird in der Sessions-Tabelle als JSON-Spalte persistiert
+ * und ist für DSGVO Art. 15 (Auskunftsrecht) sowie forensische
+ * Reproduzierbarkeit relevant.
+ *
+ * `label` und `sizeBytes` werden zusätzlich zu den vom Architekten geforderten
+ * `{id, sha256, version}` gespeichert, damit ein späterer Katalog-Rename oder
+ * eine Neu-Verpackung die Sitzungs-Historie nicht rückwirkend umschreibt.
+ */
+export interface ModelSnapshot {
+  id: string
+  label: string
+  version: string
+  sha256: string
+  sizeBytes: number
+}
+
+export interface ProcessedModelsSnapshot {
+  /** ISO-8601 — wann der Snapshot beim Pipeline-Start geschrieben wurde. */
+  capturedAt: string
+  /** Spracherkennung (Whisper). null wenn der Step nicht geplant war. */
+  asr: ModelSnapshot | null
+  /** Sprechererkennung (pyannote). null wenn der Step nicht geplant war. */
+  diarization: ModelSnapshot | null
+  /** Pseudonymisierung (flair NER). null wenn der Step nicht geplant war. */
+  ner: ModelSnapshot | null
+  /** Zusammenfassung (LLM). null wenn der Step nicht geplant oder ohne aktives Modell war. */
+  summarization: ModelSnapshot | null
+}

--- a/src/shared/types/ReconcileEvent.ts
+++ b/src/shared/types/ReconcileEvent.ts
@@ -1,0 +1,28 @@
+import type { ModelGroup } from '../validation/model-catalog-schemas'
+
+export type ReconcileReason =
+  // Active slot pointed to a model whose checkPath was not on disk.
+  | 'model-removed'
+  // Required slot was null/missing and the catalog default IS installed —
+  // promoted the default into the active slot.
+  | 'default-promoted'
+  // Optional slot had a missing model and was cleared to null (no replacement).
+  | 'group-cleared'
+
+export interface ReconcileEvent {
+  /** ULID-ish unique id; generated via crypto.randomUUID(). */
+  id: string
+  /** ISO 8601 timestamp of when the reconciler observed the inconsistency. */
+  timestamp: string
+  group: ModelGroup
+  fromModelId: string | null
+  toModelId: string | null
+  reason: ReconcileReason
+  /**
+   * Lifecycle:
+   *   pending → reconciler wrote it, BottomNav shows the dot
+   *   seen    → renderer mounted Settings → Modelle, dot dismissed but banner still visible
+   *   (deletion) → user clicked "Verstanden", entry removed from settings store
+   */
+  status: 'pending' | 'seen'
+}

--- a/src/shared/types/Session.ts
+++ b/src/shared/types/Session.ts
@@ -1,5 +1,6 @@
 import type { EntityMap } from './EntityMap'
 import type { TaskType } from './Task'
+import type { ProcessedModelsSnapshot } from './Provenance'
 
 export type SessionType = 'audio' | 'pdf'
 
@@ -39,6 +40,12 @@ export interface Session {
    * audio sessions and legacy PDF rows.
    */
   pdfHasScannedPages: boolean | null
+  /**
+   * Issue #84 Story I — captured-at-source snapshot of the active models per
+   * pipeline group, written by TaskQueueService when the pipeline starts.
+   * NULL for legacy rows that reached 'review' before this column existed.
+   */
+  processedWithModels: ProcessedModelsSnapshot | null
 }
 
 export interface CreateSessionInput {
@@ -69,4 +76,5 @@ export interface UpdateSessionInput {
   plannedSteps?: TaskType[] | null
   retryCount?: number
   pdfHasScannedPages?: boolean | null
+  processedWithModels?: ProcessedModelsSnapshot | null
 }

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -82,3 +82,5 @@ export type {
   AppUpdateStatus,
   CheckResult
 } from './ModelUpdate'
+
+export type { ModelSnapshot, ProcessedModelsSnapshot } from './Provenance'

--- a/src/shared/validation/model-update-schemas.ts
+++ b/src/shared/validation/model-update-schemas.ts
@@ -35,6 +35,13 @@ export const RestartUpdateSchema = z.object({
   updates: z.array(PendingModelUpdateSchema).min(1)
 })
 
+// Wrapper object schema for the dismiss IPC handler (Story F+G).
+// Reuses PendingModelUpdate so the renderer can pass the same payload it
+// already has from useModelUpdates / ModelUpdateScreen without rebuilding.
+export const DismissUpdatesSchema = z.object({
+  updates: z.array(PendingModelUpdateSchema).min(1)
+})
+
 // App update status (persisted in electron-store, validated on read)
 export const AppUpdateStatusSchema = z.object({
   available: z.boolean(),


### PR DESCRIPTION
## Summary

Closes the trust-gaps catalogued in epic #84 — Settings, banners, screens, and per-session metadata now match the disk + DSGVO reality.

Stories A–I, in commit order:

- **A+B+C** (`cfdc2d9`) — defensive `getActiveModelId`, capture-at-source `installedModelVersions`, bootstrap reconciler + reconcile-events UI.
- **F+G** (`8aceeee`, followup `255734d`) — UpdateBanner dismiss, ModelUpdateScreen split (`Später` / `Diese Version überspringen`), truthful error-state copy, no in-memory banner-state leak from "Später".
- **H** (`1b22e0a`) — full UI wording swap to "Pseudonymisierung", with the contrast explainer + Settings → About cross-link.
- **I** (`b4709f8`) — `processed_with_models` JSON column, captured-at-source per pipeline group; collapsible `ProvenancePanel` in Review-Editor with forensic "Technische Details" sub-disclosure.
- **E** (`6a9cb79`) — group-first Settings layout, `<ModelStatusBadge>` (4 states incl. defense-in-depth `inconsistent`), DiarizationPipelineSection mounted only when the suite is on disk.
- **D** (`ff9e1aa`) — `THERASCRIPT_CHANNEL` env, channel-tagged `installedModelVersions` keys, idempotent migration of legacy untagged keys to `prod:`.

Total: 65 files, +2859 / −362.

## Test plan

- [ ] `npm run typecheck` — passes (verified locally).
- [ ] `npm run test` — 815/815 pass (verified locally).
- [ ] First-launch flow: fresh install downloads all required models, banner not shown.
- [ ] Update flow: stale `installedModelVersions[*].sha256 = ''` heals on next manifest check without flagging an update for a bit-identical install.
- [ ] Reconcile flow: delete `~/.therascript/models/asr/*.bin` while app is closed → next start shows the inconsistent badge → reconciler clears the slot → BottomNav dot + Settings banner.
- [ ] UpdateBanner dismiss: X-button hides banner; new manifest sha256 brings it back.
- [ ] ModelUpdateScreen: "Später" reappears next launch, "Diese Version überspringen" doesn't, error → "Weiter" doesn't clear pending.
- [ ] Settings → Modelle: every group renders one list; Sprechererkennung shows pyannote-suite card on top, picker only when installed.
- [ ] About → "Wie TheraScript Daten schützt" section renders; Settings link drills into it.
- [ ] Process a session → ReviewEditor → "Verarbeitungs-Information" shows captured models; legacy sessions show the neutral hint.
- [ ] `THERASCRIPT_CHANNEL=staging npm run dev` writes only `staging:`-prefixed install records; reverting to default shows no false-positive update banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)