### PR TITLE
feat(settings): move "Feedback senden" from BottomNav to Settings header (#90)

### DIFF
--- a/src/renderer/src/components/shell/BottomNav.tsx
+++ b/src/renderer/src/components/shell/BottomNav.tsx
@@ -1,8 +1,7 @@
 import { useEffect, useLayoutEffect, useRef, useState } from 'react'
-import { Files, MessageSquare, Settings } from 'lucide-react'
+import { Files, Settings } from 'lucide-react'
 import { useAppUpdate } from '../../hooks/useAppUpdate'
 import { useReconcileEvents } from '../../hooks/useReconcileEvents'
-import { useToast } from '../../hooks/useToast'
 
 type View = 'sessions' | 'settings'
 
@@ -26,19 +25,6 @@ export default function BottomNav({ current, onChange }: BottomNavProps): React.
   const [appVersion, setAppVersion] = useState<string | null>(null)
   const { status: appUpdateStatus, openReleasePage } = useAppUpdate()
   const { pendingCount: reconcilePending } = useReconcileEvents()
-  const toast = useToast()
-
-  const handleSendFeedback = async (): Promise<void> => {
-    try {
-      await window.api.feedback.send()
-      toast.success(
-        'Feedback-Mail vorbereitet — Inhalt wurde zusätzlich in die Zwischenablage kopiert.'
-      )
-    } catch (error) {
-      console.error('[feedback] send failed:', error)
-      toast.error('Feedback konnte nicht vorbereitet werden.')
-    }
-  }
 
   useLayoutEffect(() => {
     const node = itemRefs.current[current]
@@ -117,17 +103,6 @@ export default function BottomNav({ current, onChange }: BottomNavProps): React.
             </button>
           )
         })}
-
-        <button
-          type="button"
-          onClick={handleSendFeedback}
-          className="bottom-nav-item titlebar-no-drag relative z-10 flex items-center gap-2 rounded-full px-3 py-1.5 text-sm font-medium text-text-tertiary transition-colors duration-200 hover:text-text-secondary"
-        >
-          <span className="bottom-nav-icon inline-flex">
-            <MessageSquare className="h-4 w-4" strokeWidth={1.75} aria-hidden="true" />
-          </span>
-          <span>Feedback senden</span>
-        </button>
       </nav>
 
       {updateAvailable ? (

--- a/src/renderer/src/views/Settings.tsx
+++ b/src/renderer/src/views/Settings.tsx
@@ -8,6 +8,7 @@ import ModelsSettings from '../components/settings/ModelsSettings'
 import { useTheme } from '../hooks/useTheme'
 import { useAppUpdate } from '../hooks/useAppUpdate'
 import { useModelUpdates } from '../hooks/useModelUpdates'
+import { useToast } from '../hooks/useToast'
 
 type SubPage = 'sperrliste' | 'darstellung' | 'modelle' | 'ueber'
 
@@ -23,9 +24,33 @@ const THEME_LABELS = { light: 'Hell', dark: 'Dunkel', system: 'System' } as cons
 export default function Settings(): React.JSX.Element {
   const [subpage, setSubpage] = useState<SubPage | null>(null)
   const blocklistRef = useRef<BlocklistManagerHandle>(null)
+  const toast = useToast()
 
-  const headerAction =
-    subpage === 'sperrliste' ? (
+  const handleSendFeedback = async (): Promise<void> => {
+    try {
+      await window.api.feedback.send()
+      toast.success(
+        'Feedback-Mail vorbereitet — Inhalt wurde zusätzlich in die Zwischenablage kopiert.'
+      )
+    } catch (error) {
+      console.error('[feedback] send failed:', error)
+      toast.error('Feedback konnte nicht vorbereitet werden.')
+    }
+  }
+
+  let headerAction: React.ReactNode = null
+  if (subpage === null) {
+    headerAction = (
+      <button
+        type="button"
+        className="titlebar-no-drag rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-primary-hover"
+        onClick={handleSendFeedback}
+      >
+        Feedback senden
+      </button>
+    )
+  } else if (subpage === 'sperrliste') {
+    headerAction = (
       <button
         type="button"
         className="titlebar-no-drag rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-primary-hover"
@@ -33,7 +58,8 @@ export default function Settings(): React.JSX.Element {
       >
         + Eintrag hinzufügen
       </button>
-    ) : null
+    )
+  }
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">


### PR DESCRIPTION
## Summary
- BottomNav enthält jetzt nur noch Hauptbereiche (Transkriptionen, Einstellungen).
- "Feedback senden" wandert als Primary-Top-Action in den Einstellungen-Header (nur Hauptseite, nicht Sub-Pages — analog zu "+ Eintrag hinzufügen" auf Sperrliste).
- `window.api.feedback.send()` und das Clipboard-/Toast-Verhalten bleiben unverändert.

Closes #90

## Decisions on the issue's open questions
- **Kein Icon** — Text-only Button, gleiche visuelle Sprache wie "+ Eintrag hinzufügen" (NFR-1).
- **Keine Empfänger-Anzeige beim ersten Klick** — Mail-App zeigt den Empfänger nativ; zusätzliche Reveal-Stufe wäre redundant.

## Out of scope (zur Klarstellung)
Der `TrayService.ts:150`-Eintrag "Feedback senden…" im macOS-Menübar-Tray bleibt unverändert. Die Issue-"Betroffene Dateien" listen nur BottomNav.tsx + Settings.tsx, und der Tray ist OS-Menü, nicht "in der App". Falls Tray ebenfalls bereinigt werden soll, separates Ticket.

## Test plan
- [ ] `npm run dev` — Einstellungen öffnen → Button oben rechts sichtbar, Klick öffnet Mail-App + Toast erscheint.
- [ ] In Sub-Pages (Sperrliste, Darstellung, Modelle, Über) drillen → Button verschwindet, Sperrliste zeigt weiterhin "+ Eintrag hinzufügen".
- [ ] BottomNav enthält nur noch Transkriptionen + Einstellungen.
- [ ] Während Aufnahme + im Review-Editor: kein Feedback-Button sichtbar (Settings-View ist dort hidden).
- [ ] Tab-Navigation erreicht den Button, Screenreader liest "Feedback senden".

🤖 Generated with [Claude Code](https://claude.com/claude-code)