### PR TITLE
fix(website): hide skip-link reliably until focus

### DIFF
--- a/website/styles.css
+++ b/website/styles.css
@@ -124,18 +124,27 @@ code {
 
 .skip-link {
   position: absolute;
-  top: -40px;
   left: var(--space-sm);
+  top: var(--space-sm);
   background: var(--accent);
   color: #fff;
   padding: var(--space-xs) var(--space-sm);
   border-radius: var(--radius-sm);
   text-decoration: none;
   z-index: 100;
+  clip-path: inset(50%);
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .skip-link:focus {
-  top: var(--space-sm);
+  clip-path: none;
+  width: auto;
+  height: auto;
+  overflow: visible;
+  white-space: normal;
 }
 
 /* === Header === */


### PR DESCRIPTION
## Summary
Skip-link bled a mint sliver into the viewport top for mouse users. Old `top: -40px` relied on the element being ≤40px tall, but with `padding: 0.5rem 1rem` and 18px body font it's ~44px tall.

Switched to W3C visually-hidden pattern (`clip-path: inset(50%)` + 1×1 size). Element is bulletproof-hidden by default, screen-reader accessible, fully visible only on `:focus`.

## Test plan
- [ ] CI green
- [ ] After deploy: Verify no mint sliver visible at top of https://adbstyle.github.io/therascripter/
- [ ] Press Tab → "Zum Inhalt springen" appears at top-left
- [ ] Activate skip-link → focus jumps to `#main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)