### PR TITLE
fix(alignment): Phantom-Sprecher-Inseln absorbieren + Wort-Intervall-Remap über Stitch-Grenzen

### DIFF
--- a/src/main/ml/AlignmentService.ts
+++ b/src/main/ml/AlignmentService.ts
@@ -70,9 +70,13 @@ export class AlignmentService implements TaskExecutor {
     // Build consistent speaker label mapping (raw label → "Person A", "Person B", ...)
     const labelMap = buildSpeakerLabelMap(diarization.speakers)
 
-    // Align words with speaker segments, then correct sentence boundaries
+    // Align words with speaker segments, absorb phantom speaker islands,
+    // then correct sentence boundaries. Island suppression must run FIRST:
+    // correctSentenceBoundaries otherwise extends an island backward to the
+    // sentence start, making the misassignment look tidier instead of fixing it.
     const rawAligned = alignWords(transcript.words, diarization.speakers, labelMap)
-    const alignedWords = correctSentenceBoundaries(rawAligned)
+    const deIslanded = suppressSpeakerIslands(rawAligned)
+    const alignedWords = correctSentenceBoundaries(deIslanded)
 
     onProgress(0.6)
 
@@ -162,6 +166,67 @@ export function alignWords(
       speaker: mappedLabel ? `Person ${mappedLabel}` : undefined
     }
   })
+}
+
+// Minimum number of words for a foreign-speaker island to be absorbed.
+// Single-word islands are deliberately kept (product decision): a lone word
+// from another speaker mid-sentence may be a genuine short interjection.
+const MIN_ISLAND_WORDS = 2
+
+// Maximum island size (words / seconds) that is still treated as a
+// diarization artifact. Longer runs are likely genuine speaker turns.
+// Calibrated against a verified phantom turn: 5 words / 2.7 s.
+const MAX_ISLAND_WORDS = 8
+const MAX_ISLAND_DURATION_SEC = 4.0
+
+// Absorb phantom speaker islands: pyannote occasionally emits a short
+// foreign-speaker turn in the middle of one speaker's continuous utterance
+// (clustering artifact). Word-level overlap alignment then relabels the words
+// inside that turn, and rebuildSegmentsWithSpeakers cuts the sentence apart.
+// A run of words is absorbed into the surrounding speaker when ALL hold:
+//   - sandwich: the runs before and after belong to the SAME other speaker
+//   - the run ends mid-sentence (genuine turns end with .!?)
+//   - MIN_ISLAND_WORDS <= run length <= MAX_ISLAND_WORDS
+//   - run duration <= MAX_ISLAND_DURATION_SEC
+// Single pass over the runs of the ORIGINAL input — absorptions do not cascade.
+export function suppressSpeakerIslands(words: TranscriptWord[]): TranscriptWord[] {
+  if (words.length < 3) return words
+
+  const result = words.map((w) => ({ ...w }))
+
+  // Group words into maximal runs of the same speaker (index ranges, inclusive)
+  const runs: { speaker: string | undefined; from: number; to: number }[] = []
+  for (let i = 0; i < words.length; i++) {
+    const last = runs[runs.length - 1]
+    if (last && words[i].speaker === last.speaker) {
+      last.to = i
+    } else {
+      runs.push({ speaker: words[i].speaker, from: i, to: i })
+    }
+  }
+
+  for (let r = 1; r < runs.length - 1; r++) {
+    const run = runs[r]
+    const prev = runs[r - 1]
+    const next = runs[r + 1]
+
+    // Sandwich: same speaker on both sides
+    if (prev.speaker !== next.speaker) continue
+
+    // Genuine turns end at a sentence boundary — only absorb mid-sentence runs
+    if (/[.!?]$/.test(words[run.to].text)) continue
+
+    // Size limits: keep single-word blips and anything long enough to be real
+    const runLength = run.to - run.from + 1
+    if (runLength < MIN_ISLAND_WORDS || runLength > MAX_ISLAND_WORDS) continue
+    if (words[run.to].end - words[run.from].start > MAX_ISLAND_DURATION_SEC) continue
+
+    for (let k = run.from; k <= run.to; k++) {
+      result[k] = { ...result[k], speaker: prev.speaker }
+    }
+  }
+
+  return result
 }
 
 // Maximum number of words to look back when snapping a speaker change

--- a/src/main/ml/WhisperService.ts
+++ b/src/main/ml/WhisperService.ts
@@ -22,7 +22,7 @@ import { filterSpecialTokens, mergeSubTokens } from './token-processing'
 import type { WhisperToken } from './token-processing'
 import { stitchSpeechSegments } from '../services/AudioStitchService'
 import type { StitchedAudio } from '../services/AudioStitchService'
-import { remapStitchedTimestamp } from './timestamp-remap'
+import { remapStitchedTimestamp, remapStitchedWordInterval } from './timestamp-remap'
 
 interface WhisperSegment {
   timestamps: { from: string; to: string }
@@ -382,10 +382,13 @@ function remapTranscript(
   map: StitchMap,
   originalDurationSec: number
 ): TranscriptData {
+  // Words are remapped as intervals: independent scalar remapping of start/end
+  // injects elided silence into words that span a stitch seam (see
+  // remapStitchedWordInterval). Segments keep scalar remapping — a sentence
+  // may legitimately span a seam (= pause); only the atomic word may not.
   const remappedWords: TranscriptWord[] = (transcript.words ?? []).map((w) => ({
     ...w,
-    start: remapStitchedTimestamp(w.start, map),
-    end: remapStitchedTimestamp(w.end, map)
+    ...remapStitchedWordInterval(w.start, w.end, map)
   }))
 
   const remappedSegments: TranscriptSegment[] = (transcript.segments ?? []).map((s) => ({

--- a/src/main/ml/__tests__/AlignmentService.test.ts
+++ b/src/main/ml/__tests__/AlignmentService.test.ts
@@ -3,6 +3,7 @@ import {
   buildSpeakerLabelMap,
   findBestOverlapSegment,
   alignWords,
+  suppressSpeakerIslands,
   correctSentenceBoundaries,
   findSpeakerForTime,
   rebuildSegmentsWithSpeakers,
@@ -218,6 +219,173 @@ describe('alignWords', () => {
 
     // Should get assigned to nearest segment
     expect(result[0].speaker).toBeDefined()
+  })
+})
+
+// --- suppressSpeakerIslands ---
+
+describe('suppressSpeakerIslands', () => {
+  it('absorbs multi-word sandwich island ending mid-sentence', () => {
+    // A ... [B B] ... A — island ends without .!? → diarization artifact
+    const words = [
+      word('und', 0, 0.5, 'Person A'),
+      word('dann', 0.5, 1, 'Person A'),
+      word('habe', 1, 1.5, 'Person B'),
+      word('ich', 1.5, 2, 'Person B'),
+      word('gedacht.', 2, 2.5, 'Person A')
+    ]
+
+    const result = suppressSpeakerIslands(words)
+
+    expect(result.map((w) => w.speaker)).toEqual([
+      'Person A',
+      'Person A',
+      'Person A',
+      'Person A',
+      'Person A'
+    ])
+  })
+
+  it('keeps single-word island (below MIN_ISLAND_WORDS)', () => {
+    const words = [
+      word('und', 0, 0.5, 'Person A'),
+      word('vielleicht', 0.5, 1, 'Person B'),
+      word('weiter', 1, 1.5, 'Person A')
+    ]
+
+    const result = suppressSpeakerIslands(words)
+
+    expect(result[1].speaker).toBe('Person B')
+  })
+
+  it('keeps island that ends at a sentence boundary (genuine interjection)', () => {
+    const words = [
+      word('und', 0, 0.5, 'Person A'),
+      word('warte', 0.5, 1, 'Person B'),
+      word('kurz.', 1, 1.5, 'Person B'),
+      word('weiter', 1.5, 2, 'Person A')
+    ]
+
+    const result = suppressSpeakerIslands(words)
+
+    expect(result[1].speaker).toBe('Person B')
+    expect(result[2].speaker).toBe('Person B')
+  })
+
+  it('keeps island longer than MAX_ISLAND_WORDS', () => {
+    // 9-word island exceeds the 8-word cap → likely a genuine turn
+    const island = Array.from({ length: 9 }, (_, i) =>
+      word(`w${i}`, 1 + i * 0.3, 1.3 + i * 0.3, 'Person B')
+    )
+    const words = [word('vorher', 0, 1, 'Person A'), ...island, word('nachher', 4, 4.5, 'Person A')]
+
+    const result = suppressSpeakerIslands(words)
+
+    expect(result[1].speaker).toBe('Person B')
+    expect(result[9].speaker).toBe('Person B')
+  })
+
+  it('keeps island exceeding MAX_ISLAND_DURATION_SEC', () => {
+    // 2 words but 5 s span → likely a genuine turn
+    const words = [
+      word('vorher', 0, 1, 'Person A'),
+      word('lange', 1, 3.5, 'Person B'),
+      word('Pause', 5.5, 6, 'Person B'),
+      word('nachher', 6, 6.5, 'Person A')
+    ]
+
+    const result = suppressSpeakerIslands(words)
+
+    expect(result[1].speaker).toBe('Person B')
+    expect(result[2].speaker).toBe('Person B')
+  })
+
+  it('keeps non-sandwich run (different speakers on each side)', () => {
+    const words = [
+      word('eins', 0, 0.5, 'Person A'),
+      word('zwei', 0.5, 1, 'Person B'),
+      word('drei', 1, 1.5, 'Person B'),
+      word('vier', 1.5, 2, 'Person C')
+    ]
+
+    const result = suppressSpeakerIslands(words)
+
+    expect(result[1].speaker).toBe('Person B')
+    expect(result[2].speaker).toBe('Person B')
+  })
+
+  it('leaves runs at transcript start and end untouched (no sandwich possible)', () => {
+    const words = [
+      word('Anfang', 0, 0.5, 'Person B'),
+      word('hier', 0.5, 1, 'Person B'),
+      word('Mitte.', 1, 1.5, 'Person A'),
+      word('Ende', 1.5, 2, 'Person B'),
+      word('hier', 2, 2.5, 'Person B')
+    ]
+
+    const result = suppressSpeakerIslands(words)
+
+    expect(result.map((w) => w.speaker)).toEqual([
+      'Person B',
+      'Person B',
+      'Person A',
+      'Person B',
+      'Person B'
+    ])
+  })
+
+  it('does not mutate input array', () => {
+    const words = [
+      word('und', 0, 0.5, 'Person A'),
+      word('habe', 0.5, 1, 'Person B'),
+      word('ich', 1, 1.5, 'Person B'),
+      word('gedacht.', 1.5, 2, 'Person A')
+    ]
+
+    suppressSpeakerIslands(words)
+
+    expect(words[1].speaker).toBe('Person B')
+    expect(words[2].speaker).toBe('Person B')
+  })
+
+  it('returns input unchanged for fewer than 3 words', () => {
+    const words = [word('Hallo', 0, 1, 'Person A'), word('Welt', 1, 2, 'Person B')]
+
+    expect(suppressSpeakerIslands(words)).toEqual(words)
+  })
+
+  it('regression: phantom pyannote island splits sentence across speakers (session e18cabcc)', () => {
+    // Real data: pyannote emitted a spurious 2.14 s SPEAKER_01 turn inside a
+    // continuous SPEAKER_03 utterance. The full chain must yield ONE segment.
+    const speakers = [
+      seg('SPEAKER_03', 26.963, 36.413),
+      seg('SPEAKER_01', 37.156, 39.299), // phantom island — sole occurrence in the file
+      seg('SPEAKER_03', 39.248, 60.342)
+    ]
+    const words = [
+      word('sind.', 35.65, 36.23),
+      word('Im', 36.23, 36.4),
+      word('Juli', 36.51, 37.133), // zero overlap with any turn (stitch-padding band)
+      word('etwa', 37.133, 37.513),
+      word('wurden', 37.513, 38.083),
+      word('unter', 38.083, 38.553),
+      word('anderem', 38.623, 39.203),
+      word('zwei', 39.203, 39.593),
+      word('Schweizer', 39.593, 40.03)
+    ]
+    const labelMap = buildSpeakerLabelMap(speakers)
+
+    const aligned = alignWords(words, speakers, labelMap)
+    // Precondition (documents the bug): raw alignment produces the island
+    expect(aligned[2].speaker).toBe('Person B')
+    expect(aligned[6].speaker).toBe('Person B')
+
+    const corrected = correctSentenceBoundaries(suppressSpeakerIslands(aligned))
+    const segments = rebuildSegmentsWithSpeakers(corrected, 4)
+
+    expect(segments).toHaveLength(1)
+    expect(segments[0].speaker).toBe('Person A')
+    expect(segments[0].text).toBe('sind. Im Juli etwa wurden unter anderem zwei Schweizer')
   })
 })
 

--- a/src/main/ml/__tests__/timestamp-remap.test.ts
+++ b/src/main/ml/__tests__/timestamp-remap.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { remapStitchedTimestamp } from '../timestamp-remap'
+import { remapStitchedTimestamp, remapStitchedWordInterval } from '../timestamp-remap'
 import type { StitchMap } from '../../../shared/types'
 
 const fixture: StitchMap = {
@@ -57,5 +57,81 @@ describe('remapStitchedTimestamp', () => {
       segments: []
     }
     expect(remapStitchedTimestamp(5, emptyMap)).toBe(0)
+  })
+})
+
+describe('remapStitchedWordInterval', () => {
+  it('maps interval fully inside one segment identically to scalar remap', () => {
+    const result = remapStitchedWordInterval(4, 5, fixture)
+
+    expect(result.start).toBe(14)
+    expect(result.end).toBe(15)
+  })
+
+  it('clamps boundary-spanning interval into the segment with the larger overlap (second)', () => {
+    // Stitched [9.8, 10.5] spans the seam at 10: overlap seg0 = 0.2, seg1 = 0.5
+    const result = remapStitchedWordInterval(9.8, 10.5, fixture)
+
+    // Entire interval clamped into seg1 (orig 50–60) — no elided silence injected
+    expect(result.start).toBe(50)
+    expect(result.end).toBeCloseTo(50.5, 10)
+    expect(result.end - result.start).toBeLessThanOrEqual(10.5 - 9.8)
+  })
+
+  it('clamps boundary-spanning interval into the segment with the larger overlap (first)', () => {
+    // Stitched [9.5, 10.2]: overlap seg0 = 0.5, seg1 = 0.2
+    const result = remapStitchedWordInterval(9.5, 10.2, fixture)
+
+    expect(result.start).toBeCloseTo(19.5, 10)
+    expect(result.end).toBe(20)
+  })
+
+  it('resolves overlap ties to the earlier segment', () => {
+    // Stitched [9.75, 10.25]: overlap seg0 = 0.25, seg1 = 0.25 → earlier segment wins
+    const result = remapStitchedWordInterval(9.75, 10.25, fixture)
+
+    expect(result.start).toBeCloseTo(19.75, 10)
+    expect(result.end).toBe(20)
+  })
+
+  it('falls back to scalar remap when interval overlaps no segment', () => {
+    // Past end of stitched audio → scalar behavior clamps both to last segment end
+    const result = remapStitchedWordInterval(31, 32, fixture)
+
+    expect(result.start).toBe(90)
+    expect(result.end).toBe(90)
+  })
+
+  it('falls back to scalar remap for empty stitch map', () => {
+    const emptyMap: StitchMap = {
+      paddingSec: 0,
+      originalDurationSec: 100,
+      stitchedDurationSec: 0,
+      segments: []
+    }
+
+    expect(remapStitchedWordInterval(5, 6, emptyMap)).toEqual({ start: 0, end: 0 })
+  })
+
+  it('regression: word "Juli" spanning the seam is not inflated by elided silence (session e18cabcc)', () => {
+    // Real numbers: seam at stitched 35.483, 0.343 s of original audio elided.
+    // Old behavior mapped [35.38, 35.66] → [36.510, 37.133] (0.28 s word → 0.62 s).
+    const realMap: StitchMap = {
+      paddingSec: 0.2,
+      originalDurationSec: 189.3,
+      stitchedDurationSec: 183.517,
+      segments: [
+        { originalStart: 1.13, originalEnd: 36.613, stitchedStart: 0, duration: 35.483 },
+        { originalStart: 36.956, originalEnd: 179.916, stitchedStart: 35.483, duration: 142.96 }
+      ]
+    }
+
+    const result = remapStitchedWordInterval(35.38, 35.66, realMap)
+
+    // Larger overlap lies in segment 2 (0.177 s vs 0.103 s) → clamp into it
+    expect(result.start).toBe(36.956)
+    expect(result.end).toBeCloseTo(37.133, 10)
+    // Duration must not exceed the stitched word duration (0.28 s)
+    expect(result.end - result.start).toBeLessThanOrEqual(35.66 - 35.38)
   })
 })

--- a/src/main/ml/timestamp-remap.ts
+++ b/src/main/ml/timestamp-remap.ts
@@ -32,3 +32,51 @@ export function remapStitchedTimestamp(stitched: number, map: StitchMap): number
   const last = map.segments[map.segments.length - 1]
   return last.originalEnd
 }
+
+/**
+ * Map a word's [start, end] interval from the stitched timeline back to the
+ * original timeline as a unit. Remapping start and end independently through
+ * remapStitchedTimestamp injects the elided silence into the middle of any
+ * word that spans a stitch seam (e.g. a 0.28 s word inflated to 0.62 s) —
+ * with long elided pauses the inflated interval can overlap an arbitrarily
+ * wrong diarization turn downstream.
+ *
+ * A word is atomic continuous speech, so it cannot genuinely contain elided
+ * silence: pick the stitch segment with the greatest overlap (ties → earlier
+ * segment) and clamp the whole interval into it. The result always lies
+ * within ONE original segment and never exceeds the stitched duration.
+ * Degenerate inputs (empty map, no overlap) fall back to scalar remapping.
+ */
+export function remapStitchedWordInterval(
+  start: number,
+  end: number,
+  map: StitchMap
+): { start: number; end: number } {
+  let bestSeg: StitchMap['segments'][number] | null = null
+  let bestOverlap = 0
+
+  for (const seg of map.segments) {
+    const stitchedEnd = seg.stitchedStart + seg.duration
+    const overlap = Math.min(end, stitchedEnd) - Math.max(start, seg.stitchedStart)
+    if (overlap > bestOverlap) {
+      bestOverlap = overlap
+      bestSeg = seg
+    }
+  }
+
+  if (!bestSeg) {
+    return {
+      start: remapStitchedTimestamp(start, map),
+      end: remapStitchedTimestamp(end, map)
+    }
+  }
+
+  const stitchedEnd = bestSeg.stitchedStart + bestSeg.duration
+  const clampedStart = Math.max(start, bestSeg.stitchedStart)
+  const clampedEnd = Math.min(end, stitchedEnd)
+
+  return {
+    start: bestSeg.originalStart + (clampedStart - bestSeg.stitchedStart),
+    end: bestSeg.originalStart + (clampedEnd - bestSeg.stitchedStart)
+  }
+}


### PR DESCRIPTION
## Problem

Ein zusammenhängender Satz wird im Review-Editor auf zwei Sprecher aufgeteilt:

> **Person C:** Im Juli etwa wurden unter anderem
> **Person A:** zwei Schweizer Staatsangehörige am Flughafen in [Ort 5] festgenommen. …

Root Cause (verifiziert an Session `e18cabcc`, Alignment bit-für-bit reproduziert):

1. **Pyannote-Phantom-Insel:** Ein 2,14-s-Turn `SPEAKER_01` mitten in einer durchgehenden `SPEAKER_03`-Äusserung — einziges Vorkommen dieses Sprechers in 189 s. RMS-Analyse: an der Bruchstelle durchgehend Sprache, keine Pause.
2. Das wortweise Overlap-Alignment übernimmt den Turn ungefiltert (96-ms-Marge entscheidet), `rebuildSegmentsWithSpeakers` bricht bei jedem Wort-Sprecherwechsel um. In lokalen Sessions lagen **37 % aller Sprecherwechsel mitten im Satz**.
3. `correctSentenceBoundaries` korrigiert nur die **vordere** Kante (Lookback 5 Wörter) — hier lag das Satzende ein Wort ausserhalb des Fensters; die Korrektur hat die Insel stattdessen zum Satzanfang hin **verlängert**.

## Fix 1 — `suppressSpeakerIslands()` (AlignmentService)

Absorbiert Fremd-Sprecher-Runs, wenn ALLE Bedingungen gelten:
- Sandwich: gleicher Sprecher davor und danach
- Run endet mitten im Satz (echte Turns enden auf `.!?`)
- 2–8 Wörter, ≤ 4 s Dauer (Ein-Wort-Blips bleiben bewusst stehen — Produktentscheidung)

Läuft **vor** `correctSentenceBoundaries`. Die Session enthielt drei identische Inseln — zwei wurden bisher nur durch Lookback-Glückstreffer aufgelöst, jetzt werden alle drei deterministisch absorbiert.

## Fix 2 — `remapStitchedWordInterval()` (timestamp-remap)

Latenter, unabhängiger Bug: `remapTranscript` mappte `word.start`/`word.end` getrennt. Einem Wort über einer Stitch-Naht wurde die eliminierte Stille in die Wortmitte injiziert („Juli": 0,28 s → 0,62 s; bei langen Therapie-Pausen beliebig gross → Wort überlappt beliebig falschen Turn). Jetzt: Intervall wird als Einheit in das Stitch-Segment mit dem grösseren Overlap geklemmt. Segmente behalten das Skalar-Mapping (Sätze dürfen Pausen überspannen).

## Tests

- 17 neue Unit-Tests, inkl. Regressionstests mit den echten Zahlen der Session (Phantom-Turn + Stitch-Naht)
- E2E-Gegenprobe gegen die On-Disk-Artefakte: Transkript hat jetzt 2 Segmente statt 3, **0 Sprecherwechsel mitten im Satz**; der echte Wechsel zu Person D bleibt erhalten
- `npm run typecheck` grün; ESLint auf den geänderten Dateien sauber
- Volle Suite: 1045 passed — die 6 Failures in `ModelDownloadService.reconcile.test.ts` bestehen identisch auf `develop` (vorbestehend, separat geflaggt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)