### PR TITLE
fix(models): Reconcile-Fixtures auf v2-checkPath + Slot-Restore nach First-Launch-Download

### DIFF
--- a/docs/product/features/model-management.md
+++ b/docs/product/features/model-management.md
@@ -20,7 +20,9 @@ Three models are defined in `MODEL_DEFINITIONS` inside `ModelDownloadService.ts`
 |----|-------|--------------|---------|---------------|------------|
 | `whisper-large-v3-turbo` | Spracherkennung (whisper-large-v3-turbo) | ~574 MB | No (flat `.bin`) | `asr/ggml-large-v3-turbo-q5_0.bin` | `asr/ggml-large-v3-turbo-q5_0.bin` |
 | `pyannote-community-1` | Sprechererkennung (pyannote-community-1) | ~30 MB | Yes (`.tar.gz`) | `diarization` | `diarization/models--pyannote--speaker-diarization-3.1` |
-| `flair-ner-german-large` | Anonymisierung (flair-ner-german-large) | ~1.74 GB | Yes (`.tar.gz`) | `ner` | `ner/models/ner-german-large` |
+| `flair-ner-german-large` | Anonymisierung (flair-ner-german-large) | ~1.74 GB | Yes (`.tar.gz`) | `ner` | `ner/hf/hub/models--xlm-roberta-large` |
+
+The NER check path deliberately points at the **v2-only** `hf/` tokenizer subtree (not the model payload): v1 installs (≤ 0.8.5, without `hf/`) read as "not installed", so the first-launch gate re-downloads the v2 tarball, which tar-merges over the existing `ner/`. The bootstrap reconciler shares this definition and clears the `ner` slot on such installs; `startModelDownload()` re-runs the reconciler after a successful download to re-promote the slot in the same session, and inverse repairs (X → null → X) collapse the pending reconcile event so the upgrade shows no "Modell entfernt" banner.
 
 Total download: ~2.3 GB (combined archive sizes). All downloads come from the Cloudflare R2 CDN at `https://pub-f6971d643e3a464ba6977c0816c43e50.r2.dev/`.
 
@@ -38,6 +40,9 @@ All models live under `~/.therascript/models/`:
   ner/
     models/
       ner-german-large/
+    hf/
+      hub/
+        models--xlm-roberta-large/
     ...
 ```
 

--- a/src/main/services/ModelDownloadService.ts
+++ b/src/main/services/ModelDownloadService.ts
@@ -384,6 +384,12 @@ export async function startModelDownload(): Promise<void> {
 
   // All models downloaded successfully
   getSettings().set('modelsDownloaded', true)
+  // Re-reconcile: the boot reconciler may have cleared a required slot whose
+  // checkPath was missing (v1→v2-NER-Upgrade-Pfad) — the download just made
+  // the model observable again, so the slot is re-promoted NOW instead of at
+  // the next restart. Closes the window in which sessions would record
+  // ner:null provenance and Settings would show the model as inactive.
+  reconcileActiveModels()
   sendProgress({ state: 'complete' })
   abortSignal = null
 }
@@ -793,17 +799,39 @@ export function reconcileActiveModels(): ReadonlyArray<ReconcileRepair> {
   }
 
   if (repairs.length > 0) {
-    const previous = settings.get('reconcileEvents') ?? []
-    const additions: ReconcileEvent[] = repairs.map((r) => ({
-      id: randomUUID(),
-      timestamp: new Date().toISOString(),
-      group: r.group,
-      fromModelId: r.fromModelId,
-      toModelId: r.toModelId,
-      reason: r.reason,
-      status: 'pending'
-    }))
-    settings.set('reconcileEvents', [...previous, ...additions])
+    let events = settings.get('reconcileEvents') ?? []
+    let eventsChanged = false
+    for (const r of repairs) {
+      // Round-trip collapse: this repair exactly inverts an earlier event
+      // (X → null → X, e.g. the v1→v2-NER-Upgrade: boot-reconcile cleared the
+      // slot, the re-download made the model observable again). Net state is
+      // unchanged for the user — drop the stale event instead of stacking a
+      // misleading "Modell entfernt" + "Standard aktiviert" banner pair.
+      const inverseIdx = events.findIndex(
+        (e) => e.group === r.group && e.fromModelId === r.toModelId && e.toModelId === r.fromModelId
+      )
+      if (inverseIdx >= 0) {
+        events = [...events.slice(0, inverseIdx), ...events.slice(inverseIdx + 1)]
+        eventsChanged = true
+        continue
+      }
+      events = [
+        ...events,
+        {
+          id: randomUUID(),
+          timestamp: new Date().toISOString(),
+          group: r.group,
+          fromModelId: r.fromModelId,
+          toModelId: r.toModelId,
+          reason: r.reason,
+          status: 'pending'
+        }
+      ]
+      eventsChanged = true
+    }
+    if (eventsChanged) {
+      settings.set('reconcileEvents', events)
+    }
     for (const r of repairs) {
       console.log(
         `[reconcile] ${r.group}: ${r.fromModelId ?? '<null>'} → ${r.toModelId ?? '<null>'} (${r.reason})`

--- a/src/main/services/__tests__/ModelDownloadService.reconcile.test.ts
+++ b/src/main/services/__tests__/ModelDownloadService.reconcile.test.ts
@@ -71,6 +71,7 @@ vi.mock('fs', () => {
 // MODEL_DEFINITIONS is already a real import that ships with the app.
 import {
   reconcileActiveModels,
+  startModelDownload,
   getReconcileEvents,
   markReconcileEventsSeen,
   dismissReconcileEvents,
@@ -129,7 +130,7 @@ describe('reconcileActiveModels', () => {
     pretendInstalled(
       'asr/ggml-large-v3-turbo-q5_0.bin',
       'diarization/models--pyannote--speaker-diarization-community-1',
-      'ner/models/ner-german-large'
+      'ner/hf/hub/models--xlm-roberta-large'
     )
 
     const repairs = reconcileActiveModels()
@@ -145,7 +146,7 @@ describe('reconcileActiveModels', () => {
     pretendInstalled(
       'asr/ggml-large-v3-turbo-q5_0.bin',
       'diarization/models--pyannote--speaker-diarization-community-1',
-      'ner/models/ner-german-large'
+      'ner/hf/hub/models--xlm-roberta-large'
       // summarization NOT installed — default-state, slot is null per freshState
     )
 
@@ -173,7 +174,7 @@ describe('reconcileActiveModels', () => {
     pretendInstalled(
       'asr/ggml-large-v3-turbo-q5_0.bin',
       'diarization/models--pyannote--speaker-diarization-community-1',
-      'ner/models/ner-german-large'
+      'ner/hf/hub/models--xlm-roberta-large'
       // summarization-Datei vom User gelöscht
     )
 
@@ -205,7 +206,7 @@ describe('reconcileActiveModels', () => {
     pretendInstalled(
       'asr/ggml-large-v3-turbo-q5_0.bin',
       'diarization/models--pyannote--speaker-diarization-community-1',
-      'ner/models/ner-german-large'
+      'ner/hf/hub/models--xlm-roberta-large'
     )
 
     const repairs = reconcileActiveModels()
@@ -230,7 +231,7 @@ describe('reconcileActiveModels', () => {
     pretendInstalled(
       'asr/ggml-large-v3-turbo-q5_0.bin', // multi-lingual default
       'diarization/models--pyannote--speaker-diarization-community-1',
-      'ner/models/ner-german-large'
+      'ner/hf/hub/models--xlm-roberta-large'
     )
 
     const repairs = reconcileActiveModels()
@@ -261,7 +262,7 @@ describe('reconcileActiveModels', () => {
     pretendInstalled(
       'asr/ggml-large-v3-turbo-swiss-q5_0.bin', // only the swiss variant
       'diarization/models--pyannote--speaker-diarization-community-1',
-      'ner/models/ner-german-large'
+      'ner/hf/hub/models--xlm-roberta-large'
     )
 
     const repairs = reconcileActiveModels()
@@ -287,7 +288,7 @@ describe('reconcileActiveModels', () => {
     })
     pretendInstalled(
       'diarization/models--pyannote--speaker-diarization-community-1',
-      'ner/models/ner-german-large'
+      'ner/hf/hub/models--xlm-roberta-large'
     )
 
     const repairs = reconcileActiveModels()
@@ -301,6 +302,161 @@ describe('reconcileActiveModels', () => {
       }
     ])
     expect(storeState.activeModels.transcription).toBeNull()
+  })
+
+  // ─── v1→v2-NER-Upgrade-Pfad (checkPath = v2-only-Marker, Commit 08746d5) ────
+
+  it('treats a v1 NER install (payload present, hf/ marker missing) as removed — upgrade path', () => {
+    // Every v0.8.5 installation has ner/models/ner-german-large but no hf/
+    // tokenizer subtree. checkPath deliberately points at the v2-only marker so
+    // the First-Launch gate re-downloads the v2 tarball. The reconciler shares
+    // that definition: it clears the slot and emits model-removed. This test
+    // documents that behavior EXPLICITLY — it is intended, not an accident.
+    pretendInstalled(
+      'asr/ggml-large-v3-turbo-q5_0.bin',
+      'diarization/models--pyannote--speaker-diarization-community-1',
+      'ner/models/ner-german-large' // v1 payload — NOT the v2 checkPath
+    )
+
+    const repairs = reconcileActiveModels()
+
+    expect(repairs).toEqual([
+      {
+        group: 'ner',
+        fromModelId: 'flair-ner-german-large',
+        toModelId: null,
+        reason: 'model-removed'
+      }
+    ])
+    expect(storeState.activeModels.ner).toBeNull()
+    expect(storeState.reconcileEvents).toHaveLength(1)
+    expect(storeState.reconcileEvents[0].reason).toBe('model-removed')
+  })
+
+  it('collapses the round-trip event when the removed model comes back (X → null → X)', () => {
+    // Boot 1 of the upgrade path emitted "model-removed" and cleared the slot.
+    // After the v2 re-download the model is observable again — re-promoting it
+    // must REMOVE the stale pending event instead of stacking a second banner:
+    // net state is unchanged, the user must not see "Modell entfernt" +
+    // "Standard aktiviert" for an upgrade where nothing was removed.
+    freshState({
+      activeModels: {
+        transcription: 'whisper-large-v3-turbo',
+        diarization: 'pyannote-suite',
+        diarizationPipeline: 'pyannote/speaker-diarization-3.1',
+        ner: null, // cleared by the boot-1 reconcile
+        ocr: 'apple-vision',
+        summarization: null
+      },
+      reconcileEvents: [
+        {
+          id: 'evt-boot1',
+          timestamp: '2026-08-09T10:00:00.000Z',
+          group: 'ner',
+          fromModelId: 'flair-ner-german-large',
+          toModelId: null,
+          reason: 'model-removed',
+          status: 'pending'
+        }
+      ]
+    })
+    pretendInstalled(
+      'asr/ggml-large-v3-turbo-q5_0.bin',
+      'diarization/models--pyannote--speaker-diarization-community-1',
+      'ner/hf/hub/models--xlm-roberta-large' // v2 now installed
+    )
+
+    const repairs = reconcileActiveModels()
+
+    expect(repairs).toEqual([
+      {
+        group: 'ner',
+        fromModelId: null,
+        toModelId: 'flair-ner-german-large',
+        reason: 'default-promoted'
+      }
+    ])
+    expect(storeState.activeModels.ner).toBe('flair-ner-german-large')
+    // Round-trip collapsed: no events left, no banner shown
+    expect(storeState.reconcileEvents).toHaveLength(0)
+  })
+
+  it('still emits an event for a promotion that is NOT a round-trip', () => {
+    // Slot was null with no matching removed-event → promotion is genuine news.
+    freshState({
+      activeModels: {
+        transcription: 'whisper-large-v3-turbo',
+        diarization: 'pyannote-suite',
+        diarizationPipeline: 'pyannote/speaker-diarization-3.1',
+        ner: null,
+        ocr: 'apple-vision',
+        summarization: null
+      }
+    })
+    pretendInstalled(
+      'asr/ggml-large-v3-turbo-q5_0.bin',
+      'diarization/models--pyannote--speaker-diarization-community-1',
+      'ner/hf/hub/models--xlm-roberta-large'
+    )
+
+    const repairs = reconcileActiveModels()
+
+    expect(repairs).toHaveLength(1)
+    expect(storeState.reconcileEvents).toHaveLength(1)
+    expect(storeState.reconcileEvents[0].reason).toBe('default-promoted')
+  })
+})
+
+// ─── startModelDownload: post-download reconcile ──────────────────────────────
+
+describe('startModelDownload re-reconciles required slots', () => {
+  beforeEach(() => {
+    freshState()
+    vi.clearAllMocks()
+  })
+
+  it('re-promotes a cleared required slot once the download made the model observable', () => {
+    // v1-upgrade scenario, same app session: boot reconcile cleared ner → null,
+    // FirstLaunchScreen ran startModelDownload, tar merged the v2 subtree.
+    // Without the post-download reconcile the slot stays null until the next
+    // restart — sessions processed in that window record ner:null provenance.
+    freshState({
+      modelsDownloaded: false,
+      activeModels: {
+        transcription: 'whisper-large-v3-turbo',
+        diarization: 'pyannote-suite',
+        diarizationPipeline: 'pyannote/speaker-diarization-3.1',
+        ner: null, // cleared by boot reconcile
+        ocr: 'apple-vision',
+        summarization: null
+      },
+      reconcileEvents: [
+        {
+          id: 'evt-boot1',
+          timestamp: '2026-08-09T10:00:00.000Z',
+          group: 'ner',
+          fromModelId: 'flair-ner-german-large',
+          toModelId: null,
+          reason: 'model-removed',
+          status: 'pending'
+        }
+      ]
+    })
+    // All checkPaths present → download loop skips everything (simulates the
+    // state right after tar extraction; avoids any network in the test).
+    pretendInstalled(
+      'asr/ggml-large-v3-turbo-q5_0.bin',
+      'diarization/models--pyannote--speaker-diarization-community-1',
+      'ner/hf/hub/models--xlm-roberta-large'
+    )
+
+    return startModelDownload().then(() => {
+      expect(storeState.modelsDownloaded).toBe(true)
+      // Slot restored in the SAME session — provenance gap closed
+      expect(storeState.activeModels.ner).toBe('flair-ner-german-large')
+      // Round-trip collapsed — the misleading boot-1 banner is gone
+      expect(storeState.reconcileEvents).toHaveLength(0)
+    })
   })
 })
 


### PR DESCRIPTION
## Problem

Seit [08746d5](https://github.com/adbstyle/therascripter/commit/08746d5) (NER-v2-Upgrade-Pfad, PR #118) waren 6 Tests in `ModelDownloadService.reconcile.test.ts` rot — Bisection-verifiziert: grün auf `658a5e1`, rot exakt ab `08746d5`. Ursache: Der NER-`checkPath` wurde bewusst auf den v2-only-`hf/`-Marker umgestellt, die Test-Fixtures (`pretendInstalled('ner/models/ner-german-large')`, 7 Stellen) aber nicht mitgezogen. Alle Assertions blieben fachlich gültig.

Die Untersuchung (3 unabhängige Agenten) fand darüber hinaus einen **realen Nebeneffekt** derselben Änderung, den kein Test abdeckte — relevant, weil **jede Bestandsinstallation (v0.8.5) eine v1-Installation ist** und ihn beim nächsten Release trifft:

1. Boot-Reconciler sieht v1-NER als „nicht installiert" → leert `activeModels.ner`, zeigt irreführendes Banner „Vorheriges Modell nicht mehr gefunden — kein Ersatz installiert" (das 2,1-GB-Modell liegt da, nur der 14-MB-Tokenizer-Marker fehlt)
2. First-Launch lädt v2 korrekt nach (gewollter Upgrade-Pfad ✓), aber **nichts stellt den Slot wieder her** — er bleibt bis zum nächsten Neustart `null`
3. In diesem Fenster: Sessions schreiben `ner: null` in die Provenienz (Audit-Lücke), Settings zeigt das Pflicht-Modell als inaktiv
4. Nächster Boot: zweites Banner („Standard wurde aktiviert")

Pipeline-brechend ist nichts davon (der NER-Executor hardcodet seinen Pfad).

## Änderungen

- **Fixtures** auf `ner/hf/hub/models--xlm-roberta-large` umgestellt — inkl. des falsch-grünen `falls back`-Tests, dessen `find()`-Assertion den Fixture-Fehler maskierte
- **Neuer expliziter Test** dokumentiert den v1-Upgrade-Zustand als gewolltes Verhalten (statt ihn stillschweigend aus den Fixtures zu entfernen)
- **`startModelDownload()` re-reconciled nach Abschluss** → geleerter required-Slot wird in derselben Session re-promotet (schliesst Provenienz-Lücke + inaktive Anzeige)
- **Round-Trip-Collapse im Reconciler**: Ein Repair, der ein früheres Event exakt invertiert (X → null → X), entfernt das stale Event statt ein zweites zu stapeln → der Upgrade-User sieht **gar kein** irreführendes Banner mehr
- Doku: `model-management.md` (checkPath-Tabelle war noch auf v1-Stand)

## Verifikation

- Reconcile-Suite: 23/23 grün (19 alte + 4 neue), TDD (neue Verhaltens-Tests erst rot)
- Volle Suite: **94 Dateien / 1038 Tests, alle grün**
- Typecheck grün, ESLint + Prettier auf den geänderten Dateien sauber

Hinweis fürs Repo: Das konnte nur durchrutschen, weil es kein CI-Test-Gate gibt (`.github/workflows/` enthält nur publish-website) — ein `vitest run` als PR-Check wäre der strukturelle Fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)