### PR TITLE
ci: Test-Gate für PRs (Typecheck + volle Vitest-Suite auf macos-15)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,43 @@
+name: Tests
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Typecheck + Vitest
+    # macOS-Runner zwingend: postinstall/pretest nutzen xcrun (SDKROOT für den
+    # better-sqlite3-Rebuild) — auf ubuntu-Runnern schlägt bereits npm ci fehl.
+    # Public Repo → macOS-Minuten sind kostenlos. arm64 matcht die Zielplattform.
+    runs-on: macos-15
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      # postinstall lädt Electron und rebuildet better-sqlite3 gegen die
+      # Electron-ABI; der pretest-Hook von `npm test` rebuildet danach gegen
+      # die System-Node-ABI. Beides braucht Xcode CLT (auf dem Runner vorhanden).
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      # Lint ist bewusst NICHT Teil des Gates: der Bestand hat vorbestehende
+      # ESLint-Fehler. Erst nach deren Bereinigung hier aktivieren.
+      - name: Tests
+        run: npm test


### PR DESCRIPTION
## Problem

`.github/workflows/` enthielt nur den Website-Publish — **kein Test-Gate**. Konsequenz: PR #118 wurde 64 s nach dem Commit mit einem Teil-Testlauf gemerged, obwohl die checkPath-Änderung 6 Reconcile-Tests brach (Analyse + Fix in #120).

## Änderung

Neuer Workflow `.github/workflows/test.yml`:

- **Trigger:** jeder PR, Pushes auf `main`/`develop`, manuell
- **Steps:** `npm ci` → `npm run typecheck` → `npm test` (volle Suite, 94 Dateien / 1000+ Tests)
- **Runner: `macos-15`** — zwingend, weil `postinstall`/`pretest` `xcrun` für den better-sqlite3-Rebuild nutzen (auf ubuntu schlägt schon `npm ci` fehl). Repo ist public → macOS-Minuten kostenlos; arm64 matcht die Zielplattform.
- **Lint bewusst nicht im Gate** (50 vorbestehende ESLint-Fehler im Bestand — würde sofort alles blocken; nach Bereinigung aktivierbar)
- Concurrency-Gruppe pro Ref bricht überholte Läufe ab

## Verifikation

Der Workflow läuft auf diesem PR selbst — der grüne Check unten ist der Beweis. Zusätzlich sinnvoll (Repo-Settings, kann ich nicht per PR ändern): den Check `Typecheck + Vitest` unter *Settings → Branches → Branch protection* für `develop`/`main` als **required** markieren, sonst bleibt er informativ statt blockierend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)