### PR TITLE
fix(review): Sub-Threshold-Findings aus Review von PR #122

### DIFF
--- a/scripts/sim-clean-install.sh
+++ b/scripts/sim-clean-install.sh
@@ -163,6 +163,7 @@ launch_clean() {
 (deny file-read* (subpath "$HOME/.cache/torch"))
 (deny file-write* (subpath "$HOME/.flair"))
 (deny file-write* (subpath "$HOME/.cache/huggingface"))
+(deny file-write* (subpath "$HOME/.cache/torch"))
 EOF
 
   bold "Clean-Launch — App startet OHNE /opt/homebrew und ohne Dev-Caches"

--- a/scripts/smoke-packaged.sh
+++ b/scripts/smoke-packaged.sh
@@ -78,6 +78,7 @@ cat > "$PROFILE" <<EOF
 (deny file-read* (subpath "$HOME/.cache/torch"))
 (deny file-write* (subpath "$HOME/.flair"))
 (deny file-write* (subpath "$HOME/.cache/huggingface"))
+(deny file-write* (subpath "$HOME/.cache/torch"))
 EOF
 
 CLEAN_TMPDIR="$(getconf DARWIN_USER_TEMP_DIR)"

--- a/src/main/services/ModelDownloadService.ts
+++ b/src/main/services/ModelDownloadService.ts
@@ -733,9 +733,11 @@ export interface ReconcileRepair {
 }
 
 /**
- * Bootstrap reconciler — läuft einmal beim App-Start, NACH `initSettings()`
- * und VOR `createWindow()`. Geht jede Modell-Gruppe durch und stellt das
- * Invariant sicher:
+ * Reconciler — läuft beim App-Start (NACH `initSettings()`, VOR
+ * `createWindow()`) und ein zweites Mal am Ende von `startModelDownload()`,
+ * damit ein beim Boot geleerter required-Slot direkt nach dem First-Launch-
+ * Download re-promotet wird statt erst beim nächsten Start. Geht jede
+ * Modell-Gruppe durch und stellt das Invariant sicher:
  *   "Der active-Slot zeigt entweder auf ein installiertes Katalog-Modell
  *    oder ist null."
  *


### PR DESCRIPTION
Zieht die zwei Sub-Threshold-Findings (Score 55/75) aus dem Code-Review von #122 nach, damit sie im Release-PR mitfahren:

1. **torch-Cache-Write-Deny fehlte** in beiden Sandbox-Profilen ([sim-clean-install.sh](../blob/develop/scripts/sim-clean-install.sh), [smoke-packaged.sh](../blob/develop/scripts/smoke-packaged.sh)) — der Kommentar versprach Write-Deny auf alle drei Dev-Caches, das Profil deckte nur flair + huggingface ab.
2. **Stale Docstring** von `reconcileActiveModels()` — behauptete "läuft einmal beim App-Start", seit #120 gibt es den zweiten Call-Site in `startModelDownload()`.

Verifikation: `bash -n` beide Skripte, Prettier, Reconcile-Suite 23/23 grün. Kommentar-/Sandbox-Zeilen only, keine Logik.

🤖 Generated with [Claude Code](https://claude.com/claude-code)